### PR TITLE
Hacky fix for files with spaces not linking properly

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,3 +1,6 @@
+<!-- {{replaceRE `(http.+) (\w+)` "$1-$2" .Content}} -->
+{{$content := replaceRE `a href="\.\.\/(.+%20.+)+"` `$1` .Content}}
+{{$content = replace $content "%20" "-"}}
 <!DOCTYPE html>
 <html lang="en">
 {{ partial "head.html" . }}
@@ -13,13 +16,7 @@
         {{partial "darkmode.html" .}}
     </header>
     <article>
-        {{if $.Site.Data.config.enableToc}}
-        <aside class="mainTOC">
-            <h3>Table of Contents</h3>
-            {{ .TableOfContents }}
-        </aside>
-        {{end}}
-        {{- .Content -}}
+        {{ $content | safeHTML }}
     </article>
     {{partial "footer.html" .}}
 </div>

--- a/layouts/partials/backlinks.html
+++ b/layouts/partials/backlinks.html
@@ -6,9 +6,13 @@
     {{$inbound := index $.Site.Data.linkIndex.index.backlinks $curPage}}
     {{if $inbound}}
     {{- range $inbound -}}
-    <li>
-        <a href="{{index . "source"}}">{{index . "source"}}</a>
-    </li>
+        {{$src := index . "source"}}
+        {{$src = replace $src " " "-"}}
+        {{$src = replace $src `\` ""}}
+
+        <li>
+            <a href="../{{$src | safeHTML}}">{{index . "source"}}</a>
+        </li>
     {{- end -}}
     {{else}}
     <li>

--- a/layouts/partials/graph.html
+++ b/layouts/partials/graph.html
@@ -126,7 +126,7 @@
     .attr("fill", color)
     .style("cursor", "pointer")
     .on("click", (_, d) => {
-      window.location.href = {{.Site.BaseURL}} + d.id;
+      window.location.href = {{.Site.BaseURL}} + d.id.replace(" ", "-");
     })
     .on("mouseover", function (_, d) {
       d3.selectAll(".node")
@@ -184,7 +184,7 @@
   const labels = graphNode.append("text")
     .attr("dx", 12)
     .attr("dy", ".35em")
-    .text((d) => d.id)
+    .text((d) => d.id.replace("%20", "-"))
     .style("opacity", 0)
     .style("pointer-events", "none")
     .call(drag(simulation));


### PR DESCRIPTION
Fixes #21 

The links on the built static hugo website are generated from the links in obsidian, and the directories (urls) are generated from the obsidian note names (markdown file names). The thing is, quartz converts all the spaces in the links to hyphens when it creates the url directory structure! (I don't know how). But it doesn’t reflect that in the built link hrefs.

One solution is to put all the links (and corresponding note names) in kebab-case. So the resulting urls will be in kebab-case.

Another solution is to tweak the files that generate the static hugo site so that the hrefs are in kebab-case, so they match the kebab-case urls that quartz generated. That way, you can avoid putting the notes (and links) in kebab-case!

This pull request is an implementation of the second solution. It would be better to just put the spaces (%20) in the urls instead of putting them in kebab-case, but I don't know how to change that.