### PR TITLE
disable ToC if the page's front matter has "enableToc: false"

### DIFF
--- a/content/notes/editing.md
+++ b/content/notes/editing.md
@@ -48,7 +48,7 @@ Hugo is picky when it comes to metadata for files. Make sure that your title is 
 title: "Example Title"
 tags:
 - example-tag
-disableToc: true # do not show a table of contents on this page if enabled
+enableToc: false # do not show a table of contents on this page
 ---
 
 Rest of your content here...

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -22,7 +22,7 @@
           <li><a href="{{ .Permalink }}">{{ .LinkTitle | humanize }}</a></li>
           {{ end }}
       </ul>
-      {{ if (and $.Site.Data.config.enableToc (not (.Params.disableToc))) }}
+      {{ if (and $.Site.Data.config.enableToc (ne .Params.enableToc false)) }}
       <aside class="mainTOC">
           <h3>Table of Contents</h3>
           {{ .TableOfContents }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,7 +13,7 @@
         {{partial "darkmode.html" .}}
     </header>
     <article>
-        {{ if (and $.Site.Data.config.enableToc (not (.Params.disableToc))) }}
+        {{ if (and $.Site.Data.config.enableToc (ne .Params.enableToc false)) }}
         <aside class="mainTOC">
             <h3>Table of Contents</h3>
             {{ .TableOfContents }}


### PR DESCRIPTION
If you have `enableToc: true` in your `data/config.yaml`, you can disable Table of Contents on individual pages by using `enableToc: false` in the page's front matter.

Same intention as #48 but replacing `disableToc: true` with `enableToc: false` to get the same result.
