### PR TITLE
added the liveReloadPort as an option for docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ update-force: ## Forcefully pull all changes and don't ask to patch
 
 serve: ## Serve Quartz locally
 	hugo-obsidian -input=content -output=assets/indices -index -root=.
-	hugo server --enableGitInfo --minify --bind=$(or $(HUGO_BIND),0.0.0.0) --baseURL=$(or $(HUGO_BASEURL),http://localhost) --port=$(or $(HUGO_PORT),1313) --appendPort=$(or $(HUGO_APPENDPORT),true)
+	hugo server --enableGitInfo --minify --bind=$(or $(HUGO_BIND),0.0.0.0) --baseURL=$(or $(HUGO_BASEURL),http://localhost) --port=$(or $(HUGO_PORT),1313) --appendPort=$(or $(HUGO_APPENDPORT),true) --liveReloadPort=$(or $(HUGO_LIVERELOADPORT),-1)
 
 docker: ## Serve locally using Docker
 	docker run -it --volume=$(shell pwd):/quartz -p 1313:1313 ghcr.io/jackyzha0/quartz:hugo

--- a/content/notes/docker.md
+++ b/content/notes/docker.md
@@ -26,6 +26,7 @@ services:
       - HUGO_BASEURL=http://localhost
       - HUGO_PORT=1313
       - HUGO_APPENDPORT=true
+      - HUGO_LIVERELOADPORT=-1
 ```
 
 Then run with: `docker-compose up -d` in the same directory as your `docker-compose.yml` file.


### PR DESCRIPTION
This adds the liveReloadPort as an optional environment variable for docker. I needed to this to run quartz behind a reverse proxy.