### PR TITLE
feat(search): add arrow key navigation

### DIFF
--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -353,5 +353,3 @@ async function fillDocument(index: Document<Item, false>, data: any) {
     id++
   }
 }
-
-// function highlightResultHandler(results: any, )

--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -123,9 +123,15 @@ document.addEventListener("nav", async (e: unknown) => {
       // add "#" prefix for tag search
       if (searchBar) searchBar.value = "#"
     } else if (e.key === "Enter") {
-      const anchor = document.getElementsByClassName("result-card")[0] as HTMLInputElement | null
-      if (anchor) {
-        anchor.click()
+      // If result has focus, navigate to that one, otherwise pick first result
+      if (results?.contains(document.activeElement)) {
+        const active = document.activeElement as HTMLInputElement
+        active.click()
+      } else {
+        const anchor = document.getElementsByClassName("result-card")[0] as HTMLInputElement | null
+        if (anchor) {
+          anchor.click()
+        }
       }
     } else if (e.key === "ArrowDown") {
       e.preventDefault()

--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -151,7 +151,7 @@ document.addEventListener("nav", async (e: unknown) => {
     } else if (e.key === "ArrowUp") {
       e.preventDefault()
       if (results?.contains(document.activeElement)) {
-        // If an element in results-container already has focus, focus next one
+        // If an element in results-container already has focus, focus previous one
         const prevResult = document.activeElement?.previousElementSibling as HTMLInputElement | null
         if (prevResult) {
           prevResult.focus()

--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -73,6 +73,7 @@ function highlight(searchTerm: string, text: string, trim?: boolean) {
 
 const encoder = (str: string) => str.toLowerCase().split(/([^a-z]|[^\x00-\x7F])/)
 let prevShortcutHandler: ((e: HTMLElementEventMap["keydown"]) => void) | undefined = undefined
+let currentResultIndex = -1
 document.addEventListener("nav", async (e: unknown) => {
   const currentSlug = (e as CustomEventMap["nav"]).detail.url
 
@@ -82,6 +83,7 @@ document.addEventListener("nav", async (e: unknown) => {
   const searchIcon = document.getElementById("search-icon")
   const searchBar = document.getElementById("search-bar") as HTMLInputElement | null
   const results = document.getElementById("results-container")
+  const resultCards = document.getElementsByClassName("result-card")
   const idDataMap = Object.keys(data) as FullSlug[]
 
   function hideSearch() {
@@ -97,6 +99,7 @@ document.addEventListener("nav", async (e: unknown) => {
     }
 
     searchType = "basic" // reset search type after closing
+    currentResultIndex = -1
   }
 
   function showSearch(searchTypeNew: SearchType) {
@@ -122,9 +125,32 @@ document.addEventListener("nav", async (e: unknown) => {
       // add "#" prefix for tag search
       if (searchBar) searchBar.value = "#"
     } else if (e.key === "Enter") {
-      const anchor = document.getElementsByClassName("result-card")[0] as HTMLInputElement | null
+      const anchor = document.getElementsByClassName("result-card")[currentResultIndex < 0 ? 0 : currentResultIndex] as HTMLInputElement | null
       if (anchor) {
         anchor.click()
+      }
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault()
+      if (currentResultIndex < resultCards.length - 1) {
+        let el: HTMLElement
+        if (currentResultIndex >= 0) {
+          el = resultCards[currentResultIndex] as HTMLElement
+          el.classList.remove("selected")
+        }
+        currentResultIndex++
+        el = resultCards[currentResultIndex] as HTMLElement
+        el.classList.add("selected")
+      }
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault()
+      console.log("index: ", currentResultIndex)
+      if (currentResultIndex > 0) {
+        let el: HTMLElement
+        el = resultCards[currentResultIndex] as HTMLElement
+        el.classList.remove("selected")
+        currentResultIndex--
+        el = resultCards[currentResultIndex] as HTMLElement
+        el.classList.add("selected")
       }
     }
   }
@@ -225,6 +251,9 @@ document.addEventListener("nav", async (e: unknown) => {
   async function onType(e: HTMLElementEventMap["input"]) {
     let term = (e.target as HTMLInputElement).value
     let searchResults: SimpleDocumentSearchResultSetUnit[]
+
+    // Reset result selection
+    currentResultIndex = -1
 
     if (term.toLowerCase().startsWith("#")) {
       searchType = "tags"
@@ -328,3 +357,5 @@ async function fillDocument(index: Document<Item, false>, data: any) {
     id++
   }
 }
+
+// function highlightResultHandler(results: any, )

--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -129,33 +129,25 @@ document.addEventListener("nav", async (e: unknown) => {
         active.click()
       } else {
         const anchor = document.getElementsByClassName("result-card")[0] as HTMLInputElement | null
-        if (anchor) {
-          anchor.click()
-        }
+        anchor?.click()
       }
     } else if (e.key === "ArrowDown") {
       e.preventDefault()
       // When first pressing ArrowDown, results wont contain the active element, so focus first element
       if (!results?.contains(document.activeElement)) {
         const firstResult = resultCards[0] as HTMLInputElement | null
-        if (firstResult) {
-          firstResult.focus()
-        }
+        firstResult?.focus()
       } else {
         // If an element in results-container already has focus, focus next one
         const nextResult = document.activeElement?.nextElementSibling as HTMLInputElement | null
-        if (nextResult) {
-          nextResult.focus()
-        }
+        nextResult?.focus()
       }
     } else if (e.key === "ArrowUp") {
       e.preventDefault()
       if (results?.contains(document.activeElement)) {
         // If an element in results-container already has focus, focus previous one
         const prevResult = document.activeElement?.previousElementSibling as HTMLInputElement | null
-        if (prevResult) {
-          prevResult.focus()
-        }
+        prevResult?.focus()
       }
     }
   }

--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -125,7 +125,9 @@ document.addEventListener("nav", async (e: unknown) => {
       // add "#" prefix for tag search
       if (searchBar) searchBar.value = "#"
     } else if (e.key === "Enter") {
-      const anchor = document.getElementsByClassName("result-card")[currentResultIndex < 0 ? 0 : currentResultIndex] as HTMLInputElement | null
+      const anchor = document.getElementsByClassName("result-card")[
+        currentResultIndex < 0 ? 0 : currentResultIndex
+      ] as HTMLInputElement | null
       if (anchor) {
         anchor.click()
       }

--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -133,26 +133,20 @@ document.addEventListener("nav", async (e: unknown) => {
       }
     } else if (e.key === "ArrowDown") {
       e.preventDefault()
+      // If there are are more elements, select next one
       if (currentResultIndex < resultCards.length - 1) {
-        let el: HTMLElement
+        // Starts at -1, so only try to get element if index is higher
         if (currentResultIndex >= 0) {
-          el = resultCards[currentResultIndex] as HTMLElement
-          el.classList.remove("selected")
+          resultCards[currentResultIndex].classList.remove("selected")
         }
-        currentResultIndex++
-        el = resultCards[currentResultIndex] as HTMLElement
-        el.classList.add("selected")
+        // Increment index and add "selected" class
+        resultCards[++currentResultIndex].classList.add("selected")
       }
     } else if (e.key === "ArrowUp") {
       e.preventDefault()
-      console.log("index: ", currentResultIndex)
       if (currentResultIndex > 0) {
-        let el: HTMLElement
-        el = resultCards[currentResultIndex] as HTMLElement
-        el.classList.remove("selected")
-        currentResultIndex--
-        el = resultCards[currentResultIndex] as HTMLElement
-        el.classList.add("selected")
+        resultCards[currentResultIndex].classList.remove("selected")
+        resultCards[--currentResultIndex].classList.add("selected")
       }
     }
   }

--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -176,7 +176,3 @@
     }
   }
 }
-
-.selected {
-  background-color: var(--lightgray) !important;
-}

--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -176,3 +176,7 @@
     }
   }
 }
+
+.selected {
+  background-color: var(--lightgray) !important;
+}


### PR DESCRIPTION
# What

Allows search results to be navigated by pressing `ArrowUp` and `ArrowDown`.

# How

Uses internal counter `currentResultIndex` to keep track of selected index (gets reset on type and close). This index starts at `-1`, so results wont be highlighted as you type, only when you start selecting results with arrow keys. Pressing enter navigates to currently selected result, but still navigates to the first search result if nothing is selected.