### PR TITLE
Update the hosting URL in CLI project generator

### DIFF
--- a/quartz/bootstrap-cli.mjs
+++ b/quartz/bootstrap-cli.mjs
@@ -255,7 +255,7 @@ See the [documentation](https://quartz.jzhao.xyz) for how to get started.
     outro(`You're all set! Not sure what to do next? Try:
    • Customizing Quartz a bit more by editing \`quartz.config.ts\`
    • Running \`npx quartz build --serve\` to preview your Quartz locally
-   • Hosting your Quartz online (see: https://quartz.jzhao.xyz/hosting)
+   • Hosting your Quartz online (see: https://four.quartz.jzhao.xyz/hosting)
 `)
   })
   .command("update", "Get the latest Quartz updates", CommonArgv, async (argv) => {


### PR DESCRIPTION
Hi @jackyzha0 

As mention in my [tweet](https://twitter.com/anshulxyz/status/1693558291408806300?s=20) I found that the CLI project generator directs users to the URL:quartz.jzhao.xyz/setup/hosting

![image](https://github.com/jackyzha0/quartz/assets/6121530/e674a0d0-ff82-42b3-9a83-ce1d610fcdcb)

Which looks broken.

![image](https://github.com/jackyzha0/quartz/assets/6121530/de98925a-e20d-435c-8cfe-531a461aedc8)

Meanwhile when browsing docs I see that URL for hosting is https://four.quartz.jzhao.xyz/hosting

I'm sending PR to update the URL in the CLI generator.