### PR TITLE
Fix rendering issues within codeblocks

### DIFF
--- a/layouts/partials/textprocessing.html
+++ b/layouts/partials/textprocessing.html
@@ -2,19 +2,15 @@
 {{ $raw := .RawContent }}
 {{ $page := .Page }}
 
-{{/* Escape slashes for Latex to fix line breaks */}}
-{{$latex := findRE "(?:\\${2}([^\\$]+)\\${2})|(?:\\$([^\\$]*)\\$)" $content}}
-{{range $latex}}
-  {{$fixed := replaceRE "\\\\(?: +|\\n)" "\\\\ " .}}
-  {{$content = replace $content . $fixed}}
-{{end}}
-
-{{/* Wikilinks */}}
-{{$wikilinks := $content | findRE "!?\\[\\[\\S[^\\[\\]\\|]*(?:\\|[^\\[\\]]*)?\\S\\]\\]" }}
+<!-- detect code blocks and fences -->
 {{$codefences := $raw | findRE "\\x60[^\\x60\\n]+\\x60"}}
 {{$codeblocks := $raw | findRE "\\x60{3}[^\\x60]+\\x60{3}"}}
 {{$code := union $codefences $codeblocks}}
 
+{{/*  pre-parse processing  */}}
+
+{{/* Wikilinks */}}
+{{$wikilinks := $raw | findRE "!?\\[\\[\\S[^\\[\\]\\|]*(?:\\|[^\\[\\]]*)?\\S\\]\\]" }}
 {{range $wikilinks}}
   {{$cur := .}}
   {{$incode := false}}
@@ -68,7 +64,7 @@
       {{$block = strings.TrimRight "/" (cond (eq $block "") $block (printf "#%s" $block)) | urlize | lower}}
       {{$href := strings.TrimRight "/" $curpage.RelPermalink}}
       {{$link := printf "<a href=\"%s%s\" rel=\"noopener\" class=\"internal-link\" data-src=\"%s\">%s</a>" $href $block $href $display}}
-      {{$content = replace $content . $link}}
+      {{$raw = replace $raw . $link}}
     <!-- If path to existing file -->
     {{else if fileExists $relpath}}
       {{$splitpath := split $relpath "/"}}
@@ -82,37 +78,65 @@
         {{if in ".png .jpg .jpeg .gif .bmp .svg" $embed_ext }}
           {{$width := default "auto" (index $split 1) }}
           {{$link := printf "<img src=\"%s\" width=\"%s\" />" $href $width}}
-          {{$content = replace $content . $link}}
+          {{$raw = replace $raw . $link}}
         <!-- Video -->
         {{else if in ".mp4 .webm .ogv .mov .mkv" $embed_ext}}
           {{$link := printf "<video src=\"%s\" style=\"width: -webkit-fill-available;\" controls></video>" $href}}
-          {{$content = replace $content . $link}}
+          {{$raw = replace $raw . $link}}
         <!-- Audio -->
         {{else if in ".mp3 .webm .wav .m4a .ogg .3gp .flac" $embed_ext}}
           {{$link := printf "<audio src=\"%s\" controls></audio>" $href}}
-          {{$content = replace $content . $link}}
+          {{$raw = replace $raw . $link}}
         <!-- PDF -->
         {{else if in ".pdf" $embed_ext }}
           {{$src_link := printf "<a href=\"%s\" rel=\"noopener\" class=\"internal-link\">[source]</a>" $href}}
           {{$iframe_link := printf "<iframe src=\"%s\" style=\"height: -webkit-fill-available; width: -webkit-fill-available;\"></iframe>" $href}}
           {{$link := printf "%s<br>%s" $src_link $iframe_link}}
-          {{$content = replace $content . $link}}
+          {{$raw = replace $raw . $link}}
         <!-- other -->
         {{else}}
           {{$link := printf "<a href=\"%s\" rel=\"noopener\" class=\"internal-link\">%s</a>" $href $href}}
-          {{$content = replace $content . $link}}
+          {{$raw = replace $raw . $link}}
         {{end}}
       {{else}}
         {{$link := printf "<a href=\"%s\" rel=\"noopener\" class=\"internal-link\">%s</a>" $href $display}}
-        {{$content = replace $content . $link}}
+        {{$raw = replace $raw . $link}}
       {{end}}
     <!-- Broken path -->
     {{else}}
       {{$link := printf "<a class=\"internal-link broken\">%s</a>" $display}}
-      {{$content = replace $content . $link}}
+      {{$raw = replace $raw . $link}}
     {{end}}
 
   {{end}}
+{{end}}
+
+{{/* Make ==text== into <mark>text</mark> */}}
+{{$mark := findRE "==([^=\n]+)==" $raw}}
+{{range $mark}}
+  {{$cur := .}}
+  {{$incode := false}}
+  {{range $code}}
+    {{if (in . $cur)}}
+      {{$incode = true}}
+    {{end}}
+  {{end}}
+
+  {{if not $incode}}
+    {{$fixed := printf "<mark>%s</mark>" (replace . "==" "")}}
+    {{$raw = replace $raw . $fixed}}
+  {{ end }}
+{{end}}
+
+{{ $content = $raw | markdownify }}
+
+{{/*  post-parse processing  */}}
+
+{{/* Escape slashes for Latex to fix line breaks */}}
+{{$latex := findRE "(?:\\${2}([^\\$]+)\\${2})|(?:\\$([^\\$]*)\\$)" $content}}
+{{range $latex}}
+  {{$fixed := replaceRE "\\\\(?: +|\\n)" "\\\\ " .}}
+  {{$content = replace $content . $fixed}}
 {{end}}
 
 {{/* Add jumpable anchors */}}
@@ -152,11 +176,5 @@
   {{ $content = $content | replaceRE `(?s)(<blockquote class="\S+-callout">.*?)<br>(.*?<\/blockquote)` `${1}</p><p>${2}` }}
 {{end}}
 
-{{/* Make ==text== into <mark>text</mark> */}}
-{{$mark := findRE "==([^=\n]+)==" $content}}
-{{range $mark}}
-  {{$fixed := printf "<mark>%s</mark>" (replace . "==" "")}}
-  {{$content = replace $content . $fixed}}
-{{end}}
 
 {{ $content | safeHTML }}

--- a/layouts/partials/textprocessing.html
+++ b/layouts/partials/textprocessing.html
@@ -4,7 +4,7 @@
 
 <!-- detect code blocks and fences -->
 {{$codefences := $raw | findRE "\\x60[^\\x60\\n]+\\x60"}}
-{{$codeblocks := $raw | findRE "\\x60{3}[^\\x60]+\\x60{3}"}}
+{{$codeblocks := $raw | findRE "\\x60{3}([^\\x60]|\\x60[^\\x60]|\\x60\\x60[^\\x60])*\\x60{3}"}}
 {{$code := union $codefences $codeblocks}}
 
 {{/*  pre-parse processing  */}}


### PR DESCRIPTION
This PR fixes https://github.com/jackyzha0/quartz/issues/227, fixes https://github.com/jackyzha0/quartz/issues/241 and fixes https://github.com/jackyzha0/quartz/issues/260.

The file `layouts/partials/textprocessing.html` has been re-structured to incorporate the following changes:
1. Processing has been divided into two parts, pre-processing and post-processing. 
	- In the pre-processing section, we use `.RawContent` and detect codeblocks, wikilinks and marked text and make approriate replacements with HTML tags.
	- Then we use `markdownify` to parse the content. In the post-processing section, we handle stuff that deals with these HTML tags or id-s generated by Hugo. 
2. We work only with `.RawContent` this time, since `.Content` renders [*shortcodes*](https://gohugo.io/content-management/shortcodes/) (into HTML tags) and highlighting through [chroma](https://github.com/alecthomas/chroma) is achieved through shortcodes ([ref](https://gohugo.io/content-management/syntax-highlighting/#highlight-shortcode)). Thus using `.Content` associates a bunch of HTML tags with codeblocks and breaks detection with regex. Sure, detecting the specific html tags is possible, but it is more involved and could be broken by a future change in the highlighting engine. Dealing with `.RawContent` is devoid of these framework-specific issues and stays close to the established markdown spec.
3. The advantage this method has is to have more control over the parsing step by making appropriate replacements early-on. This could fix Katex-rendering issues (https://github.com/jackyzha0/quartz/issues/263 or https://github.com/jackyzha0/quartz/issues/175, for instance) and I have some future fixes in mind.
4. Also tweaked the codeblock regex used to allow at most two consecutive backticks in codeblocks (expected behaviour and consistent with Obsidian).

Please review the changes and feel free to make suggestions as you go along.