### PR TITLE
fix: Replacing "internal-link broken" with link to asset

### DIFF
--- a/layouts/partials/textprocessing.html
+++ b/layouts/partials/textprocessing.html
@@ -35,23 +35,26 @@
       {{$inner := . | strings.TrimPrefix "[[" | strings.TrimSuffix "]]" }}
       <!-- split from alias -->
       {{$split := split $inner "|"}}
+
       <!-- separate link path -->
       {{$path := index $split 0}}
       {{$reference := split $path "#"}}
       <!-- path with heading link (i.e. $block) removed -->
       {{$title := index $reference 0}}
-      <!-- heading link -->
-      {{$block := default "" (index $reference 1)}}
-      {{$block = strings.TrimRight "/" (cond (eq $block "") $block (printf "#%s" $block)) | urlize | lower}}
-      {{$href := strings.TrimRight "/" ($page.GetPage $title).RelPermalink}}
+
       <!-- if alias given, use alias, else title -->
       {{$display := default $title (index $split 1)}}
-      <!-- ADDED LINE TO REMOVE SUBFOLDER FROM TITLE: -->
+      <!-- REMOVE SUBFOLDER FROM TITLE -->
       {{$display := index (last 1 (split $display "/")) 0}}
-      {{if not $href}}
-        {{$link := printf "<a class=\"internal-link broken\">%s</a>" $display}}
+
+      {{if eq (string ($page.GetPage $title)) "nopPage"}}
+        {{$path := index $split 0 | relURL}}
+        {{$link := printf "<a href=\"%s\" rel=\"noopener\" class=\"internal-link\">%s</a>" $path $display}}
         {{$content = replace $content . $link}}
       {{else}}
+        {{$block := default "" (index $reference 1)}}
+        {{$block = strings.TrimRight "/" (cond (eq $block "") $block (printf "#%s" $block)) | urlize | lower}}
+        {{$href := strings.TrimRight "/" ($page.GetPage $title).RelPermalink}}
         {{$fullhref := printf "%s%s" $href $block }}
         {{$link := printf "<a href=\"%s\" rel=\"noopener\" class=\"internal-link\" data-src=\"%s\">%s</a>" $fullhref $href $display}}
         {{$content = replace $content . $link}}

--- a/layouts/partials/textprocessing.html
+++ b/layouts/partials/textprocessing.html
@@ -14,6 +14,7 @@
 {{$codefences := $raw | findRE "\\x60[^\\x60\\n]+\\x60"}}
 {{$codeblocks := $raw | findRE "\\x60{3}[^\\x60]+\\x60{3}"}}
 {{$code := union $codefences $codeblocks}}
+
 {{range $wikilinks}}
   {{$cur := .}}
   {{$incode := false}}
@@ -22,44 +23,45 @@
       {{$incode = true}}
     {{end}}
   {{end}}
+
   {{if not $incode}}
-    {{if (hasPrefix . "!")}}
-      {{$inner := . | strings.TrimPrefix "![[" | strings.TrimSuffix "]]" }}
-      {{$split := split $inner "|"}}
-      {{$path := index $split 0 | relURL}}
-      {{$width := index $split 1}}
-      {{$img := printf "<img src=\"%s\" width=\"%s\" />" $path (default "auto" $width)}}
-      {{$content = replace $content . $img}}
-    {{else}}
-      <!-- remove link delimiters -->
-      {{$inner := . | strings.TrimPrefix "[[" | strings.TrimSuffix "]]" }}
-      <!-- split from alias -->
-      {{$split := split $inner "|"}}
 
-      <!-- separate link path -->
-      {{$path := index $split 0}}
-      {{$reference := split $path "#"}}
-      <!-- path with heading link (i.e. $block) removed -->
-      {{$title := index $reference 0}}
+    {{$inner := . | strings.TrimPrefix "!" | strings.TrimPrefix "[[" | strings.TrimSuffix "]]" }}
+    {{$split := split $inner "|"}}
+    {{$path := index $split 0}}
 
-      <!-- if alias given, use alias, else title -->
-      {{$display := default $title (index $split 1)}}
-      <!-- REMOVE SUBFOLDER FROM TITLE -->
-      {{$display := index (last 1 (split $display "/")) 0}}
+    {{$reference := split $path "#"}}
+    {{$title := index $reference 0}}
+    {{$display := default $title (index $split 1)}}
+    {{$display := index (last 1 (split $display "/")) 0}}
 
-      {{if eq (string ($page.GetPage $title)) "nopPage"}}
-        {{$path := index $split 0 | relURL}}
-        {{$link := printf "<a href=\"%s\" rel=\"noopener\" class=\"internal-link\">%s</a>" $path $display}}
+    {{$curpage := $page.GetPage $title}}
+    {{$relpath := relURL $path}}
+
+    {{if not (eq $curpage.String "nopPage") }}
+      {{$block := default "" (index $reference 1)}}
+      {{$block = strings.TrimRight "/" (cond (eq $block "") $block (printf "#%s" $block)) | urlize | lower}}
+      {{$href := strings.TrimRight "/" $curpage.RelPermalink}}
+      {{$link := printf "<a href=\"%s%s\" rel=\"noopener\" class=\"internal-link\" data-src=\"%s\">%s</a>" $href $block $href $display}}
+      {{$content = replace $content . $link}}
+    {{else if fileExists $relpath}}
+      {{$splitpath := split $relpath "/"}}
+      {{$dirname := first (sub (len $splitpath) 1) $splitpath | path.Join | urlize}}
+      {{$basename := index (last 1 $splitpath) 0}}
+      {{$href := printf "/%s/%s" $dirname $basename}}
+      {{if (hasPrefix . "!")}}
+        {{$width := index $split 1}}
+        {{$link := printf "<img src=\"%s\" width=\"%s\" />" $href (default "auto" $width)}}
         {{$content = replace $content . $link}}
       {{else}}
-        {{$block := default "" (index $reference 1)}}
-        {{$block = strings.TrimRight "/" (cond (eq $block "") $block (printf "#%s" $block)) | urlize | lower}}
-        {{$href := strings.TrimRight "/" ($page.GetPage $title).RelPermalink}}
-        {{$fullhref := printf "%s%s" $href $block }}
-        {{$link := printf "<a href=\"%s\" rel=\"noopener\" class=\"internal-link\" data-src=\"%s\">%s</a>" $fullhref $href $display}}
+        {{$link := printf "<a href=\"%s\" rel=\"noopener\" class=\"internal-link\">%s</a>" $href $display}}
         {{$content = replace $content . $link}}
       {{end}}
+    {{else}}
+      {{$link := printf "<a class=\"internal-link broken\">%s</a>" $display}}
+      {{$content = replace $content . $link}}
     {{end}}
+
   {{end}}
 {{end}}
 

--- a/layouts/partials/textprocessing.html
+++ b/layouts/partials/textprocessing.html
@@ -26,29 +26,39 @@
 
   {{if not $incode}}
 
+    <!-- remove link delimiters -->
     {{$inner := . | strings.TrimPrefix "!" | strings.TrimPrefix "[[" | strings.TrimSuffix "]]" }}
+    <!-- split from alias -->
     {{$split := split $inner "|"}}
+    <!-- separate link path -->
     {{$path := index $split 0}}
 
     {{$reference := split $path "#"}}
+    <!-- path with heading link removed -->
     {{$title := index $reference 0}}
+    <!-- $display is hyperlink display text -->
+    <!-- use alias, else title -->
     {{$display := default $title (index $split 1)}}
+    <!-- remove subfolder from title -->
     {{$display := index (last 1 (split $display "/")) 0}}
 
     {{$curpage := $page.GetPage $title}}
     {{$relpath := relURL $path}}
 
+    <!-- If path to Hugo page -->
     {{if not (eq $curpage.String "nopPage") }}
       {{$block := default "" (index $reference 1)}}
       {{$block = strings.TrimRight "/" (cond (eq $block "") $block (printf "#%s" $block)) | urlize | lower}}
       {{$href := strings.TrimRight "/" $curpage.RelPermalink}}
       {{$link := printf "<a href=\"%s%s\" rel=\"noopener\" class=\"internal-link\" data-src=\"%s\">%s</a>" $href $block $href $display}}
       {{$content = replace $content . $link}}
+    <!-- If path to existing file -->
     {{else if fileExists $relpath}}
       {{$splitpath := split $relpath "/"}}
       {{$dirname := first (sub (len $splitpath) 1) $splitpath | path.Join | urlize}}
       {{$basename := index (last 1 $splitpath) 0}}
       {{$href := printf "/%s/%s" $dirname $basename}}
+      <!-- Embedded? -->
       {{if (hasPrefix . "!")}}
         {{$width := index $split 1}}
         {{$link := printf "<img src=\"%s\" width=\"%s\" />" $href (default "auto" $width)}}
@@ -57,6 +67,7 @@
         {{$link := printf "<a href=\"%s\" rel=\"noopener\" class=\"internal-link\">%s</a>" $href $display}}
         {{$content = replace $content . $link}}
       {{end}}
+    <!-- Broken path -->
     {{else}}
       {{$link := printf "<a class=\"internal-link broken\">%s</a>" $display}}
       {{$content = replace $content . $link}}


### PR DESCRIPTION
If a non-Markdown file (e.g. PDF or PNG) exists under `content/`, a wikilink to that file will currently render `internal-link broken`, because the existing script assumes it should be a page. I have modified this script to render a direct link to that file in the case that it is not a page.