### PR TITLE
fix edge cases link processing

### DIFF
--- a/layouts/partials/textprocessing.html
+++ b/layouts/partials/textprocessing.html
@@ -42,7 +42,24 @@
     <!-- remove subfolder from title -->
     {{$display := index (last 1 (split $display "/")) 0}}
 
-    {{$curpage := $page.GetPage $title}}
+    <!-- attempt to get title -->
+    {{$searchtitle := $title }}
+    {{$curpage := $page.GetPage $searchtitle }}
+    <!-- attempt to search md file instead  -->
+    {{ if (eq $curpage.String "nopPage") }}
+      {{$searchtitle = (add $title ".md") }}
+      {{$curpage = $page.GetPage $searchtitle }}
+    {{ end }}
+    <!-- attempt to reverse typographer behaviour  -->
+    {{ if (eq $curpage.String "nopPage") }}
+      {{$searchtitle = (replace $searchtitle "&amp;" "&") }}
+      {{$searchtitle = (replace $searchtitle "&quot;" "\"") }}
+      {{$searchtitle = (replace $searchtitle "&rdquo;" "\"") }}
+      {{$searchtitle = (replace $searchtitle "&ldquo;" "\"") }}
+      {{$searchtitle = (replace $searchtitle "&rsquo;" "'") }}
+      {{$searchtitle = (replace $searchtitle "&lsquo;" "'") }}
+      {{$curpage = $page.GetPage $searchtitle }}
+    {{ end }}
     {{$relpath := relURL $path}}
 
     <!-- If path to Hugo page -->


### PR DESCRIPTION
Fixes #176 and a few other issues caused by failure to search for existing notes in situations like:

- File name includes `.`
- File name changed by markdown processor (e.g. `&` into `&amp;` and `'` into `&rsquo;`)

The fix basically:
- attempt to search a file with the `.md` extension
- reverses some of the changes made by typographer

Before:

![Capture d’écran 2022-12-22 at 13 21 11](https://user-images.githubusercontent.com/38693485/209202827-0cfd857c-8864-4284-ae44-4ed9ec5bddc2.jpg)

After:

![Capture d’écran 2022-12-22 at 13 20 41](https://user-images.githubusercontent.com/38693485/209202842-d8e1cf9d-3e63-4490-975e-8695a0621029.jpg)

