### PR TITLE
Fixed backlinks.html + Prettified graph.html

### DIFF
--- a/layouts/partials/backlinks.html
+++ b/layouts/partials/backlinks.html
@@ -1,16 +1,12 @@
 <h3>Backlinks</h3>
 <ul class="backlinks">
-    {{$url := urls.Parse .Site.BaseURL }}
-    {{$host := strings.TrimRight "/" $url.Path }}
-    {{$curPage := strings.TrimPrefix $host (strings.TrimRight "/" .Page.RelPermalink) }}
+    {{$curPage := strings.TrimRight "/" .Page.RelPermalink }}
     {{$inbound := index $.Site.Data.linkIndex.index.backlinks $curPage}}
-    {{$contentTable := $.Site.Data.contentIndex}}
     {{if $inbound}}
-    {{$cleanedInbound := apply (apply $inbound "index" "." "source") "replace" "." " " "-"}}
-    {{- range $cleanedInbound | uniq -}}
-        <li>
-            <a href="{{.}}">{{index (index $contentTable .) "title"}}</a>
-        </li>
+    {{- range $inbound -}}
+    <li>
+        <a href="{{index . "source"}}">{{ replace (index . "source") "/notes/" "" }}</a>
+    </li>
     {{- end -}}
     {{else}}
     <li>

--- a/layouts/partials/graph.html
+++ b/layouts/partials/graph.html
@@ -201,7 +201,7 @@
   const labels = graphNode.append("text")
     .attr("dx", 12)
     .attr("dy", ".35em")
-    .text((d) => content[decodeURI(d.id).replace(/\s+/g, '-')]?.title || "Untitled")
+    .text((d) => d.id.replace(/(\/notes\/)/g, '').replace(/\s+/g, '-')) //content[decodeURI(d.id).replace(/\s+/g, '-')]?.title || "Untitled")
     .style("opacity", 0)
     .style("pointer-events", "none")
     .call(drag(simulation));


### PR DESCRIPTION
Hey Jacky! 

I loved your website when I stumbled across your reddit post about it! I want to build my site inspired by similar aesthetic using the quartz framework! Here are a couple changes I made:

### /backlinks.html
When I forked and ran quartz following the instructions you had on your website, hugo would keep erroring out while building the /backlinks.html partial. I kept working on trying to fix it by myself and then came across [this](https://github.com/A2ITNotes/quartz/blob/hugo/layouts/partials/backlinks.html) solution [A2ITNotes](https://github.com/A2ITNotes) and their solution worked like a charm! I am barely getting started with Hugo hence finding this solution was a lifesaver!

> Here is the error:
> ![image](https://user-images.githubusercontent.com/32976987/153754434-3bbb9db3-99bf-4acd-ac96-9bb82484d96c.png)


### /graph.html
Additionally, I've edited the graph partial to remove the /notes/ prefix to the nodes, imho this would increase readability (since all notes are supposed to be made under /notes/ I thought it would be better for this to be default)