### PR TITLE
Decode the heading id from split link

### DIFF
--- a/assets/js/popover.js
+++ b/assets/js/popover.js
@@ -27,7 +27,7 @@ function initPopover(baseURL, useContextualBacklinks, renderLatex) {
             let splitLink = li.href.split("#")
             let cleanedContent = removeMarkdown(linkDest.content)
             if (splitLink.length > 1) {
-              let headingName = splitLink[1].replace(/\-/g, " ")
+              let headingName = decodeURIComponent(splitLink[1]).replace(/\-/g, " ")
               let headingIndex = cleanedContent.toLowerCase().indexOf("<b>" + headingName + "</b>")
               cleanedContent = cleanedContent.substring(headingIndex, cleanedContent.length)
             }


### PR DESCRIPTION
If href contains encoded characters (such as í, č, or others), they won't match with the content (since they are not encoded there). The function `decodeURIComponent()` solves this, and makes it possible to use headings such as `# Oxidatívna fosforylácia`.