### PR TITLE
fix(explorer): increase consistency, explicitly use font-family

### DIFF
--- a/docs/features/explorer.md
+++ b/docs/features/explorer.md
@@ -8,6 +8,8 @@ Quartz features an explorer that allows you to navigate all files and folders on
 
 By default, it shows all folders and files on your page. To display the explorer in a different spot, you can edit the [[layout]].
 
+Display names for folders get determined by the `title` frontmatter field in `folder/index.md` (more detail in [[Authoring Content]]). If this file does not exist or does not contain frontmatter, the local folder name will be used instead.
+
 > [!info]
 > The explorer uses local storage by default to save the state of your explorer. This is done to ensure a smooth experience when navigating to different pages.
 >

--- a/docs/features/explorer.md
+++ b/docs/features/explorer.md
@@ -8,7 +8,7 @@ Quartz features an explorer that allows you to navigate all files and folders on
 
 By default, it shows all folders and files on your page. To display the explorer in a different spot, you can edit the [[layout]].
 
-Display names for folders get determined by the `title` frontmatter field in `folder/index.md` (more detail in [[Authoring Content]]). If this file does not exist or does not contain frontmatter, the local folder name will be used instead.
+Display names for folders get determined by the `title` frontmatter field in `folder/index.md` (more detail in [[authoring content | Authoring Content]]). If this file does not exist or does not contain frontmatter, the local folder name will be used instead.
 
 > [!info]
 > The explorer uses local storage by default to save the state of your explorer. This is done to ensure a smooth experience when navigating to different pages.

--- a/quartz/components/ExplorerNode.tsx
+++ b/quartz/components/ExplorerNode.tsx
@@ -46,7 +46,10 @@ export class FileNode {
       if (file.path[0] !== "index.md") {
         this.children.push(new FileNode(file.file.frontmatter!.title, file.file, this.depth + 1))
       } else {
-        this.displayName = file.file.frontmatter!.title
+        const title = file.file.frontmatter?.title
+        if (title && title !== "index" && file.path[0] === "index.md") {
+          this.displayName = title
+        }
       }
     } else {
       const next = file.path[0]

--- a/quartz/components/styles/explorer.scss
+++ b/quartz/components/styles/explorer.scss
@@ -81,16 +81,19 @@ svg {
   align-items: center;
   user-select: none;
 
-  & li > a {
+  & div > a {
     // other selector is more specific, needs important
-    color: var(--secondary) !important;
-    opacity: 1 !important;
-    font-size: 1.05rem !important;
+    color: var(--secondary);
+    font-family: var(--headerFont);
+    font-size: 0.95rem;
+    font-weight: 600;
+    line-height: 1.5rem;
+    display: inline-block;
   }
 
-  & li > a:hover {
+  & div > a:hover {
     // other selector is more specific, needs important
-    color: var(--tertiary) !important;
+    color: var(--tertiary);
   }
 
   & div > button {
@@ -103,6 +106,7 @@ svg {
     padding-right: 0;
     display: flex;
     align-items: center;
+    font-family: var(--headerFont);
 
     & p {
       font-size: 0.95rem;
@@ -111,7 +115,6 @@ svg {
       font-weight: 600;
       margin: 0;
       line-height: 1.5rem;
-      font-weight: bold;
       pointer-events: none;
     }
   }

--- a/quartz/components/styles/explorer.scss
+++ b/quartz/components/styles/explorer.scss
@@ -82,7 +82,6 @@ svg {
   user-select: none;
 
   & div > a {
-    // other selector is more specific, needs important
     color: var(--secondary);
     font-family: var(--headerFont);
     font-size: 0.95rem;

--- a/quartz/components/styles/explorer.scss
+++ b/quartz/components/styles/explorer.scss
@@ -91,7 +91,6 @@ svg {
   }
 
   & div > a:hover {
-    // other selector is more specific, needs important
     color: var(--tertiary);
   }
 


### PR DESCRIPTION
Fixes inconsistent behaviour between `folderClickBehaviour: "link"` and `collapse`, explicitly use `headerFont` for folder labels. CSS selector was also broken, fixed now (without needing `!important` anymore)

An issue was reported where folder labels using `folderClickBehaviour: "collapse"` was not using the correct font, this should also fix that problem.

Also fixes wikilink thats only broken after docs are deployed.