### PR TITLE
feat: implement breadcrumb component

### DIFF
--- a/docs/features/breadcrumbs.md
+++ b/docs/features/breadcrumbs.md
@@ -1,0 +1,35 @@
+---
+title: "Breadcrumbs"
+tags:
+  - component
+---
+
+Breadcrumbs are a list of links that help visualize the location of a pages within a sites hierarchical structure, it allows navigation up to any of the ancestors.
+
+By default, the element at the very top of your page is the breadcrumb navigation bar (can also be seen at the top on this page!).
+
+## Customization
+
+Most configuration can be done by passing in options to `Component.Breadcrumbs()`.
+
+For example, here's what the default configuration looks like:
+
+```typescript title="quartz.layout.ts"
+Component.Breadcrumbs({
+  spacerSymbol: ">", // symbol between crumbs
+  rootName: "Home", // name of first/root element
+  resolveFrontmatterTitle: false, // wether to resolve folder names through frontmatter titles (more computationally expensive)
+  hideOnRoot: true, // wether to hide breadcrumbs on root `index.md` page
+})
+```
+
+When passing in your own options, you can omit any or all of these fields if you'd like to keep the default value for that field.
+
+You can also adjust where the breadcrumbs will be displayed by adjusting the [[layout]] (moving `Component.Breadcrumbs()` up or down)
+
+Want to customize it even more?
+
+- Removing graph view: delete all usages of `Component.Breadcrumbs()` from `quartz.layout.ts`.
+- Component: `quartz/components/Breadcrumbs.tsx`
+- Style: `quartz/components/styles/breadcrumbs.scss`
+- Script: inline at `quartz/components/Breadcrumbs.tsx`

--- a/docs/features/breadcrumbs.md
+++ b/docs/features/breadcrumbs.md
@@ -4,7 +4,7 @@ tags:
   - component
 ---
 
-Breadcrumbs are a list of links that help visualize the location of a pages within a sites hierarchical structure, it allows navigation up to any of the ancestors.
+Breadcrumbs provide a way to navigate a hierarchy of pages within your site using a list of its parent folders.
 
 By default, the element at the very top of your page is the breadcrumb navigation bar (can also be seen at the top on this page!).
 

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -16,10 +16,10 @@ export const sharedPageComponents: SharedLayout = {
 // components for pages that display a single page (e.g. a single note)
 export const defaultContentPageLayout: PageLayout = {
   beforeBody: [
+    Component.Breadcrumbs(),
     Component.ArticleTitle(),
     Component.ContentMeta(),
     Component.TagList(),
-    Component.Breadcrumbs(),
   ],
   left: [
     Component.PageTitle(),

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -15,7 +15,12 @@ export const sharedPageComponents: SharedLayout = {
 
 // components for pages that display a single page (e.g. a single note)
 export const defaultContentPageLayout: PageLayout = {
-  beforeBody: [Component.ArticleTitle(), Component.ContentMeta(), Component.TagList()],
+  beforeBody: [
+    Component.ArticleTitle(),
+    Component.ContentMeta(),
+    Component.TagList(),
+    Component.Breadcrumbs(),
+  ],
   left: [
     Component.PageTitle(),
     Component.MobileOnly(Component.Spacer()),

--- a/quartz/components/Breadcrumbs.tsx
+++ b/quartz/components/Breadcrumbs.tsx
@@ -1,0 +1,50 @@
+import { QuartzComponentConstructor, QuartzComponentProps } from "./types"
+import breadcrumbsStyle from "./styles/breadcrumbs.scss"
+import { FullSlug, SimpleSlug, resolveRelative } from "../util/path"
+
+type CrumbData = {
+  displayName: string
+  path: string
+}
+
+const capitalize = (s: string): string => {
+  return s.substring(0, 1).toUpperCase() + s.substring(1)
+}
+
+export default (() => {
+  function Breadcrumbs({ fileData }: QuartzComponentProps) {
+    const crumbs: CrumbData[] = [
+      { displayName: "Home", path: resolveRelative(fileData.slug!, "/" as SimpleSlug) },
+    ]
+    const parts = fileData.filePath?.split("/")?.splice(1)
+    if (parts) {
+      // full path until current part
+      let current = ""
+      for (let i = 0; i < parts.length - 1; i++) {
+        current += parts[i] + "/"
+        crumbs.push({
+          displayName: capitalize(parts[i]),
+          path: resolveRelative(fileData.slug!, current as SimpleSlug),
+        })
+      }
+      if (parts.length > 0) {
+        crumbs.push({
+          displayName: fileData.frontmatter!.title,
+          path: resolveRelative(fileData.slug!, fileData.slug as FullSlug),
+        })
+      }
+    }
+    return (
+      <div class={`breadcrumb-container`}>
+        {crumbs.map((crumb, index) => (
+          <div class="breadcrumb-element">
+            <a href={crumb.path}>{crumb.displayName}</a>
+            {index !== crumbs.length - 1 && <p>{" > "}</p>}
+          </div>
+        ))}
+      </div>
+    )
+  }
+  Breadcrumbs.css = breadcrumbsStyle
+  return Breadcrumbs
+}) satisfies QuartzComponentConstructor

--- a/quartz/components/Breadcrumbs.tsx
+++ b/quartz/components/Breadcrumbs.tsx
@@ -39,13 +39,14 @@ function formatCrumb(displayName: string, baseSlug: FullSlug, currentSlug: Simpl
   return { displayName, path: resolveRelative(baseSlug, currentSlug) }
 }
 
-function findCurrent(allFiles: QuartzPluginData[], currentName: string) {
+// given a folderName (e.g. "features"), search for the corresponding `index.md` file
+function findCurrentFile(allFiles: QuartzPluginData[], folderName: string) {
   return allFiles.find((file) => {
     if (file.slug?.endsWith("index")) {
       const folderParts = file.filePath?.split("/")
       if (folderParts) {
         const name = folderParts[folderParts?.length - 2]
-        if (name === currentName) {
+        if (name === folderName) {
           return true
         }
       }
@@ -80,7 +81,7 @@ export default ((opts?: Partial<BreadcrumbOptions>) => {
         // Try to resolve frontmatter folder title
         if (options?.resolveFrontmatterTitle) {
           // try to find file for current path
-          const currentFile = findCurrent(allFiles, folderName)
+          const currentFile = findCurrentFile(allFiles, folderName)
           if (currentFile) {
             currentTitle = currentFile.frontmatter!.title
           }

--- a/quartz/components/Breadcrumbs.tsx
+++ b/quartz/components/Breadcrumbs.tsx
@@ -77,6 +77,7 @@ export default ((opts?: Partial<BreadcrumbOptions>) => {
         const folderName = parts[i]
         let currentTitle = folderName
 
+        // TODO: performance optimizations/memoizing
         // Try to resolve frontmatter folder title
         if (options?.resolveFrontmatterTitle) {
           // try to find file for current path

--- a/quartz/components/Breadcrumbs.tsx
+++ b/quartz/components/Breadcrumbs.tsx
@@ -8,14 +8,27 @@ type CrumbData = {
   path: string
 }
 
+interface BreadcrumbOptions {
+  spacerSymbol: string
+  rootName: string
+  resolveFrontmatterTitle: boolean
+}
+
+const defaultOptions: BreadcrumbOptions = {
+  spacerSymbol: ">",
+  rootName: "Home",
+  resolveFrontmatterTitle: false,
+}
+
 function formatCrumb(displayName: string, baseSlug: FullSlug, currentSlug: SimpleSlug): CrumbData {
   return { displayName, path: resolveRelative(baseSlug, currentSlug) }
 }
 
-export default (() => {
-  function Breadcrumbs({ fileData, allFiles }: QuartzComponentProps) {
+export default ((opts?: Partial<BreadcrumbOptions>) => {
+  const options: BreadcrumbOptions = { ...defaultOptions, ...opts }
+  function Breadcrumbs({ fileData }: QuartzComponentProps) {
     // Format entry for root element
-    const firstEntry = formatCrumb("Home", fileData.slug!, "/" as SimpleSlug)
+    const firstEntry = formatCrumb(options.rootName, fileData.slug!, "/" as SimpleSlug)
     const crumbs: CrumbData[] = [firstEntry]
 
     // Get parts of filePath (every folder)
@@ -41,11 +54,11 @@ export default (() => {
       }
     }
     return (
-      <div class={`breadcrumb-container`}>
+      <div class="breadcrumb-container">
         {crumbs.map((crumb, index) => (
           <div class="breadcrumb-element">
             <a href={crumb.path}>{crumb.displayName}</a>
-            {index !== crumbs.length - 1 && <p>{" > "}</p>}
+            {index !== crumbs.length - 1 && <p>{` ${options.spacerSymbol} `}</p>}
           </div>
         ))}
       </div>

--- a/quartz/components/Breadcrumbs.tsx
+++ b/quartz/components/Breadcrumbs.tsx
@@ -65,7 +65,7 @@ export default ((opts?: Partial<BreadcrumbOptions>) => {
       }
     }
     // Format entry for root element
-    const firstEntry = formatCrumb(options.rootName, fileData.slug!, "/" as SimpleSlug)
+    const firstEntry = formatCrumb(capitalize(options.rootName), fileData.slug!, "/" as SimpleSlug)
     const crumbs: CrumbData[] = [firstEntry]
 
     // Get parts of filePath (every folder)
@@ -96,7 +96,7 @@ export default ((opts?: Partial<BreadcrumbOptions>) => {
       // Add current file to crumb (can directly use frontmatter title)
       if (parts.length > 0) {
         crumbs.push({
-          displayName: fileData.frontmatter!.title,
+          displayName: capitalize(fileData.frontmatter!.title),
           path: "",
         })
       }

--- a/quartz/components/Breadcrumbs.tsx
+++ b/quartz/components/Breadcrumbs.tsx
@@ -1,18 +1,15 @@
 import { QuartzComponentConstructor, QuartzComponentProps } from "./types"
 import breadcrumbsStyle from "./styles/breadcrumbs.scss"
 import { FullSlug, SimpleSlug, resolveRelative } from "../util/path"
+import { capitalize } from "../util/lang"
 
 type CrumbData = {
   displayName: string
   path: string
 }
 
-const capitalize = (s: string): string => {
-  return s.substring(0, 1).toUpperCase() + s.substring(1)
-}
-
 export default (() => {
-  function Breadcrumbs({ fileData }: QuartzComponentProps) {
+  function Breadcrumbs({ fileData, allFiles }: QuartzComponentProps) {
     const crumbs: CrumbData[] = [
       { displayName: "Home", path: resolveRelative(fileData.slug!, "/" as SimpleSlug) },
     ]

--- a/quartz/components/Breadcrumbs.tsx
+++ b/quartz/components/Breadcrumbs.tsx
@@ -60,11 +60,10 @@ export default ((opts?: Partial<BreadcrumbOptions>) => {
 
   function Breadcrumbs({ fileData, allFiles }: QuartzComponentProps) {
     // Hide crumbs on root if enabled
-    if (options.hideOnRoot) {
-      if (fileData.slug === "index") {
-        return <></>
-      }
+    if (options.hideOnRoot && fileData.slug === "index") {
+      return <></>
     }
+
     // Format entry for root element
     const firstEntry = formatCrumb(capitalize(options.rootName), fileData.slug!, "/" as SimpleSlug)
     const crumbs: CrumbData[] = [firstEntry]

--- a/quartz/components/Breadcrumbs.tsx
+++ b/quartz/components/Breadcrumbs.tsx
@@ -103,14 +103,14 @@ export default ((opts?: Partial<BreadcrumbOptions>) => {
       }
     }
     return (
-      <div class="breadcrumb-container">
+      <nav class="breadcrumb-container" aria-label="breadcrumbs">
         {crumbs.map((crumb, index) => (
           <div class="breadcrumb-element">
             <a href={crumb.path}>{crumb.displayName}</a>
             {index !== crumbs.length - 1 && <p>{` ${options.spacerSymbol} `}</p>}
           </div>
         ))}
-      </div>
+      </nav>
     )
   }
   Breadcrumbs.css = breadcrumbsStyle

--- a/quartz/components/Breadcrumbs.tsx
+++ b/quartz/components/Breadcrumbs.tsx
@@ -8,26 +8,35 @@ type CrumbData = {
   path: string
 }
 
+function formatCrumb(displayName: string, baseSlug: FullSlug, currentSlug: SimpleSlug): CrumbData {
+  return { displayName, path: resolveRelative(baseSlug, currentSlug) }
+}
+
 export default (() => {
   function Breadcrumbs({ fileData, allFiles }: QuartzComponentProps) {
-    const crumbs: CrumbData[] = [
-      { displayName: "Home", path: resolveRelative(fileData.slug!, "/" as SimpleSlug) },
-    ]
+    // Format entry for root element
+    const firstEntry = formatCrumb("Home", fileData.slug!, "/" as SimpleSlug)
+    const crumbs: CrumbData[] = [firstEntry]
+
+    // Get parts of filePath (every folder)
     const parts = fileData.filePath?.split("/")?.splice(1)
     if (parts) {
       // full path until current part
       let current = ""
       for (let i = 0; i < parts.length - 1; i++) {
+        // Add current path to full path
         current += parts[i] + "/"
-        crumbs.push({
-          displayName: capitalize(parts[i]),
-          path: resolveRelative(fileData.slug!, current as SimpleSlug),
-        })
+
+        // Format and add current crumb
+        const crumb = formatCrumb(capitalize(parts[i]), fileData.slug!, current as SimpleSlug)
+        crumbs.push(crumb)
       }
+
+      // Add current file to crumb (can directly use frontmatter title)
       if (parts.length > 0) {
         crumbs.push({
           displayName: fileData.frontmatter!.title,
-          path: resolveRelative(fileData.slug!, fileData.slug as FullSlug),
+          path: "",
         })
       }
     }

--- a/quartz/components/Breadcrumbs.tsx
+++ b/quartz/components/Breadcrumbs.tsx
@@ -22,12 +22,17 @@ interface BreadcrumbOptions {
    * wether to look up frontmatter title for folders (could cause performance problems with big vaults)
    */
   resolveFrontmatterTitle: boolean
+  /**
+   * Wether to display breadcrumbs on root `index.md`
+   */
+  hideOnRoot: boolean
 }
 
 const defaultOptions: BreadcrumbOptions = {
   spacerSymbol: ">",
   rootName: "Home",
   resolveFrontmatterTitle: false,
+  hideOnRoot: true,
 }
 
 function formatCrumb(displayName: string, baseSlug: FullSlug, currentSlug: SimpleSlug): CrumbData {
@@ -53,6 +58,12 @@ export default ((opts?: Partial<BreadcrumbOptions>) => {
   const options: BreadcrumbOptions = { ...defaultOptions, ...opts }
 
   function Breadcrumbs({ fileData, allFiles }: QuartzComponentProps) {
+    // Hide crumbs on root if enabled
+    if (options.hideOnRoot) {
+      if (fileData.slug === "index") {
+        return <></>
+      }
+    }
     // Format entry for root element
     const firstEntry = formatCrumb(options.rootName, fileData.slug!, "/" as SimpleSlug)
     const crumbs: CrumbData[] = [firstEntry]

--- a/quartz/components/index.ts
+++ b/quartz/components/index.ts
@@ -18,6 +18,7 @@ import Footer from "./Footer"
 import DesktopOnly from "./DesktopOnly"
 import MobileOnly from "./MobileOnly"
 import RecentNotes from "./RecentNotes"
+import Breadcrumbs from "./Breadcrumbs"
 
 export {
   ArticleTitle,
@@ -40,4 +41,5 @@ export {
   MobileOnly,
   RecentNotes,
   NotFound,
+  Breadcrumbs,
 }

--- a/quartz/components/styles/breadcrumbs.scss
+++ b/quartz/components/styles/breadcrumbs.scss
@@ -1,0 +1,26 @@
+// p {
+//   margin: 0;
+//   padding: 0;
+// }
+
+.breadcrumb-container {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+}
+
+.breadcrumb-element {
+  p {
+    margin: 0;
+    margin-bottom: -0.15rem;
+    margin-left: 0.5rem;
+    padding: 0;
+    line-height: normal;
+  }
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+}

--- a/quartz/components/styles/breadcrumbs.scss
+++ b/quartz/components/styles/breadcrumbs.scss
@@ -1,8 +1,3 @@
-// p {
-//   margin: 0;
-//   padding: 0;
-// }
-
 .breadcrumb-container {
   margin: 0;
   padding: 0;
@@ -14,7 +9,6 @@
 .breadcrumb-element {
   p {
     margin: 0;
-    margin-bottom: -0.15rem;
     margin-left: 0.5rem;
     padding: 0;
     line-height: normal;
@@ -23,4 +17,8 @@
   flex-direction: row;
   align-items: center;
   justify-content: center;
+
+  a {
+    line-break: strict;
+  }
 }

--- a/quartz/components/styles/breadcrumbs.scss
+++ b/quartz/components/styles/breadcrumbs.scss
@@ -3,6 +3,7 @@
   padding: 0;
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   gap: 0.5rem;
 }
 
@@ -17,8 +18,4 @@
   flex-direction: row;
   align-items: center;
   justify-content: center;
-
-  a {
-    line-break: strict;
-  }
 }

--- a/quartz/components/styles/breadcrumbs.scss
+++ b/quartz/components/styles/breadcrumbs.scss
@@ -1,5 +1,6 @@
 .breadcrumb-container {
   margin: 0;
+  margin-top: 0.75rem;
   padding: 0;
   display: flex;
   flex-direction: row;

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -14,6 +14,7 @@ import { FilePath, pathToRoot, slugTag, slugifyFilePath } from "../../util/path"
 import { toHast } from "mdast-util-to-hast"
 import { toHtml } from "hast-util-to-html"
 import { PhrasingContent } from "mdast-util-find-and-replace/lib"
+import { capitalize } from "../../util/lang"
 
 export interface Options {
   comments: boolean
@@ -102,10 +103,6 @@ const calloutMapping: Record<string, keyof typeof callouts> = {
 function canonicalizeCallout(calloutName: string): keyof typeof callouts {
   let callout = calloutName.toLowerCase() as keyof typeof calloutMapping
   return calloutMapping[callout] ?? "note"
-}
-
-const capitalize = (s: string): string => {
-  return s.substring(0, 1).toUpperCase() + s.substring(1)
 }
 
 // !?               -> optional embedding

--- a/quartz/util/lang.ts
+++ b/quartz/util/lang.ts
@@ -5,3 +5,7 @@ export function pluralize(count: number, s: string): string {
     return `${count} ${s}s`
   }
 }
+
+export function capitalize(s: string): string {
+  return s.substring(0, 1).toUpperCase() + s.substring(1)
+}


### PR DESCRIPTION
# What

Implement a component for breadcrumbs

<img src="https://i.imgur.com/2H8LOtb.png"/>

Also work in popover previews:

<img width="745" alt="image" src="https://github.com/jackyzha0/quartz/assets/31989404/efa1609a-137d-488f-8586-e0b1ef66cef7">


# How

Uses `fileData.filePath` to construct crumbs (split by "/"). First crumb has special name, every crumb in between uses folder name by default (also supports looking up frontmatter title), the last/current crumb uses frontmatter title directly.

More details in docs

Also move shared `capitalize` function to `lang.ts`