### PR TITLE
fix(esbuild): conflict with esbuild-sass-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@types/workerpool": "^6.4.0",
     "@types/ws": "^8.5.5",
     "@types/yargs": "^17.0.24",
-    "esbuild": "^0.18.11",
+    "esbuild": "^0.19.1",
     "prettier": "^3.0.0",
     "tsx": "^3.12.7",
     "typescript": "^5.0.4"


### PR DESCRIPTION
transitive esbuild from esbuild-sass-plugin requires esbuild==0.19.1, whilst the previous dev is at 0.18.20