### PR TITLE
fix: keep / at end of URL to avoid redirects

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -7,7 +7,7 @@
 {{$spacedurl := replace $trimmed "%20" " " }}
 {{$fixedUrl := (cond (hasPrefix $spacedurl "/") $spacedurl (print "/" $spacedurl)) | urlize}}
 {{$nonexistent := eq (.Page.GetPage $spacedurl).RelPermalink ""}}
-{{$rooted := default $spacedurl (strings.TrimRight "/" (.Page.GetPage $spacedurl).RelPermalink) }}
+{{$rooted := default $spacedurl ((.Page.GetPage $spacedurl).RelPermalink) }}
 <a
   {{if not $nonexistent}}href="{{$rooted}}"{{end}}
   rel="noopener" class="internal-link{{if $nonexistent}} broken{{end}}"


### PR DESCRIPTION
Removed strings.TrimRight "/" in line 10 to keep the trailing slash at the end of URLs in regular links. This avoids having every single internal link being a 301 redirect.