### PR TITLE
fix: search highlight not showing because for trailing slash

### DIFF
--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -117,7 +117,7 @@ const resultToHTML = ({ url, title, content }) => {
 const redir = (id, term) => {
   const shouldTrim = PRODUCTION && SEARCH_ENABLED
   const baseURLPrefix = shouldTrim ? "" : BASE_URL.replace(/\/$/g, "")
-  const urlString = `${baseURLPrefix}${id}#:~:text=${encodeURIComponent(term)}/`
+  const urlString = `${baseURLPrefix}${id}#:~:text=${encodeURIComponent(term)}`
   window.Million.navigate(
     new URL(urlString),
     ".singlePage",


### PR DESCRIPTION
### fix: fix search highlight not showing because for trailing slash

> before-fix (with slash) : https://ibb.co/Qr1Dpqp
> after-fix (without slash):  https://ibb.co/w4dD3Nm