### PR TITLE
Add `.obsidian` to ignorePatterns

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -10,7 +10,7 @@ const config: QuartzConfig = {
       provider: "plausible",
     },
     baseUrl: "quartz.jzhao.xyz",
-    ignorePatterns: ["private", "templates"],
+    ignorePatterns: ["private", "templates", ".obsidian"],
     defaultDateType: "created",
     theme: {
       typography: {


### PR DESCRIPTION
To prevent unintended behavior when linking the entire obsidian vault via symlink, add `.obsidian` to ignorePatterns in `quartz.config.ts`.