### PR TITLE
Search Result Styling

### DIFF
--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -128,7 +128,7 @@
 
           & > h3 {
             margin: 0;
-            color: var(--darkgray)
+            color: var(--darkgray);
           }
 
           & > ul > li {

--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -128,6 +128,7 @@
 
           & > h3 {
             margin: 0;
+            color: var(--darkgray)
           }
 
           & > ul > li {


### PR DESCRIPTION
Added styling for color for search result heading, when using quartz I noticed that my search results heading was discolored. 