### PR TITLE
feat: Adding Twitter and Social image preview including description

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,6 +1,7 @@
 <!-- set data/config yaml file based on website language -->
 {{ $config := cond (eq $.Site.Language.Lang "en") "config" (printf "config.%s" $.Site.Language.Lang) }}
 {{ $data := index $.Site.Data $config }}
+{{.Site.BaseURL}}icon.png
 <head>
   <!-- Meta tags -->
   <meta charset="UTF-8" />
@@ -10,14 +11,14 @@
   />
   <meta property="og:title" content="{{ .Title }}">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="icon.png">
+  <meta property="og:image" content="{{.Site.BaseURL}}icon.png">
   <meta property="og:url" content="{{ .Permalink }}">
   <meta property="og:width" content="200">
   <meta property="og:height" content="200">
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:title" content="{{ .Title }}" />
   <meta name="twitter:description" content="{{if .IsHome}}{{$data.description | default $.Site.Data.config.description}}{{else}}{{.Summary}}{{end}}" />
-  <meta name="twitter:image" content="icon.png">
+  <meta name="twitter:image" content="{{.Site.BaseURL}}icon.png">
   {{ range $data.links }}
     {{ if strings.Contains .link "twitter.com" }}
       {{ $twitter_handle := index (split .link "/") (sub (len (split .link "/")) 1) }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,15 +8,22 @@
     name="description"
     content="{{if .IsHome}}{{$data.description | default $.Site.Data.config.description}}{{else}}{{.Summary}}{{end}}"
   />
-  <meta property="og:image" content="https://quartz.jzhao.xyz/icon.png">
+  <meta property="og:title" content="{{ .Title }}">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="icon.png">
+  <meta property="og:url" content="{{ .Permalink }}">
   <meta property="og:width" content="200">
   <meta property="og:height" content="200">
-  <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary" />
-  <meta name="twitter:site" content="@_jzhao" />
   <meta name="twitter:title" content="{{ .Title }}" />
   <meta name="twitter:description" content="{{if .IsHome}}{{$data.description | default $.Site.Data.config.description}}{{else}}{{.Summary}}{{end}}" />
-  <meta name="twitter:image" content="https://quartz.jzhao.xyz/icon.png">
+  <meta name="twitter:image" content="icon.png">
+  {{ range $data.links }}
+    {{ if strings.Contains .link "twitter.com" }}
+      {{ $twitter_handle := index (split .link "/") (sub (len (split .link "/")) 1) }}
+      <meta name="twitter:site" content="{{ $twitter_handle }}" />
+    {{ end }}
+  {{ end }}
 
   <title>
     {{ if .Title }}{{ .Title }}{{ else }}{{ $data.page_title | default $.Site.Data.config.page_title }}{{

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,6 +8,16 @@
     name="description"
     content="{{if .IsHome}}{{$data.description | default $.Site.Data.config.description}}{{else}}{{.Summary}}{{end}}"
   />
+  <meta property="og:image" content="https://quartz.jzhao.xyz/icon.png">
+  <meta property="og:width" content="200">
+  <meta property="og:height" content="200">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:site" content="@_jzhao" />
+  <meta name="twitter:title" content="{{ .Title }}" />
+  <meta name="twitter:description" content="{{if .IsHome}}{{$data.description | default $.Site.Data.config.description}}{{else}}{{.Summary}}{{end}}" />
+  <meta name="twitter:image" content="https://quartz.jzhao.xyz/icon.png">
+
   <title>
     {{ if .Title }}{{ .Title }}{{ else }}{{ $data.page_title | default $.Site.Data.config.page_title }}{{
     end }}


### PR DESCRIPTION
When sharing on socials, this change will preview an image, title, and the actual description of the note (if not home/index page).

An example of how Twitter shows it:
![image](https://user-images.githubusercontent.com/689199/192890904-3d091599-2089-4501-a240-36b569abfb96.png)
