### PR TITLE
remove horizontal scrollbar

### DIFF
--- a/assets/syntax.scss
+++ b/assets/syntax.scss
@@ -1,4 +1,4 @@
-/* Background */ .chroma { color: #f8f8f2; background-color: #282a36 }
+/* Background */ .chroma { color: #f8f8f2; background-color: #282a36; overflow: hidden }
 /* Other */ .chroma .x {  }
 /* Error */ .chroma .err {  }
 /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }


### PR DESCRIPTION
This removes a static scrollbar that seems to only be present in windows (I've tried on windows and iOS)

I am not sure if thats the right place to make the change, or if it could break something not obvious. Please let me know 😄 

Before and after:
![image](https://user-images.githubusercontent.com/994594/144543092-0cdb8ef1-f84c-4557-8acd-3de7f880d97f.png)

If you actually need a scrollbar:
![image](https://user-images.githubusercontent.com/994594/144543302-e131bef1-7df8-49bf-b8a7-802f0ad63c6e.png)
