### PR TITLE
make pages more responsive separating contact links with &ZeroWidthSpace;

### DIFF
--- a/assets/styles/base.scss
+++ b/assets/styles/base.scss
@@ -520,3 +520,15 @@ header {
     user-select: none;
   }
 }
+
+#contact_buttons ul {
+  list-style-type: none;
+
+  li {
+    display: inline-block;
+  }
+
+  li a {
+    padding: 5px 20px;
+  }
+}

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -6,7 +6,7 @@
         <a href="/">Home</a>
         {{end}}
         {{- range $.Site.Data.config.links -}}
-        <a href="{{.link}}">{{.link_name}}</a>
+        &ZeroWidthSpace;<a href="{{.link}}">{{.link_name}}</a>
         {{- end -}}
     </footer>
 </div>

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -2,11 +2,22 @@
 <div id="contact_buttons">
     <footer>
         <p>Made by {{ $.Site.Data.config.name }} using <a href="https://github.com/jackyzha0/quartz">Quartz</a>, © {{ dateFormat "2006" now }}</p>
+<<<<<<< Updated upstream
         {{ if not .IsHome }}
         <a href="/">Home</a>
         {{end}}
         {{- range $.Site.Data.config.links -}}
         &ZeroWidthSpace;<a href="{{.link}}">{{.link_name}}</a>
         {{- end -}}
+=======
+        <ul>
+            {{ if not .IsHome }}
+            <li><a href="/">Home</a></li>
+            {{end}}
+            {{- range $.Site.Data.config.links -}}
+            <li><a href="{{.link}}">{{.link_name}}</a></li>
+            {{- end -}}
+        </ul>
+>>>>>>> Stashed changes
     </footer>
 </div>

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -2,14 +2,6 @@
 <div id="contact_buttons">
     <footer>
         <p>Made by {{ $.Site.Data.config.name }} using <a href="https://github.com/jackyzha0/quartz">Quartz</a>, © {{ dateFormat "2006" now }}</p>
-<<<<<<< Updated upstream
-        {{ if not .IsHome }}
-        <a href="/">Home</a>
-        {{end}}
-        {{- range $.Site.Data.config.links -}}
-        &ZeroWidthSpace;<a href="{{.link}}">{{.link_name}}</a>
-        {{- end -}}
-=======
         <ul>
             {{ if not .IsHome }}
             <li><a href="/">Home</a></li>
@@ -18,6 +10,5 @@
             <li><a href="{{.link}}">{{.link_name}}</a></li>
             {{- end -}}
         </ul>
->>>>>>> Stashed changes
     </footer>
 </div>


### PR DESCRIPTION
When we put a bunch of `links` inside `data/config.yaml` we can see a horizontal scrolling like this:

![image](https://user-images.githubusercontent.com/8508804/161392828-a14594c7-178d-438e-a721-9c6e36b17182.png)


This happens because in `layouts/partials/contact.html` the links are generated with no spaces between them.

I managed to solve this adding a `&ZeroWidthSpace;` between each link. Here's how it looks now:
![image](https://user-images.githubusercontent.com/8508804/161392969-e9f064d4-6485-459c-9527-f8e61e59f302.png)


