### PR TITLE
Fix some bug with callouts

### DIFF
--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -69,6 +69,8 @@ const callouts = {
 const calloutMapping: Record<string, keyof typeof callouts> = {
   note: "note",
   abstract: "abstract",
+  summary: "abstract",
+  tldr: "abstract",
   info: "info",
   todo: "todo",
   tip: "tip",
@@ -96,7 +98,7 @@ const calloutMapping: Record<string, keyof typeof callouts> = {
 
 function canonicalizeCallout(calloutName: string): keyof typeof callouts {
   let callout = calloutName.toLowerCase() as keyof typeof calloutMapping
-  return calloutMapping[callout] ?? calloutName
+  return calloutMapping[callout] ?? "note"
 }
 
 const capitalize = (s: string): string => {


### PR DESCRIPTION
Add alias for abstract callout, and set default callout name to "note".

before:
```markdown

> [!abstract] abstract
> abstract

> [!summary] summary
> summary

> [!tldr] tldr
> tldr

> [!customName] customName
> customName
```

![image](https://github.com/jackyzha0/quartz/assets/38579760/61ce57a9-c60a-41da-ae31-05f91c8bb1f4)

after:

![image](https://github.com/jackyzha0/quartz/assets/38579760/b7175f3e-5ea0-449b-9c50-7d3923961019)
