### PR TITLE
Execute darkmode script before first render

### DIFF
--- a/assets/darkmode.js
+++ b/assets/darkmode.js
@@ -1,14 +1,8 @@
-// Darkmode toggle
-const toggleSwitch = document.querySelector('#darkmode-toggle')
-
 const userPref = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark'
 const currentTheme = localStorage.getItem('theme') ?? userPref
 
 if (currentTheme) {
   document.documentElement.setAttribute('saved-theme', currentTheme);
-  if (currentTheme === 'dark') {
-    toggleSwitch.checked = true
-  }
 }
 
 const switchTheme = (e) => {
@@ -22,5 +16,14 @@ const switchTheme = (e) => {
   }
 }
 
-// listen for toggle
-toggleSwitch.addEventListener('change', switchTheme, false)
+window.addEventListener('DOMContentLoaded', () => {
+  // Darkmode toggle
+  const toggleSwitch = document.querySelector('#darkmode-toggle')
+
+  // listen for toggle
+  toggleSwitch.addEventListener('change', switchTheme, false)
+
+  if (currentTheme === 'dark') {
+    toggleSwitch.checked = true
+  }
+})

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -11,12 +11,6 @@
         <a href="/">↳ Let's get you home.</a>
     </div>
 </div>
-
-{{- with resources.Get "darkmode.js" | minify -}}
-<script>
-  {{.Content | safeJS }}
-</script>
-{{- end -}}
 </body>
 
 </html>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -18,13 +18,6 @@
     </article>
     {{partial "footer.html" .}}
 </div>
-
-{{- with resources.Get "darkmode.js" | minify -}}
-<script>
-  {{.Content | safeJS }}
-</script>
-{{- end -}}
-
 </body>
 
 </html>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,10 +13,4 @@
         {{partial "footer.html" .}}
     </div>
 </div>
-
-{{- with resources.Get "darkmode.js" | minify -}}
-<script>
-  {{.Content | safeJS }}
-</script>
-{{- end -}}
 {{end}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,5 +17,11 @@
     </style>
     {{end}}
     {{end}}
+
+    {{- with resources.Get "darkmode.js" | minify -}}
+    <script>
+      {{.Content | safeJS }}
+    </script>
+    {{- end -}}
 </head>
 {{ template "_internal/google_analytics.html" . }}


### PR DESCRIPTION
Currently, the `darkmode.js` script is loaded after the main content. This means that if you enabled dark mode, you still get a flash of light mode before the script executes and sets it to dark mode. To fix this I've moved the script to the document head. To make that possible I've also had to make some modifications to the script itself, using the `DOMContentLoaded` event to bootstrap the theme toggle switch.