### PR TITLE
fix(explorer): display names for folders without frontmatter

### DIFF
--- a/docs/features/explorer.md
+++ b/docs/features/explorer.md
@@ -8,6 +8,8 @@ Quartz features an explorer that allows you to navigate all files and folders on
 
 By default, it shows all folders and files on your page. To display the explorer in a different spot, you can edit the [[layout]].
 
+Display names for folders get determined by the `title` frontmatter field in `folder/index.md` (more detail in [[Authoring Content]]). If this file does not exist or does not contain frontmatter, the local folder name will be used instead.
+
 > [!info]
 > The explorer uses local storage by default to save the state of your explorer. This is done to ensure a smooth experience when navigating to different pages.
 >

--- a/quartz/components/ExplorerNode.tsx
+++ b/quartz/components/ExplorerNode.tsx
@@ -46,7 +46,10 @@ export class FileNode {
       if (file.path[0] !== "index.md") {
         this.children.push(new FileNode(file.file.frontmatter!.title, file.file, this.depth + 1))
       } else {
-        this.displayName = file.file.frontmatter!.title
+        const title = file.file.frontmatter?.title
+        if (title && title !== "index" && file.path[0] === "index.md") {
+          this.displayName = title
+        }
       }
     } else {
       const next = file.path[0]


### PR DESCRIPTION
After the changes in #489, folders that don't have an `index.md` file or are missing the `title` frontmatter will be displayed as `index`. As a better fallback, the local folder name will be used as a display name (consistent with behavior before #489)

Also update docs to document new folder display name behaviour.

---

Before:

<img width="172" alt="image" src="https://github.com/jackyzha0/quartz/assets/31989404/3e4a8b71-34aa-4af7-9ee5-4ff32e9f072e">



After:

<img width="173" alt="image" src="https://github.com/jackyzha0/quartz/assets/31989404/2ac3e971-7ec1-4b3e-b0b2-6a5d00bc3f15">

(`newFolder` was displayed as `index`)
