### PR TITLE
fix: Apply monospace style to all meta in a popover

### DIFF
--- a/assets/styles/base.scss
+++ b/assets/styles/base.scss
@@ -588,7 +588,7 @@ header {
     margin: 0.25rem 0;
   }
 
-  & > .meta {
+  & .meta {
     margin-top: 0.25rem;
     opacity: 0.5;
     font-family: var(--font-mono);


### PR DESCRIPTION
Not only direct children.

You can see the discrepancy here: https://quartz.jzhao.xyz/

One of these popovers is correctly monospace and another isn't:

<img width="474" alt="Screen Shot 2022-10-16 at 12 20 27 PM" src="https://user-images.githubusercontent.com/5167293/196046463-526bd1be-de55-479f-a940-b811f4e4e789.png">

versus

<img width="479" alt="Screen Shot 2022-10-16 at 12 20 20 PM" src="https://user-images.githubusercontent.com/5167293/196046485-e39d8f1a-ad2e-4266-99b9-d8d756494a2d.png">

Not sure if this is the right change to make to this problem but it looked okay on my fork!
