### PR TITLE
fix: Bad UI due to head.html

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,7 +1,6 @@
 <!-- set data/config yaml file based on website language -->
 {{ $config := cond (eq $.Site.Language.Lang "en") "config" (printf "config.%s" $.Site.Language.Lang) }}
 {{ $data := index $.Site.Data $config }}
-{{.Site.BaseURL}}icon.png
 <head>
   <!-- Meta tags -->
   <meta charset="UTF-8" />
@@ -10,6 +9,7 @@
     content="{{if .IsHome}}{{$data.description | default $.Site.Data.config.description}}{{else}}{{.Summary}}{{end}}"
   />
   <meta property="og:title" content="{{ .Title }}">
+  <meta property="og:description" content="{{if .IsHome}}{{$data.description | default $.Site.Data.config.description}}{{else}}{{.Summary}}{{end}}">
   <meta property="og:type" content="website">
   <meta property="og:image" content="{{.Site.BaseURL}}icon.png">
   <meta property="og:url" content="{{ .Permalink }}">


### PR DESCRIPTION
<img width="1545" alt="스크린샷 2023-02-07 오후 8 41 44" src="https://user-images.githubusercontent.com/87688023/217239311-a020ed99-a572-4f1e-81b7-be174c280cfc.png">

- I fixed it because the newly added `{{.Site.BaseURL}}icon.png` code added incorrectly to the UI.
- I added code `<meta property="og:description" content="" />` for websites using open graph.