### PR TITLE
Add disableToc parameter to not show TOC on a page

### DIFF
--- a/content/notes/editing.md
+++ b/content/notes/editing.md
@@ -48,6 +48,7 @@ Hugo is picky when it comes to metadata for files. Make sure that your title is 
 title: "Example Title"
 tags:
 - example-tag
+disableToc: true # do not show a table of contents on this page if enabled
 ---
 
 Rest of your content here...

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -22,7 +22,7 @@
           <li><a href="{{ .Permalink }}">{{ .LinkTitle | humanize }}</a></li>
           {{ end }}
       </ul>
-      {{if $.Site.Data.config.enableToc}}
+      {{ if (and $.Site.Data.config.enableToc (not (.Params.disableToc))) }}
       <aside class="mainTOC">
           <h3>Table of Contents</h3>
           {{ .TableOfContents }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,7 +13,7 @@
         {{partial "darkmode.html" .}}
     </header>
     <article>
-        {{if $.Site.Data.config.enableToc}}
+        {{ if (and $.Site.Data.config.enableToc (not (.Params.disableToc))) }}
         <aside class="mainTOC">
             <h3>Table of Contents</h3>
             {{ .TableOfContents }}


### PR DESCRIPTION
`disableToc: true` can be set in page frontmatter to not show the table of contents for that page.