### PR TITLE
fix(search): clipboard button visible through preview

### DIFF
--- a/quartz/components/styles/clipboard.scss
+++ b/quartz/components/styles/clipboard.scss
@@ -10,7 +10,6 @@
   background-color: var(--light);
   border: 1px solid;
   border-radius: 5px;
-  z-index: 1;
   opacity: 0;
   transition: 0.2s;
 


### PR DESCRIPTION
This fixes a bug where the syntax highlighting clipboard button is visible through the search preview

![image](https://github.com/jackyzha0/quartz/assets/31989404/f11b0a75-eb93-4639-9cf4-6e4fb881d3a1)
