### PR TITLE
Fix callout behaviour inconsistent with Obsidian (closes #168)

### DIFF
--- a/layouts/partials/textprocessing.html
+++ b/layouts/partials/textprocessing.html
@@ -127,6 +127,7 @@
   {{end}}
   {{ $content = $content | replaceRE `\[![a-zA-Z]+\][-\+]?` "" }}
   {{ $content = $content | replaceRE "blockquote class=callout" "blockquote" }}
+  {{ $content = $content | replaceRE `(?s)(<blockquote class="\S+-callout">.*?)<br>(.*?<\/blockquote)` `${1}</p><p>${2}` }}
 {{end}}
 
 {{/* Make ==text== into <mark>text</mark> */}}


### PR DESCRIPTION
Hi! I think I found a regex fix for #168. It's probably not the cleanest solution, but it gets the job done. Basically it looks for the first <br> in a callout and break it into two paragraphs.

Say we have the following markdown:

```md
> [!NOTE] Title
> Contents 1

> [!SUMMARY] Title
> 
> Contents 2 as paragraph

> [!info] Title
> 
> hard
> wrap

> [!bug] Title
> hard
> wrap

> [!warning]+ Title
> 
> hard
> wrap
> 
> paragraph

> [!success]- Title
> 
> paragraph
> 
> paragraph

> normal blockquote

> normal blockquote paragraph 1
> 
> normal blockquote paragraph 1

> hard wrap 1
> hard wrap 1
```

Before fix:

![Capture d’écran 2023-01-04 at 19 11 57](https://user-images.githubusercontent.com/38693485/210673984-931384da-0f1a-4770-8a1e-22ed9fd4cc79.jpg)

After fix:

![Capture d’écran 2023-01-04 at 19 12 12](https://user-images.githubusercontent.com/38693485/210673988-faee3d3d-27e8-4fda-b38b-4b385ebc5be6.jpg)

As far as I can tell, the regex replacement isn't causing other issues, but there could be cases I haven't tested yet.

