### PR TITLE
feat: edit the clipboard button to change border colour on success

### DIFF
--- a/assets/js/clipboard.js
+++ b/assets/js/clipboard.js
@@ -25,7 +25,7 @@ const addCopyButtons = () => {
                 () => {
                     button.blur();
                     button.innerHTML = svgCheck;
-                    setTimeout(() => (button.innerHTML = svgCopy), 2000);
+                    setTimeout(() => {button.innerHTML = svgCopy;button.style.borderColor = "";}, 2000);
                 },
                 (error) => (button.innerHTML = "Error")
             );

--- a/assets/js/clipboard.js
+++ b/assets/js/clipboard.js
@@ -25,7 +25,10 @@ const addCopyButtons = () => {
                 () => {
                     button.blur();
                     button.innerHTML = svgCheck;
-                    setTimeout(() => {button.innerHTML = svgCopy;button.style.borderColor = "";}, 2000);
+                    setTimeout(() => {
+                    	button.innerHTML = svgCopy
+                    	button.style.borderColor = ""
+                    }, 2000);
                 },
                 (error) => (button.innerHTML = "Error")
             );


### PR DESCRIPTION
Suggesting this edit to provide a more responsive user experience when copying code successfully.