### PR TITLE
Fix bug where `index.md` graph nodes display incorrect label

### DIFF
--- a/quartz/components/scripts/graph.inline.ts
+++ b/quartz/components/scripts/graph.inline.ts
@@ -231,7 +231,9 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
     .attr("dy", (d) => -nodeRadius(d) + "px")
     .attr("text-anchor", "middle")
     .text(
-      (d) => data[d.id]?.title || (d.id.charAt(1).toUpperCase() + d.id.slice(2)).replace("-", " "),
+      (d) =>
+        data[d.id]?.title ||
+        (d.id.charAt(0).toUpperCase() + d.id.slice(1, d.id.length - 1)).replace("-", " "),
     )
     .style("opacity", (opacityScale - 1) / 3.75)
     .style("pointer-events", "none")


### PR DESCRIPTION
Labels for `index.md` nodes were "off by one", first character gets trimmed and last character gets left in.

This fixes the bug by using correct index for creating label (start with first character, trim last character)


Before:

![image](https://github.com/jackyzha0/quartz/assets/31989404/3cf14333-d948-4914-9960-42f3117ef7c7)

After:

![image](https://github.com/jackyzha0/quartz/assets/31989404/e1dd8d77-b2fe-4939-8615-dfb241838a83)
