### PR TITLE
fix(search): matches no longer get highlighted in title

### DIFF
--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -157,7 +157,7 @@ document.addEventListener("nav", async (e: unknown) => {
     return {
       id,
       slug,
-      title: highlight(term, data[slug].title ?? ""),
+      title: searchType === "tags" ? data[slug].title : highlight(term, data[slug].title ?? ""),
       // if searchType is tag, display context from start of file and trim, otherwise use regular highlight
       content:
         searchType === "tags"


### PR DESCRIPTION
Title was getting highlighted with matches, even if `searchType` was `tags`. If the query also partially matched the title, this would be confusing, as the title is not what is queried for in tag search.

Example: search for `#c` in `docs`
Before: 

<img width="858" alt="image" src="https://github.com/jackyzha0/quartz/assets/31989404/1078d895-ee35-465e-a1bb-4ad73f1a42b1">

After:

<img width="867" alt="image" src="https://github.com/jackyzha0/quartz/assets/31989404/c8ab8927-9751-4d06-b99a-b8a2f59cc4fa">
