### PR TITLE
Prevent overflow of long links and words

### DIFF
--- a/assets/styles/base.scss
+++ b/assets/styles/base.scss
@@ -183,6 +183,10 @@ article {
       border-radius: 3px;
     }
   }
+  
+  & p {
+    overflow-wrap: anywhere;
+  }
 }
 
 .backlinks a {


### PR DESCRIPTION
When a word (or any string without breakpoints (spaces, dashes....), making links the most common place where this becomes an issue) is wider than its container, the text will simply overflow any container, including the viewport. This commit fixes this behavior by making the word-wrap strategy of the browser more aggressive.

Long link before the fix:
![image](https://user-images.githubusercontent.com/9874071/157503048-2477906c-699a-455c-adff-8353e5374d3f.png)

The same link after applying this fix:
![image](https://user-images.githubusercontent.com/9874071/157503104-7c7739f5-43e8-4336-8fbc-29e146490c50.png)


