### PR TITLE
fix: padding for empty title callouts

### DIFF
--- a/assets/styles/_callouts.scss
+++ b/assets/styles/_callouts.scss
@@ -114,6 +114,10 @@ blockquote[class*="-callout"] > p:first-child {
   }
 }
 
+blockquote[class*="-callout"] > p:empty {
+  padding: 1.2em 35px;
+}
+
 $summary: summary, abstract, tldr;
 $bug: bug;
 $danger: danger, error;


### PR DESCRIPTION
### Summary

* Fix padding for empty title callouts

Given a callout without title we can see from the picture below that this is the visual resoult:
![callouts_error](https://user-images.githubusercontent.com/26528873/229312594-16d2cc55-a9c3-480b-93e4-40dedc740624.jpg)

Instead I've tried to fix this issue, creating this type of padding, which is similar to the case of a callout with a title:
![callouts_error_fixed](https://user-images.githubusercontent.com/26528873/229312649-292b2bbb-2cfc-4414-b09f-dcc5b427c369.jpg)

