### PR TITLE
feat: support configurable ws port and remote development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ tsconfig.tsbuildinfo
 .obsidian
 .quartz-cache
 private/
+.replit
+replit.nix

--- a/quartz/cli/args.js
+++ b/quartz/cli/args.js
@@ -76,6 +76,15 @@ export const BuildArgv = {
     default: 8080,
     describe: "port to serve Quartz on",
   },
+  wsPort: {
+    number: true,
+    default: 3001,
+    describe: "port to server Quartz develpmont reload on",
+  },
+  remoteDevHost: {
+    string: true,
+    default: "",
+  },
   bundleInfo: {
     boolean: true,
     default: false,

--- a/quartz/cli/args.js
+++ b/quartz/cli/args.js
@@ -79,7 +79,7 @@ export const BuildArgv = {
   wsPort: {
     number: true,
     default: 3001,
-    describe: "port to server Quartz develpmont reload on",
+    describe: "port to use for WebSocket-based hot-reload notifications",
   },
   remoteDevHost: {
     string: true,

--- a/quartz/cli/args.js
+++ b/quartz/cli/args.js
@@ -84,6 +84,7 @@ export const BuildArgv = {
   remoteDevHost: {
     string: true,
     default: "",
+    describe: "A URL override for the websocket connection if you are not developing on localhost"
   },
   bundleInfo: {
     boolean: true,

--- a/quartz/cli/args.js
+++ b/quartz/cli/args.js
@@ -84,7 +84,7 @@ export const BuildArgv = {
   remoteDevHost: {
     string: true,
     default: "",
-    describe: "A URL override for the websocket connection if you are not developing on localhost"
+    describe: "A URL override for the websocket connection if you are not developing on localhost",
   },
   bundleInfo: {
     boolean: true,

--- a/quartz/cli/handlers.js
+++ b/quartz/cli/handlers.js
@@ -402,7 +402,7 @@ export async function handleBuild(argv) {
       return serve()
     })
     server.listen(argv.port)
-    const wss = new WebSocketServer({ port: 3001 })
+    const wss = new WebSocketServer({ port: argv.wsPort })
     wss.on("connection", (ws) => connections.push(ws))
     console.log(
       chalk.cyan(

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -107,12 +107,18 @@ function addGlobalPageResources(
         document.dispatchEvent(event)`)
   }
 
+  let wsUrl = `ws://localhost:${ctx.argv.wsPort}`
+
+  if (ctx.argv.remoteDevHost) {
+    wsUrl = `wss://${ctx.argv.remoteDevHost}:${ctx.argv.wsPort}`
+  }
+
   if (reloadScript) {
     staticResources.js.push({
       loadTime: "afterDOMReady",
       contentType: "inline",
       script: `
-          const socket = new WebSocket('ws://localhost:3001')
+          const socket = new WebSocket('${wsUrl}'')
           socket.addEventListener('message', () => document.location.reload())
         `,
     })

--- a/quartz/util/ctx.ts
+++ b/quartz/util/ctx.ts
@@ -7,6 +7,8 @@ export interface Argv {
   output: string
   serve: boolean
   port: number
+  wsPort: number
+  remoteDevHost?: string
   concurrency?: number
 }
 


### PR DESCRIPTION
Sometimes you need to override ports! This should apply to the ws connection in addition to the http port.

Also, the client gets localhost hard coded, but if you are developing in a remote environment like Replit, this needs to be overridden to allow the auto rebuilding to work.

To test, I'll fork this branch in Replit, configure the ports in my .replit file, and ensure serving/reloading works. Will also do this locally with no configuration