### PR TITLE
docs: warn about possible lost of customization

### DIFF
--- a/content/notes/setup.md
+++ b/content/notes/setup.md
@@ -33,11 +33,16 @@ Having problems? Checkout our [FAQ and Troubleshooting guide](notes/troubleshoot
 ## Updating
 Haven't updated Quartz in a while and want all the cool new optimizations?
 
+> ⚠️ **WARNING** ⚠️
+>
+> if you customized `assets/styles/custom.scss`, the files in `data/`, or anything inside `layouts/`, your customization may be overwritten!
+
+
 ```shell
 # add Quartz as a remote host
 git remote add upstream git@github.com:jackyzha0/quartz.git
 
 # index and fetch changes
 git fetch upstream
-git checkout upstream/hugo -- layouts .github Makefile assets config.toml data layouts static
+git checkout upstream/hugo -- layouts .github Makefile assets config.toml data static
 ```


### PR DESCRIPTION
Just an update in the documentation:

![image](https://user-images.githubusercontent.com/8508804/161626985-7d61a989-b07a-4d2b-a375-1c78a2a9fbd9.png)

(I also removed a duplicated mention to `layouts`)

closes #84