### PR TITLE
Bump million to 1.9.6

### DIFF
--- a/assets/js/router.js
+++ b/assets/js/router.js
@@ -1,4 +1,4 @@
-import { router, navigate, reload, prefetch } from "https://unpkg.com/million@1.9.5/dist/router.mjs"
+import { router, navigate, reload, prefetch } from "https://unpkg.com/million@1.9.6/dist/router.mjs"
 
 export const attachSPARouting = (draw) => {
   // Attach SPA functions to the global Million namespace

--- a/assets/js/router.js
+++ b/assets/js/router.js
@@ -1,4 +1,4 @@
-import { router, navigate, reload, prefetch } from "https://unpkg.com/million@1.9.4/dist/router.mjs"
+import { router, navigate, reload, prefetch } from "https://unpkg.com/million@1.9.5/dist/router.mjs"
 
 export const attachSPARouting = (draw) => {
   // Attach SPA functions to the global Million namespace


### PR DESCRIPTION
Introduces `stale-while-revalidate` for SPA navigation, a HTTP cache invalidation strategy popularized by [HTTP RFC 5861](https://tools.ietf.org/html/rfc5861). SWR is a strategy to first return the data from cache (stale), then send the fetch request (revalidate), and finally come with the up-to-date data.

The main advantage of SWR is that Million can now take advantage of using disk cache