### PR TITLE
Unescaping percent encoding on graph when title is not specified (or post does not exist)

### DIFF
--- a/assets/js/graph.js
+++ b/assets/js/graph.js
@@ -238,7 +238,7 @@ async function drawGraph(baseUrl, isHome, pathColors, graphConfig) {
     .attr("dx", 0)
     .attr("dy", (d) => nodeRadius(d) + 8 + "px")
     .attr("text-anchor", "middle")
-    .text((d) => content[d.id]?.title || (d.id.charAt(1).toUpperCase() + d.id.slice(2)).replace("-", " "))
+    .text((d) => content[d.id]?.title || (decodeURI(d.id.charAt(1).toUpperCase() + d.id.slice(2))).replace("-", " "))
     .style('opacity', (opacityScale - 1) / 3.75)
     .style("pointer-events", "none")
     .style('font-size', fontSize + 'em')


### PR DESCRIPTION
This PR solves the issue mentioned at here https://github.com/jackyzha0/hugo-obsidian/pull/27 .

The posts which has CJK filename and no title metadata on frontmatter, or the wikilink for non-existent word are shown with percent-encoding.

This PR just decodes URI when its displayed.
