### PR TITLE
404 page: link to home goes to baseURL

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -8,7 +8,7 @@
     <div class="centered">
         <h1>404.</h1>
         <h3>Hey! You look a little lost. This page doesn't exist (or may be private).</h3>
-        <a href="/">↳ Let's get you home.</a>
+        <a href="{{ .Site.BaseURL }}">↳ Let's get you home.</a>
     </div>
 </div>
 </body>


### PR DESCRIPTION
Currently it goes to the root, which doesn't work when people have `USERNAME.github.io/MY-DIGITAL-GARDEN`.