### PR TITLE
fix: fetch github info

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
       - name: Build Link Index
         uses: jackyzha0/hugo-obsidian@v2.12

--- a/config.toml
+++ b/config.toml
@@ -28,3 +28,6 @@ enableGitInfo = true
         lineNumbersInTable = true
         style = "dracula"
         tabWidth = 4
+    [frontmatter]
+        lastmod = ["lastmod", ":git", "date", "publishDate"]
+        publishDate = ["publishDate", "date"]


### PR DESCRIPTION
This PR fixes the issue of Last Modified dates not working properly in deployed pages
- Add `fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod` to github actions 
- add date config to `config.yaml`