### PR TITLE
feat(plugins): add toml support for frontmatter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "serve-handler": "^6.1.5",
         "source-map-support": "^0.5.21",
         "to-vfile": "^7.2.4",
+        "toml": "^3.0.0",
         "unified": "^10.1.2",
         "unist-util-visit": "^4.1.2",
         "vfile": "^5.3.7",
@@ -5547,6 +5548,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
     },
     "node_modules/tough-cookie": {
       "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "serve-handler": "^6.1.5",
     "source-map-support": "^0.5.21",
     "to-vfile": "^7.2.4",
+    "toml": "^3.0.0",
     "unified": "^10.1.2",
     "unist-util-visit": "^4.1.2",
     "vfile": "^5.3.7",

--- a/quartz/plugins/transformers/frontmatter.ts
+++ b/quartz/plugins/transformers/frontmatter.ts
@@ -7,7 +7,7 @@ import { slugTag } from "../../util/path"
 
 export interface Options {
   delims: string | string[]
-  language: string | string[]
+  language: "yaml" | "toml"
 }
 
 const defaultOptions: Options = {

--- a/quartz/plugins/transformers/frontmatter.ts
+++ b/quartz/plugins/transformers/frontmatter.ts
@@ -2,14 +2,17 @@ import matter from "gray-matter"
 import remarkFrontmatter from "remark-frontmatter"
 import { QuartzTransformerPlugin } from "../types"
 import yaml from "js-yaml"
+import toml from "toml"
 import { slugTag } from "../../util/path"
 
 export interface Options {
   delims: string | string[]
+  language: string | string[]
 }
 
 const defaultOptions: Options = {
   delims: "---",
+  language: "yaml",
 }
 
 export const FrontMatter: QuartzTransformerPlugin<Partial<Options> | undefined> = (userOpts) => {
@@ -25,6 +28,7 @@ export const FrontMatter: QuartzTransformerPlugin<Partial<Options> | undefined> 
               ...opts,
               engines: {
                 yaml: (s) => yaml.load(s, { schema: yaml.JSON_SCHEMA }) as object,
+                toml: (s) => toml.parse(s) as object,
               },
             })
 


### PR DESCRIPTION
Currently frontmatter is expected to be yaml, with delimiter set to "---". This might not always be the case, for example ox-hugo(a hugo exporter for org-mode files) exports in toml format with the delimiter set to "+++" by default.

With this change, the users will be able use frontmatter plugin to support this toml frontmatter format.

Example usage: `Plugin.FrontMatter({delims: "+++", language: 'toml'})`

- [0] https://ox-hugo.scripter.co/doc/org-meta-data-to-hugo-front-matter/

Resolves https://github.com/jackyzha0/quartz/issues/417 partially