### PR TITLE
Fix search bar after navigate

### DIFF
--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -128,6 +128,7 @@ document.addEventListener("nav", async (e: unknown) => {
     button.addEventListener("click", () => {
       const targ = resolveRelative(currentSlug, slug)
       window.spaNavigate(new URL(targ, window.location.toString()))
+      hideSearch();
     })
     return button
   }

--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -128,7 +128,7 @@ document.addEventListener("nav", async (e: unknown) => {
     button.addEventListener("click", () => {
       const targ = resolveRelative(currentSlug, slug)
       window.spaNavigate(new URL(targ, window.location.toString()))
-      hideSearch();
+      hideSearch()
     })
     return button
   }


### PR DESCRIPTION
When following a search result, the search bar still contains the old search when opening search again. This fixes the problem.