### PR TITLE
Update CLI to support arguments for create process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -112,6 +112,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/quartz/bootstrap-cli.mjs
+++ b/quartz/bootstrap-cli.mjs
@@ -170,13 +170,13 @@ yargs(hideBin(process.argv))
     // If all cmd arguments were provided, check if theyre valid
     if (contentFolder && setupStrategy && linkResolutionStrategy) {
       if (!validSetupStrategies.includes(setupStrategy)) {
-        outro("Invalid setup strategy (argument '-c', provided: " + setupStrategy + ", expected: [" + validSetupStrategies.join(" | ") + "])");
-        return;
+        outro(chalk.red("Invalid setup strategy (argument " + chalk.yellow('-c') + ", provided: " + chalk.yellow(setupStrategy) + ", expected: [" + chalk.yellow(validSetupStrategies.join(" | ")) + "])"));
+        process.exit(1);
       }
 
       if (!validResolutionStrategies.includes(linkResolutionStrategy)) {
-        outro("Invalid link resolution strategy (argument '-l', provided: " + linkResolutionStrategy + ", expected: [" + validResolutionStrategies.join(" | ") + "])");
-        return;
+        outro(chalk.red("Invalid link resolution strategy (argument " + chalk.yellow('-l') + ", provided: " + chalk.yellow(linkResolutionStrategy) + ", expected: [" + chalk.yellow(validResolutionStrategies.join(" | ")) + "])"));
+        process.exit(1);
       }
 
       hasAllCmdArgs = true;

--- a/quartz/bootstrap-cli.mjs
+++ b/quartz/bootstrap-cli.mjs
@@ -194,7 +194,6 @@ yargs(hideBin(process.argv))
       }
 
       hasAllCmdArgs = true;
-      return;
     }
 
     // Use cli process if cmd args werent provided
@@ -226,23 +225,28 @@ yargs(hideBin(process.argv))
 
     await fs.promises.unlink(path.join(contentFolder, ".gitkeep"))
     if (setupStrategy === "copy" || setupStrategy === "symlink") {
-      const originalFolder = escapePath(
-        exitIfCancel(
-          await text({
-            message: "Enter the full path to existing content folder",
-            placeholder:
-              "On most terminal emulators, you can drag and drop a folder into the window and it will paste the full path",
-            validate(fp) {
-              const fullPath = escapePath(fp)
-              if (!fs.existsSync(fullPath)) {
-                return "The given path doesn't exist"
-              } else if (!fs.lstatSync(fullPath).isDirectory()) {
-                return "The given path is not a folder"
-              }
-            },
-          }),
-        ),
-      )
+      let originalFolder = inDirectory;
+
+      // If input directory was not passed, use cli
+      if (!inDirectory) {
+        originalFolder = escapePath(
+          exitIfCancel(
+            await text({
+              message: "Enter the full path to existing content folder",
+              placeholder:
+                "On most terminal emulators, you can drag and drop a folder into the window and it will paste the full path",
+              validate(fp) {
+                const fullPath = escapePath(fp)
+                if (!fs.existsSync(fullPath)) {
+                  return "The given path doesn't exist"
+                } else if (!fs.lstatSync(fullPath).isDirectory()) {
+                  return "The given path is not a folder"
+                }
+              },
+            }),
+          ),
+        )
+      }
 
       await rmContentFolder()
       if (setupStrategy === "copy") {

--- a/quartz/bootstrap-cli.mjs
+++ b/quartz/bootstrap-cli.mjs
@@ -286,7 +286,7 @@ See the [documentation](https://quartz.jzhao.xyz) for how to get started.
     }
 
     // Use cli process if cmd args werent provided
-    if (!hasAllCmdArgs) {
+    if (!linkResolutionStrategy) {
       // get a preferred link resolution strategy
       linkResolutionStrategy = exitIfCancel(
         await select({

--- a/quartz/bootstrap-cli.mjs
+++ b/quartz/bootstrap-cli.mjs
@@ -40,7 +40,11 @@ const CommonArgv = {
     alias: ["v"],
     default: false,
     describe: "print out extra logging information",
-  },
+  }
+}
+
+const CreateArgv = {
+  ...CommonArgv,
   "in-directory": {
     string: true,
     alias: ["i"],
@@ -164,7 +168,7 @@ yargs(hideBin(process.argv))
   .scriptName("quartz")
   .version(version)
   .usage("$0 <cmd> [args]")
-  .command("create", "Initialize Quartz", CommonArgv, async (argv) => {
+  .command("create", "Initialize Quartz", CreateArgv, async (argv) => {
     console.log()
     intro(chalk.bgGreen.black(` Quartz v${version} `))
     const contentFolder = path.join(cwd, argv.directory)

--- a/quartz/bootstrap-cli.mjs
+++ b/quartz/bootstrap-cli.mjs
@@ -41,6 +41,16 @@ const CommonArgv = {
     default: false,
     describe: "print out extra logging information",
   },
+  content: {
+    string: true,
+    alias: ["c"],
+    describe: "how to initialize content folder [allows 'empty', 'existing' or 'symlink']"
+  },
+  links: {
+    string: true,
+    alias: ["l"],
+    describe: "strategy to resolve links [allows 'absolute', 'shortest' or 'relative']"
+  }
 }
 
 const SyncArgv = {

--- a/quartz/bootstrap-cli.mjs
+++ b/quartz/bootstrap-cli.mjs
@@ -44,20 +44,20 @@ const CommonArgv = {
   "in-directory": {
     string: true,
     alias: ["i"],
-    describe: "what directory to copy/create symlink from"
+    describe: "what directory to copy/create symlink from",
   },
   setup: {
     string: true,
     alias: ["s"],
     choices: ["new", "copy", "symlink"],
-    describe: "strategy for content folder setup"
+    describe: "strategy for content folder setup",
   },
   links: {
     string: true,
     alias: ["l"],
     choices: ["absolute", "shortest", "relative"],
-    describe: "strategy to resolve links"
-  }
+    describe: "strategy to resolve links",
+  },
 }
 
 const SyncArgv = {
@@ -168,32 +168,57 @@ yargs(hideBin(process.argv))
     console.log()
     intro(chalk.bgGreen.black(` Quartz v${version} `))
     const contentFolder = path.join(cwd, argv.directory)
-    let setupStrategy = argv.setup?.toLowerCase();
-    let linkResolutionStrategy = argv.links?.toLowerCase();
-    const inDirectory = argv["in-directory"];
-    let hasAllCmdArgs = false;
+    let setupStrategy = argv.setup?.toLowerCase()
+    let linkResolutionStrategy = argv.links?.toLowerCase()
+    const inDirectory = argv["in-directory"]
+    let hasAllCmdArgs = false
 
     // If all cmd arguments were provided, check if theyre valid
     if (setupStrategy && linkResolutionStrategy) {
-
       // If setup isn't, "new", --in-directory argument is required
       if (setupStrategy !== "new") {
         // Error handling
         if (!inDirectory) {
-          outro(chalk.red("Setup strategies (arg '" + chalk.yellow('-' + CommonArgv.setup.alias[0]) + "') other than '" + chalk.yellow("new") + "' require content folder argument ('" + chalk.yellow('-' + CommonArgv["in-directory"].alias[0]) + "') to be set"));
-          return 1;
+          outro(
+            chalk.red(
+              "Setup strategies (arg '" +
+                chalk.yellow("-" + CommonArgv.setup.alias[0]) +
+                "') other than '" +
+                chalk.yellow("new") +
+                "' require content folder argument ('" +
+                chalk.yellow("-" + CommonArgv["in-directory"].alias[0]) +
+                "') to be set",
+            ),
+          )
+          return 1
         } else {
           if (!fs.existsSync(inDirectory)) {
-            outro(chalk.red("Input directory to copy/symlink 'content' from not found ('" + chalk.yellow(inDirectory) + "', invalid argument " + chalk.yellow('-' + CommonArgv["in-directory"].alias[0]) + ")" ));
-            return 1;
+            outro(
+              chalk.red(
+                "Input directory to copy/symlink 'content' from not found ('" +
+                  chalk.yellow(inDirectory) +
+                  "', invalid argument " +
+                  chalk.yellow("-" + CommonArgv["in-directory"].alias[0]) +
+                  ")",
+              ),
+            )
+            return 1
           } else if (!fs.lstatSync(inDirectory).isDirectory()) {
-            outro(chalk.red("Input directory to copy/symlink 'content' from is not a directory (found file at '" + chalk.yellow(inDirectory) + "', invalid argument " + chalk.yellow('-' + CommonArgv["in-directory"].alias[0]) + ")" ));
-            return 1;
+            outro(
+              chalk.red(
+                "Input directory to copy/symlink 'content' from is not a directory (found file at '" +
+                  chalk.yellow(inDirectory) +
+                  "', invalid argument " +
+                  chalk.yellow("-" + CommonArgv["in-directory"].alias[0]) +
+                  ")",
+              ),
+            )
+            return 1
           }
         }
       }
 
-      hasAllCmdArgs = true;
+      hasAllCmdArgs = true
     }
 
     // Use cli process if cmd args werent provided
@@ -225,7 +250,7 @@ yargs(hideBin(process.argv))
 
     await fs.promises.unlink(path.join(contentFolder, ".gitkeep"))
     if (setupStrategy === "copy" || setupStrategy === "symlink") {
-      let originalFolder = inDirectory;
+      let originalFolder = inDirectory
 
       // If input directory was not passed, use cli
       if (!inDirectory) {

--- a/quartz/bootstrap-cli.mjs
+++ b/quartz/bootstrap-cli.mjs
@@ -161,8 +161,8 @@ yargs(hideBin(process.argv))
     console.log()
     intro(chalk.bgGreen.black(` Quartz v${version} `))
     const contentFolder = path.join(cwd, argv.directory)
-    let setupStrategy = argv.content.toLowerCase();
-    let linkResolutionStrategy = argv.links.toLowerCase();
+    let setupStrategy = argv.content?.toLowerCase();
+    let linkResolutionStrategy = argv.links?.toLowerCase();
     const validSetupStrategies = ["new", "copy", "symlink"];
     const validResolutionStrategies = ["absolute", "shortest", "relative"];
     let hasAllCmdArgs = false;
@@ -180,24 +180,26 @@ yargs(hideBin(process.argv))
       }
 
       hasAllCmdArgs = true;
-      outro("All args were found.");
       return;
     }
 
-    setupStrategy = exitIfCancel(
-      await select({
-        message: `Choose how to initialize the content in \`${contentFolder}\``,
-        options: [
-          { value: "new", label: "Empty Quartz" },
-          { value: "copy", label: "Copy an existing folder", hint: "overwrites `content`" },
-          {
-            value: "symlink",
-            label: "Symlink an existing folder",
-            hint: "don't select this unless you know what you are doing!",
-          },
-        ],
-      }),
-    )
+    // Use cli process if cmd args werent provided
+    if (!hasAllCmdArgs) {
+      setupStrategy = exitIfCancel(
+        await select({
+          message: `Choose how to initialize the content in \`${contentFolder}\``,
+          options: [
+            { value: "new", label: "Empty Quartz" },
+            { value: "copy", label: "Copy an existing folder", hint: "overwrites `content`" },
+            {
+              value: "symlink",
+              label: "Symlink an existing folder",
+              hint: "don't select this unless you know what you are doing!",
+            },
+          ],
+        }),
+      )
+    }
 
     async function rmContentFolder() {
       const contentStat = await fs.promises.lstat(contentFolder)
@@ -250,29 +252,32 @@ See the [documentation](https://quartz.jzhao.xyz) for how to get started.
       )
     }
 
-    // get a preferred link resolution strategy
-    linkResolutionStrategy = exitIfCancel(
-      await select({
-        message: `Choose how Quartz should resolve links in your content. You can change this later in \`quartz.config.ts\`.`,
-        options: [
-          {
-            value: "absolute",
-            label: "Treat links as absolute path",
-            hint: "for content made for Quartz 3 and Hugo",
-          },
-          {
-            value: "shortest",
-            label: "Treat links as shortest path",
-            hint: "for most Obsidian vaults",
-          },
-          {
-            value: "relative",
-            label: "Treat links as relative paths",
-            hint: "for just normal Markdown files",
-          },
-        ],
-      }),
-    )
+    // Use cli process if cmd args werent provided
+    if (!hasAllCmdArgs) {
+      // get a preferred link resolution strategy
+      linkResolutionStrategy = exitIfCancel(
+        await select({
+          message: `Choose how Quartz should resolve links in your content. You can change this later in \`quartz.config.ts\`.`,
+          options: [
+            {
+              value: "absolute",
+              label: "Treat links as absolute path",
+              hint: "for content made for Quartz 3 and Hugo",
+            },
+            {
+              value: "shortest",
+              label: "Treat links as shortest path",
+              hint: "for most Obsidian vaults",
+            },
+            {
+              value: "relative",
+              label: "Treat links as relative paths",
+              hint: "for just normal Markdown files",
+            },
+          ],
+        }),
+      )
+    }
 
     // now, do config changes
     const configFilePath = path.join(cwd, "quartz.config.ts")

--- a/quartz/bootstrap-cli.mjs
+++ b/quartz/bootstrap-cli.mjs
@@ -44,7 +44,7 @@ const CommonArgv = {
   content: {
     string: true,
     alias: ["c"],
-    describe: "how to initialize content folder [allows 'empty', 'existing' or 'symlink']"
+    describe: "how to initialize content folder [allows 'new', 'copy' or 'symlink']"
   },
   links: {
     string: true,
@@ -161,7 +161,30 @@ yargs(hideBin(process.argv))
     console.log()
     intro(chalk.bgGreen.black(` Quartz v${version} `))
     const contentFolder = path.join(cwd, argv.directory)
-    const setupStrategy = exitIfCancel(
+    let setupStrategy = argv.content.toLowerCase();
+    let linkResolutionStrategy = argv.links.toLowerCase();
+    const validSetupStrategies = ["new", "copy", "symlink"];
+    const validResolutionStrategies = ["absolute", "shortest", "relative"];
+    let hasAllCmdArgs = false;
+
+    // If all cmd arguments were provided, check if theyre valid
+    if (contentFolder && setupStrategy && linkResolutionStrategy) {
+      if (!validSetupStrategies.includes(setupStrategy)) {
+        outro("Invalid setup strategy (argument '-c', provided: " + setupStrategy + ", expected: [" + validSetupStrategies.join(" | ") + "])");
+        return;
+      }
+
+      if (!validResolutionStrategies.includes(linkResolutionStrategy)) {
+        outro("Invalid link resolution strategy (argument '-l', provided: " + linkResolutionStrategy + ", expected: [" + validResolutionStrategies.join(" | ") + "])");
+        return;
+      }
+
+      hasAllCmdArgs = true;
+      outro("All args were found.");
+      return;
+    }
+
+    setupStrategy = exitIfCancel(
       await select({
         message: `Choose how to initialize the content in \`${contentFolder}\``,
         options: [
@@ -228,7 +251,7 @@ See the [documentation](https://quartz.jzhao.xyz) for how to get started.
     }
 
     // get a preferred link resolution strategy
-    const linkResolutionStrategy = exitIfCancel(
+    linkResolutionStrategy = exitIfCancel(
       await select({
         message: `Choose how Quartz should resolve links in your content. You can change this later in \`quartz.config.ts\`.`,
         options: [

--- a/quartz/bootstrap-cli.mjs
+++ b/quartz/bootstrap-cli.mjs
@@ -190,7 +190,7 @@ yargs(hideBin(process.argv))
                 "') to be set",
             ),
           )
-          return 1
+          process.exit(1)
         } else {
           if (!fs.existsSync(inDirectory)) {
             outro(
@@ -202,7 +202,7 @@ yargs(hideBin(process.argv))
                   ")",
               ),
             )
-            return 1
+            process.exit(1)
           } else if (!fs.lstatSync(inDirectory).isDirectory()) {
             outro(
               chalk.red(
@@ -213,7 +213,7 @@ yargs(hideBin(process.argv))
                   ")",
               ),
             )
-            return 1
+            process.exit(1)
           }
         }
       }

--- a/quartz/bootstrap-cli.mjs
+++ b/quartz/bootstrap-cli.mjs
@@ -175,7 +175,6 @@ yargs(hideBin(process.argv))
     let setupStrategy = argv.strategy?.toLowerCase()
     let linkResolutionStrategy = argv.links?.toLowerCase()
     const sourceDirectory = argv.source
-    let hasAllCmdArgs = false
 
     // If all cmd arguments were provided, check if theyre valid
     if (setupStrategy && linkResolutionStrategy) {
@@ -217,12 +216,10 @@ yargs(hideBin(process.argv))
           }
         }
       }
-
-      hasAllCmdArgs = true
     }
 
     // Use cli process if cmd args werent provided
-    if (!hasAllCmdArgs) {
+    if (!setupStrategy) {
       setupStrategy = exitIfCancel(
         await select({
           message: `Choose how to initialize the content in \`${contentFolder}\``,

--- a/quartz/bootstrap-cli.mjs
+++ b/quartz/bootstrap-cli.mjs
@@ -40,7 +40,7 @@ const CommonArgv = {
     alias: ["v"],
     default: false,
     describe: "print out extra logging information",
-  }
+  },
 }
 
 const CreateArgv = {
@@ -185,7 +185,13 @@ yargs(hideBin(process.argv))
         if (!sourceDirectory) {
           outro(
             chalk.red(
-              `Setup strategies (arg '${chalk.yellow(`-${CreateArgv.strategy.alias[0]}`)}') other than '${chalk.yellow("new")}' require content folder argument ('${chalk.yellow(`-${CreateArgv.source.alias[0]}`)}') to be set`,
+              `Setup strategies (arg '${chalk.yellow(
+                `-${CreateArgv.strategy.alias[0]}`,
+              )}') other than '${chalk.yellow(
+                "new",
+              )}' require content folder argument ('${chalk.yellow(
+                `-${CreateArgv.source.alias[0]}`,
+              )}') to be set`,
             ),
           )
           process.exit(1)
@@ -193,14 +199,18 @@ yargs(hideBin(process.argv))
           if (!fs.existsSync(sourceDirectory)) {
             outro(
               chalk.red(
-                `Input directory to copy/symlink 'content' from not found ('${chalk.yellow(sourceDirectory)}', invalid argument "${chalk.yellow(`-${CreateArgv.source.alias[0]}`)})`,
+                `Input directory to copy/symlink 'content' from not found ('${chalk.yellow(
+                  sourceDirectory,
+                )}', invalid argument "${chalk.yellow(`-${CreateArgv.source.alias[0]}`)})`,
               ),
             )
             process.exit(1)
           } else if (!fs.lstatSync(sourceDirectory).isDirectory()) {
             outro(
               chalk.red(
-                `Source directory to copy/symlink 'content' from is not a directory (found file at '${chalk.yellow(sourceDirectory)}', invalid argument ${chalk.yellow(`-${CreateArgv.source.alias[0]}`)}")`,
+                `Source directory to copy/symlink 'content' from is not a directory (found file at '${chalk.yellow(
+                  sourceDirectory,
+                )}', invalid argument ${chalk.yellow(`-${CreateArgv.source.alias[0]}`)}")`,
               ),
             )
             process.exit(1)

--- a/quartz/bootstrap-cli.mjs
+++ b/quartz/bootstrap-cli.mjs
@@ -44,12 +44,14 @@ const CommonArgv = {
   content: {
     string: true,
     alias: ["c"],
-    describe: "how to initialize content folder [allows 'new', 'copy' or 'symlink']"
+    choices: ["new", "copy", "symlink"],
+    describe: "strategy to initialize content folder"
   },
   links: {
     string: true,
     alias: ["l"],
-    describe: "strategy to resolve links [allows 'absolute', 'shortest' or 'relative']"
+    choices: ["absolute", "shortest", "relative"],
+    describe: "strategy to resolve links"
   }
 }
 
@@ -163,20 +165,15 @@ yargs(hideBin(process.argv))
     const contentFolder = path.join(cwd, argv.directory)
     let setupStrategy = argv.content?.toLowerCase();
     let linkResolutionStrategy = argv.links?.toLowerCase();
-    const validSetupStrategies = ["new", "copy", "symlink"];
-    const validResolutionStrategies = ["absolute", "shortest", "relative"];
     let hasAllCmdArgs = false;
 
     // If all cmd arguments were provided, check if theyre valid
-    if (contentFolder && setupStrategy && linkResolutionStrategy) {
-      if (!validSetupStrategies.includes(setupStrategy)) {
-        outro(chalk.red("Invalid setup strategy (argument " + chalk.yellow('-c') + ", provided: " + chalk.yellow(setupStrategy) + ", expected: [" + chalk.yellow(validSetupStrategies.join(" | ")) + "])"));
-        process.exit(1);
-      }
+    if (setupStrategy && linkResolutionStrategy) {
 
-      if (!validResolutionStrategies.includes(linkResolutionStrategy)) {
-        outro(chalk.red("Invalid link resolution strategy (argument " + chalk.yellow('-l') + ", provided: " + chalk.yellow(linkResolutionStrategy) + ", expected: [" + chalk.yellow(validResolutionStrategies.join(" | ")) + "])"));
-        process.exit(1);
+      // If setup isn't, "new", content argument is required (argv.directory defaults to 'content')
+      if (setupStrategy !== "new" && argv.directory === "content") {
+        outro(chalk.red("Setup strategies (arg '" + chalk.yellow("-c") + "') other than '" + chalk.yellow("new") + "' require content folder argument ('" + chalk.yellow('-d') + "') to be set"));
+        return 1;
       }
 
       hasAllCmdArgs = true;


### PR DESCRIPTION
## Motivation

Allow users to go through the setup process (creating quartz) by providing all needed arguments to skip going through manual cli process

## Arguments

Added new arguments to `quartz create` for 'setup strategy' (`-s`), 'linking strategy' (`-l`) and 'input directory' (`-i` to copy/symlink from, optional for setup "new")

## Testing

All happy paths were tested from a freshly cloned install

### Steps to reproduce

To test a new permutation, I did the following steps:

1. git clone the repository
2. cd quartz
3. npm i
4. replace `bootstrap-cli.mjs` with new version
5. run `quartz create` with new permutation.

### Happy paths
I tested the following permutations of arguments for `npx quartz create` manually (on windows):

1. setup strategy `copy` ✅:
   - `-s`: "copy"
   - `-i`: valid path
   - `-l`: "shortest"

2. setup strategy `symlink` ~:
   - `-s`: "symlink"
   - `-i`: valid path
   - `-l`: "shortest"

this only works if command is executed as admin, iirc this is consistent with the behavior of using the cli manually (also requires admin to create symlinks)

3. setup strategy `new` ✅:
   - `-s`: "new"
   - `-i`: tested with valid path and without providing `-i` argument
   - `-l`: "shortest

### Exception paths

- Trying to provide `-s` and`-l` without providing `-i` shows error and exits with `process.exit(1)`
- Trying to provide `-s`, `-l` and `-i` with an invalid directory shows error and exits with `process.exit(1)`
- Trying to provide `-s`, `-l` and `-i` with path to a file  shows error and exits with `process.exit(1)`
- Trying to provide only the setup strategy or linking strategy defaults to manual cli process and overrides both