### PR TITLE
fix: bad visibility for last explorer item

### DIFF
--- a/quartz/components/Explorer.tsx
+++ b/quartz/components/Explorer.tsx
@@ -59,6 +59,7 @@ export default ((userOpts?: Partial<Options>) => {
         <div id="explorer-content">
           <ul class="overflow" id="explorer-ul">
             <ExplorerNode node={fileTree} opts={opts} fileData={fileData} />
+            <div id="explorer-end" />
           </ul>
         </div>
       </div>

--- a/quartz/components/Explorer.tsx
+++ b/quartz/components/Explorer.tsx
@@ -57,7 +57,7 @@ export default ((userOpts?: Partial<Options>) => {
           </svg>
         </button>
         <div id="explorer-content">
-          <ul class="overflow">
+          <ul class="overflow" id="explorer-ul">
             <ExplorerNode node={fileTree} opts={opts} fileData={fileData} />
           </ul>
         </div>

--- a/quartz/components/scripts/explorer.inline.ts
+++ b/quartz/components/scripts/explorer.inline.ts
@@ -3,6 +3,18 @@ import { FolderState } from "../ExplorerNode"
 // Current state of folders
 let explorerState: FolderState[]
 
+const observer = new IntersectionObserver((entries) => {
+  // If last element is observed, remove gradient of "overflow" class so element is visible
+  const explorer = document.getElementById("explorer-ul")
+  for (const entry of entries) {
+    if (entry.isIntersecting) {
+      explorer?.classList.add("no-background")
+    } else {
+      explorer?.classList.remove("no-background")
+    }
+  }
+})
+
 function toggleExplorer(this: HTMLElement) {
   // Toggle collapsed state of entire explorer
   this.classList.toggle("collapsed")
@@ -101,8 +113,10 @@ function setupExplorer() {
       ) as HTMLElement
 
       // Get corresponding content <ul> tag and set state
-      const folderUL = folderLi.parentElement?.nextElementSibling as HTMLElement
-      setFolderState(folderUL, folderUl.collapsed)
+      const folderUL = folderLi.parentElement?.nextElementSibling
+      if (folderUL) {
+        setFolderState(folderUL as HTMLElement, folderUl.collapsed)
+      }
     })
   } else {
     // If tree is not in localStorage or config is disabled, use tree passed from Explorer as dataset
@@ -113,6 +127,13 @@ function setupExplorer() {
 window.addEventListener("resize", setupExplorer)
 document.addEventListener("nav", () => {
   setupExplorer()
+
+  const explorerContent = document.getElementById("explorer-ul")
+  // select last item in explorer (folder or item)
+  const lastItem = explorerContent?.firstChild?.firstChild?.firstChild?.firstChild?.lastChild
+
+  observer.disconnect()
+  observer.observe(lastItem as Element)
 })
 
 /**

--- a/quartz/components/scripts/explorer.inline.ts
+++ b/quartz/components/scripts/explorer.inline.ts
@@ -129,8 +129,8 @@ document.addEventListener("nav", () => {
   setupExplorer()
 
   const explorerContent = document.getElementById("explorer-ul")
-  // select last item in explorer (folder or item)
-  const lastItem = explorerContent?.firstChild?.firstChild?.firstChild?.firstChild?.lastChild
+  // select pseudo element at end of list
+  const lastItem = document.getElementById("explorer-end")
 
   observer.disconnect()
   observer.observe(lastItem as Element)

--- a/quartz/components/styles/explorer.scss
+++ b/quartz/components/styles/explorer.scss
@@ -131,3 +131,7 @@ div:has(> .folder-outer:not(.open)) > .folder-container > svg {
 .folder-icon:hover {
   color: var(--tertiary);
 }
+
+.no-background::after {
+  background: none !important;
+}

--- a/quartz/components/styles/explorer.scss
+++ b/quartz/components/styles/explorer.scss
@@ -135,3 +135,8 @@ div:has(> .folder-outer:not(.open)) > .folder-container > svg {
 .no-background::after {
   background: none !important;
 }
+
+#explorer-end {
+  // needs height so IntersectionObserver gets triggered
+  height: 1px;
+}


### PR DESCRIPTION
# What

Fixes bad visibility for last item when scrolling down (still has "fade" gradient, so last item is hard to read)

| Before | After |
| ------------- | ------------- |
| <img width="214" alt="image" src="https://github.com/jackyzha0/quartz/assets/31989404/6cfe49cd-b182-4bf2-8332-22230db1c4b7"> | <img width="219" alt="image" src="https://github.com/jackyzha0/quartz/assets/31989404/97f907cc-8267-4585-a7bd-c462cb9b0794"> |

# How

Uses `IntersectionObserver` on last item, then removes gradient only if last item is in view. 
