### PR TITLE
feat: Remove leading slash of folders in graph view

### DIFF
--- a/assets/js/graph.js
+++ b/assets/js/graph.js
@@ -229,7 +229,7 @@ async function drawGraph(baseUrl, isHome, pathColors, graphConfig) {
     .attr("dx", 0)
     .attr("dy", (d) => nodeRadius(d) + 8 + "px")
     .attr("text-anchor", "middle")
-    .text((d) => content[d.id]?.title || d.id.replace("-", " "))
+    .text((d) => content[d.id]?.title || (d.id.charAt(1).toUpperCase() + d.id.slice(2)).replace("-", " "))
     .style('opacity', (opacityScale - 1) / 3.75)
     .style("pointer-events", "none")
     .style('font-size', fontSize+'em')


### PR DESCRIPTION
In case someone links a directory where e.g. a list of notes within it is getting shown, the directory's node will be formatted properly.