### PR TITLE
fix: adapt vercel cleanurls

### DIFF
--- a/quartz/components/pages/TagContent.tsx
+++ b/quartz/components/pages/TagContent.tsx
@@ -55,7 +55,7 @@ function TagContent(props: QuartzComponentProps) {
             return (
               <div>
                 <h2>
-                  <a class="internal tag-link" href={`./${tag}`}>
+                  <a class="internal tag-link" href={`../${tag}`}>
                     #{tag}
                   </a>
                 </h2>


### PR DESCRIPTION
quartz recommend use `cleanurls=true` in vercel deploy.
but cleanurls will cause current location is 'https://ip/tags' and not 'https://ip/tags/'
so the url which is './tag1' will convert to 'https://ip/tag1' , this is 404 error