### PR TITLE
fix(explorer): default sort function

### DIFF
--- a/docs/features/explorer.md
+++ b/docs/features/explorer.md
@@ -75,7 +75,11 @@ Every function you can pass is optional. By default, only a `sort` function will
 Component.Explorer({
   sortFn: (a, b) => {
     if ((!a.file && !b.file) || (a.file && b.file)) {
-      return a.displayName.localeCompare(b.displayName)
+      if (!a.displayName) {
+        return 0
+      } else {
+        return a.displayName.localeCompare(b.displayName)
+      }
     }
     if (a.file && !b.file) {
       return 1

--- a/docs/features/explorer.md
+++ b/docs/features/explorer.md
@@ -75,11 +75,7 @@ Every function you can pass is optional. By default, only a `sort` function will
 Component.Explorer({
   sortFn: (a, b) => {
     if ((!a.file && !b.file) || (a.file && b.file)) {
-      if (!a.displayName) {
-        return 0
-      } else {
-        return a.displayName.localeCompare(b.displayName)
-      }
+      return a.displayName.toString().localeCompare(b.displayName.toString())
     }
     if (a.file && !b.file) {
       return 1

--- a/quartz/components/Explorer.tsx
+++ b/quartz/components/Explorer.tsx
@@ -15,11 +15,7 @@ const defaultOptions = {
   sortFn: (a, b) => {
     // Sort order: folders first, then files. Sort folders and files alphabetically
     if ((!a.file && !b.file) || (a.file && b.file)) {
-      if (!a.displayName) {
-        return 0
-      } else {
-        return a.displayName.localeCompare(b.displayName)
-      }
+      return a.displayName.toString().localeCompare(b.displayName.toString())
     }
     if (a.file && !b.file) {
       return 1

--- a/quartz/components/Explorer.tsx
+++ b/quartz/components/Explorer.tsx
@@ -15,7 +15,11 @@ const defaultOptions = {
   sortFn: (a, b) => {
     // Sort order: folders first, then files. Sort folders and files alphabetically
     if ((!a.file && !b.file) || (a.file && b.file)) {
-      return a.displayName.localeCompare(b.displayName)
+      if (!a.displayName) {
+        return 0
+      } else {
+        return a.displayName.localeCompare(b.displayName)
+      }
     }
     if (a.file && !b.file) {
       return 1


### PR DESCRIPTION
Since there were still a few bug reports coming in for `a.displayName.localeCompare is not a function`, i explicitly handled the case that a.displayName doesn't exist in the default sort function.

I haven't been able to reproduce this issue myself and have no idea how it could even happen that a `FileNode` has no displayName, as the displayName comes from the frontmatter title that always exist (at worst a default string), but this should hopefully help either way.

Edit:

I was able to reproduce the error message. This only seems to happen if `a` is a number and results in the same error message (`a.localeCompare is not a function`). Still don't understand _how_ this can happen, as `frontmatter.title` should never be a number, but it does seem to happen, so doing `.toString()` on display name will fix that bug.

tested with this snippet:
```ts
const a = 3
const b = "abc"
console.log("Compare: ", a.localeCompare(b))
```

if a is undefined or null as i initially thought, the error message is `cannot read properties of undefined/null`, so it does seem to come from displayName being a number somehow