### PR TITLE
Support active node with other data at end of url

### DIFF
--- a/assets/js/graph.js
+++ b/assets/js/graph.js
@@ -7,10 +7,13 @@ async function drawGraph(
   enableZoom
 ) {
   const container = document.getElementById('graph-container')
-
   const { index, links, content } = await fetchData
+
+  const rawUrl = new URL(window.location.href);
   // Use .pathname to remove hashes / searchParams / text fragments
-  const curPage = window.location.pathname.replace(/\/$/g, "")
+  const cleanUrl = rawUrl.origin + rawUrl.pathname
+
+  const curPage = cleanUrl.replace(/\/$/g, "").replace(baseUrl, "")
 
   const parseIdsFromLinks = (links) => [
     ...new Set(links.flatMap((link) => [link.source, link.target])),

--- a/assets/js/graph.js
+++ b/assets/js/graph.js
@@ -9,7 +9,8 @@ async function drawGraph(
   const container = document.getElementById('graph-container')
 
   const { index, links, content } = await fetchData
-  const curPage = window.location.href.replace(baseUrl, "").replace(/\/$/g, "")
+  // Use .pathname to remove hashes / searchParams / text fragments
+  const curPage = window.location.pathname.replace(/\/$/g, "")
 
   const parseIdsFromLinks = (links) => [
     ...new Set(links.flatMap((link) => [link.source, link.target])),

--- a/assets/js/graph.js
+++ b/assets/js/graph.js
@@ -9,9 +9,8 @@ async function drawGraph(
   const container = document.getElementById('graph-container')
   const { index, links, content } = await fetchData
 
-  const rawUrl = new URL(window.location.href);
   // Use .pathname to remove hashes / searchParams / text fragments
-  const cleanUrl = rawUrl.origin + rawUrl.pathname
+  const cleanUrl = window.location.origin + window.location.pathname
 
   const curPage = cleanUrl.replace(/\/$/g, "").replace(baseUrl, "")
 

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -144,7 +144,7 @@ const removeMarkdown = (
     // SPA navigation
     window.navigate(
       new URL(
-        `${BASE_URL}${id}#:~:text=${encodeURIComponent(term)}/`
+        `${BASE_URL.replace(/\/$/g, "")}${id}#:~:text=${encodeURIComponent(term)}/`
       ),
       '.singlePage'
     )

--- a/layouts/partials/graph.html
+++ b/layouts/partials/graph.html
@@ -16,13 +16,3 @@
 </style>
 {{ $js := resources.Get "js/graph.js" | resources.Fingerprint "md5" }}
 <script src="{{ $js.Permalink }}"></script>
-<script>
-drawGraph(
-  {{strings.TrimRight "/" .Site.BaseURL}},
-  {{$.Site.Data.graphConfig.paths}},
-  {{$.Site.Data.graphConfig.depth}},
-  {{$.Site.Data.graphConfig.enableDrag}},
-  {{$.Site.Data.graphConfig.enableLegend}},
-  {{$.Site.Data.graphConfig.enableZoom}}
-);
-</script>


### PR DESCRIPTION
Active nodes will not work if there is a text fragment, particularly one after Cmd-K search
<img width="979" alt="Screen Shot 2022-05-03 at 10 39 53 AM" src="https://user-images.githubusercontent.com/38025074/166508714-54941510-654a-4721-85a5-40eb3595d3f3.png">

