### PR TITLE
feat: support kebab-case and nested tags in Obsidian-flavored Markdown tag-in-content parsing

### DIFF
--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -118,7 +118,7 @@ const calloutLineRegex = new RegExp(/^> *\[\!\w+\][+-]?.*$/, "gm")
 // #(...)               -> capturing group, tag itself must start with #
 // (?:[-_\p{L}])+       -> non-capturing group, non-empty string of (Unicode-aware) alpha-numeric characters, hyphens and/or underscores
 // (?:\/[-_\p{L}]+)*)   -> non-capturing group, matches an arbitrary number of tag strings separated by "/"
-const nestedTagRegex = new RegExp(/(?:^| )#((?:[-_\p{L}])+(?:\/[-_\p{L}]+)*)/, "gu")
+const tagRegex = new RegExp(/(?:^| )#((?:[-_\p{L}\d])+(?:\/[-_\p{L}\d]+)*)/, "gu")
 
 export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> | undefined> = (
   userOpts,


### PR DESCRIPTION
## Background

> Hey there quartz peeps 👋🏼 ! I was hoping to use quartz for my own digital garden and noticed a few things missing / broken wrt tags -- namely supporting nested tags and tags in `kebab-case` or `snake_case` since these seem to be supported by Obsidian [according to their docs](https://help.obsidian.md/Editing+and+formatting/Tags) -- so I figured I'd just contribute! I definitely don't know the ins and outs of this repo, so I could absolutely be missing something, but these changes seemed to work for my site locally!

Overall, only two aspects were added:

1. Support hyphens and underscores in tag names, e.g. `#cool-tag-name`. 
2. Support nested tags, e.g. #crypto and #crypto/ethereum with generated tag routes to `tags/crypto/` and `tags/crypto/ethereum` respectively

## Overview of Code Changes

- updated the regex in the `ObsidianFlavoredMarkdown` plugin to match an (optional) hyphen or underscore and/or text following a `/` for nested tags
- updated the replace function with this new regex and set the tags based on the capture groups [per mdast docs on the Replace function](https://github.com/syntax-tree/mdast-util-find-and-replace#replacefunction). In our case, the first match maps to our "base" tag, whereas the second match (if defined) will map to our nested value.

Would love any thoughts and/or feedback!
