### PR TITLE
Fixed priority in graph option vs default param

### DIFF
--- a/quartz/components/Graph.tsx
+++ b/quartz/components/Graph.tsx
@@ -47,8 +47,8 @@ const defaultOptions: GraphOptions = {
 
 export default ((opts?: GraphOptions) => {
   function Graph() {
-    const localGraph = { ...opts?.localGraph, ...defaultOptions.localGraph }
-    const globalGraph = { ...opts?.globalGraph, ...defaultOptions.globalGraph }
+    const localGraph = { ...defaultOptions.localGraph, ...opts?.localGraph, }
+    const globalGraph = { ...defaultOptions.globalGraph, ...opts?.globalGraph, }
     return (
       <div class="graph">
         <h3>Graph View</h3>


### PR DESCRIPTION
Passing option of graph through `quartz.layout.ts`  did not work because default parameter overrides passed arguments currently.

This PR fixes the priority of the default parameter and arguments.