### PR TITLE
feat: add styling to text selection

### DIFF
--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -27,6 +27,11 @@ section {
   border-radius: 5px;
 }
 
+::selection {
+  background: color-mix(in srgb, var(--tertiary) 75%, transparent);
+  color: var(--darkgray)
+}
+
 p,
 ul,
 text,


### PR DESCRIPTION
Integrate `tertiary` color from `quartz.config.ts` to `base.scss` text selection to make theming more consistent.

Looks like this:

![dark](https://github.com/jackyzha0/quartz/assets/31989404/b621e246-0c1d-4e57-ae67-8851dbfef7e8)

![light](https://github.com/jackyzha0/quartz/assets/31989404/756629b6-ae1d-4764-9e6e-ef55205c2e6c)


