### PR TITLE
feat: Dockerfile and automated container build

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,41 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: ['hugo']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.16
+
+RUN apk add --no-cache go hugo git make perl
+RUN go install github.com/jackyzha0/hugo-obsidian@latest
+ENV PATH="/root/go/bin:$PATH"
+RUN git clone https://github.com/jackyzha0/quartz.git /quartz
+
+WORKDIR /quartz
+
+CMD ["make", "serve"]

--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,5 @@ update-force: ## Forcefully pull all changes and don't ask to patch
 	git checkout upstream/hugo -- layouts .github Makefile assets/js assets/styles/base.scss assets/styles/darkmode.scss config.toml data
 
 serve: ## Serve Quartz locally
-	hugo-obsidian -input=content -output=assets/indices -index -root=. && hugo server --enableGitInfo --minify
+	hugo-obsidian -input=content -output=assets/indices -index -root=.
+	hugo server --enableGitInfo --minify --bind=$(or $(HUGO_BIND),0.0.0.0) --baseURL=$(or $(HUGO_BASEURL),http://localhost) --port=$(or $(HUGO_PORT),1313) --appendPort=$(or $(HUGO_APPENDPORT),true)

--- a/content/notes/docker.md
+++ b/content/notes/docker.md
@@ -1,0 +1,59 @@
+---
+title: "Hosting with Docker"
+tags:
+- setup
+---
+
+If you want to host Quartz on a specific machine, it may be easier to [install Docker Compose](https://docs.docker.com/compose/install/) and follow the instructions below (than to [install Quartz's dependencies manually](notes/preview%20changes.md)).
+
+## Hosting Quartz Locally
+
+You can serve Quartz locally at `http://localhost:1313` with the following script:
+
+docker-compose.yml
+```
+services:
+  quartz-hugo:
+    image: ghcr.io/jackyzha0/quartz:hugo
+    container_name: quartz-hugo
+    volumes:
+      - /path/to/quartz:/quartz
+    ports:
+      - 1313:1313
+
+    # optional
+    environment:
+      - HUGO_BIND=0.0.0.0
+      - HUGO_BASEURL=http://localhost
+      - HUGO_PORT=1313
+      - HUGO_APPENDPORT=true
+```
+
+By default, the container will clone and serve `github:jackyzha0/quartz`. However, you can serve your own fork of `quartz` by cloning to the above `/path/to/quartz` directory.
+
+Then run with: `docker-compose up -d` in the same directory as your `docker-compose.yml` file.
+
+While the container is running, you can update their `quartz` fork with: `docker exec -it quartz-hugo make update`.
+
+## Exposing Your Container to the Internet
+
+### To Your Public IP Address with Port Forwarding (insecure)
+
+Assuming you are already familiar with [port forwarding](https://en.wikipedia.org/wiki/Port_forwarding) and [setting it up with your router model](https://portforward.com):
+
+1. You should set the environment variable `HUGO_BASEURL=http://your-public-ip` and then start your container.
+2. Set up port forwarding on your router from port `p` to `your-local-ip:1313`.
+3. You should now be able to access Quartz from outside your local network at `http://your-public-ip:p`.
+
+However, your HTTP connection will be unencrypted and **this method is not secure**.
+
+### To a Domain using Cloudflare Proxy
+
+1. Port forward 443 (HTTPS) from your machine.
+2. Buy a custom domain (say, `your-domain.com`) from [Cloudflare](https://www.cloudflare.com/products/registrar/). Point a DNS A record from `your-domain.com` to your public IP address and enable the proxy.
+3. Set the environment variables `HUGO_BASEURL=https://your-domain.com`, `HUGO_PORT=443`, and `HUGO_APPENDPORT=false`. Change `1313:1313` to `443:443` for the `ports` in `docker-compose.yml`.
+4. Spin up your Quartz container and enjoy it at `https://your-domain.com`!
+
+### To a Domain using a Reverse Proxy
+
+If you want to serve more than just Quartz to the internet on this machine (or don't want to use the Cloudflare registrar and proxy), you should follow the steps in the section above (as appropriate) and also set up a reverse proxy, like [Traefik](https://doc.traefik.io/traefik). Be sure to configure your TLS certificates too!

--- a/content/notes/editing.md
+++ b/content/notes/editing.md
@@ -56,11 +56,19 @@ This step is purely optional and mostly for those who want to see the published 
 
 > 👀 Step 4: [Preview Quartz Changes](notes/preview%20changes.md)
 
+If you prefer, you can preview changes by [hosting locally with Docker](notes/docker.md) instead! If you have Docker, this might be the easiest approach.
+
 For those who like to live life more on the edge, viewing the garden through Obsidian gets you pretty close to the real thing.
 
 ## Publishing Changes
 Now that you know the basics of managing your digital garden using Quartz, you can publish it to the internet!
 
 > 🌍 Step 5: [Hosting Quartz online!](notes/hosting.md)
+
+## Hosting with Docker
+You can also choose to publish your digital garden on a local or remote machine using Docker.
+
+> 🐳 [Hosting with Docker](notes/docker.md)
+
 
 Having problems? Checkout our [FAQ and Troubleshooting guide](notes/troubleshooting.md).


### PR DESCRIPTION
I created a Dockerfile for an alpine container build of Quartz (as discussed in #211). Upon merging this PR, one can serve Quartz locally at `http://localhost:1313` with the following script:

docker-compose.yml
```
services:
  quartz-hugo:
    image: ghcr.io/jackyzha0/quartz:hugo
    container_name: quartz-hugo
    volumes:
      - /path/to/quartz:/quartz
    ports:
      - 1313:1313
 
    # optional
    environment:
      - HUGO_BIND=0.0.0.0
      - HUGO_BASEURL=http://localhost
      - HUGO_PORT=1313
      - HUGO_APPENDPORT=true
```

By default, the container will clone and serve `github:jackyzha0/quartz`. However, one can serve their own fork of `quartz` by cloning to the above `/path/to/quartz` directory.

Then run with: `docker-compose up -d`

One can update their `quartz` fork with: `docker exec -it quartz-hugo make update`.