### PR TITLE
Enable hard wraps in paragraph rendering

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -32,3 +32,4 @@ enableGitInfo = true
         publishDate = ["publishDate", "date"]
     [markup.goldmark.renderer]
         unsafe = true
+        hardWraps = true


### PR DESCRIPTION
The [hardWraps](https://gohugo.io/getting-started/configuration-markup/#goldmark) config option of Goldmark makes a single linebreak equivalent to a linebreak (`<br />`) in a paragraph.

This makes the rendering consistent with Obsidian.