### PR TITLE
Fix: Revert contentIndex to RSS 2.0

### DIFF
--- a/quartz/plugins/emitters/contentIndex.ts
+++ b/quartz/plugins/emitters/contentIndex.ts
@@ -41,26 +41,26 @@ function generateRSSFeed(cfg: GlobalConfiguration, idx: ContentIndex): string {
   const base = cfg.baseUrl ?? ""
   const root = `https://${base}`
 
-  const createURLEntry = (slug: SimpleSlug, content: ContentDetails): string => `<items>
+  const createURLEntry = (slug: SimpleSlug, content: ContentDetails): string => `<item>
     <title>${content.title}</title>
     <link>${root}/${slug}</link>
     <guid>${root}/${slug}</guid>
     <description>${content.description}</description>
     <pubDate>${content.date?.toUTCString()}</pubDate>
-  </items>`
+  </item>`
 
   const items = Array.from(idx)
     .map(([slug, content]) => createURLEntry(simplifySlug(slug), content))
     .join("")
-  return `<rss xmlns:atom="http://www.w3.org/2005/atom" version="2.0">
+  return `<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
     <channel>
       <title>${cfg.pageTitle}</title>
       <link>${root}</link>
       <description>Recent content on ${cfg.pageTitle}</description>
       <generator>Quartz -- quartz.jzhao.xyz</generator>
-      <atom:link href="${root}/index.xml" rel="self" type="application/rss+xml"/>
+      ${items}
     </channel>
-    ${items}
   </rss>`
 }
 


### PR DESCRIPTION
The current implementation of the RSS feed was failing feed validation by https://validator.w3.org/feed/ because it jumbled RSS 2.0 and Atom syntax. This PR makes it validate as an RSS 2.0 feed.

Tested and working with Thunderbird and https://rssviewer.app/.

Thank you for being the only project in the greater Obsidian ecosystem that has anything to do with an RSS feed!

(also, thank you for structuring your plugin files so well that I can easily follow and edit them to work properly in one evening...)