### PR TITLE
Fix latex

### DIFF
--- a/.pnpm-debug.log
+++ b/.pnpm-debug.log
@@ -1,0 +1,14 @@
+{
+  "0 debug pnpm:scope": {
+    "selected": 1
+  },
+  "1 error pnpm": {
+    "code": "ERR_PNPM_NO_SCRIPT",
+    "err": {
+      "name": "pnpm",
+      "message": "Missing script: dev",
+      "code": "ERR_PNPM_NO_SCRIPT",
+      "stack": "pnpm: Missing script: dev\n    at Object.handler (/opt/homebrew/lib/node_modules/pnpm/dist/pnpm.cjs:170956:15)\n    at async /opt/homebrew/lib/node_modules/pnpm/dist/pnpm.cjs:175391:21\n    at async run (/opt/homebrew/lib/node_modules/pnpm/dist/pnpm.cjs:175365:34)\n    at async runPnpm (/opt/homebrew/lib/node_modules/pnpm/dist/pnpm.cjs:175583:5)\n    at async /opt/homebrew/lib/node_modules/pnpm/dist/pnpm.cjs:175575:7"
+    }
+  }
+}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -87,6 +87,15 @@
       {{if $.Site.Data.config.enableLinkPreview}}
         initPopover({{strings.TrimRight "/" .Site.BaseURL }})
       {{end}}
+      {{if $.Site.Data.config.enableLatex}}
+        renderMathInElement(document.body, {
+          delimiters: [
+            {left: '$$', right: '$$', display: true},
+            {left: '$', right: '$', display: false},
+          ],
+          throwOnError : false
+        });
+      {{end}}
     };
     attachSPARouting(draw);
   </script>

--- a/layouts/partials/katex.html
+++ b/layouts/partials/katex.html
@@ -2,15 +2,4 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/katex.min.css" integrity="sha384-R4558gYOUz8mP9YWpZJjofhk+zx0AS11p36HnD2ZKj/6JR5z27gSSULCNHIRReVs" crossorigin="anonymous">
 <script defer src="https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/katex.min.js" integrity="sha384-z1fJDqw8ZApjGO3/unPWUPsIymfsJmyrDVWC8Tv/a1HeOtGmkwNd/7xUS0Xcnvsx" crossorigin="anonymous"></script>
 <script defer src="https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/contrib/auto-render.min.js" integrity="sha384-+XBljXPPiv+OzfbB3cVmLHf4hdUFHlWNZN5spNQ7rmHTXpd7WvJum6fIACpNNfIR" crossorigin="anonymous"></script>
-<script>
-  document.addEventListener("DOMContentLoaded", function() {
-    renderMathInElement(document.body, {
-      delimiters: [
-        {left: '$$', right: '$$', display: true},
-        {left: '$', right: '$', display: false},
-      ],
-      throwOnError : false
-    });
-  });
-</script>
 {{end}}


### PR DESCRIPTION
Currently LaTeX support is broken because it only works on initial load. The JavaScript under `partial/katex.html` is moved under the `draw` function in `head.html`.  This way, it is loaded on every page navigation.

<img width="705" alt="image" src="https://user-images.githubusercontent.com/38025074/166714007-9a2fbc6d-4a7f-459d-b6e6-8aecb2ece492.png">
