### PR TITLE
fix(explorer): default sortFn implementation

### DIFF
--- a/docs/features/explorer.md
+++ b/docs/features/explorer.md
@@ -75,7 +75,12 @@ Every function you can pass is optional. By default, only a `sort` function will
 Component.Explorer({
   sortFn: (a, b) => {
     if ((!a.file && !b.file) || (a.file && b.file)) {
-      return a.displayName.localeCompare(b.displayName)
+      // sensitivity: "base": Only strings that differ in base letters compare as unequal. Examples: a ≠ b, a = á, a = A
+      // numeric: true: Whether numeric collation should be used, such that "1" < "2" < "10"
+      return a.displayName.localeCompare(b.displayName, undefined, {
+        numeric: true,
+        sensitivity: "base",
+      })
     }
     if (a.file && !b.file) {
       return 1

--- a/quartz/components/Explorer.tsx
+++ b/quartz/components/Explorer.tsx
@@ -15,7 +15,12 @@ const defaultOptions = {
   sortFn: (a, b) => {
     // Sort order: folders first, then files. Sort folders and files alphabetically
     if ((!a.file && !b.file) || (a.file && b.file)) {
-      return a.displayName.localeCompare(b.displayName)
+      // sensitivity: "base": Only strings that differ in base letters compare as unequal. Examples: a ≠ b, a = á, a = A
+      // numeric: true: Whether numeric collation should be used, such that "1" < "2" < "10"
+      return a.displayName.localeCompare(b.displayName, undefined, {
+        numeric: true,
+        sensitivity: "base",
+      })
     }
     if (a.file && !b.file) {
       return 1

--- a/quartz/components/Explorer.tsx
+++ b/quartz/components/Explorer.tsx
@@ -15,8 +15,8 @@ const defaultOptions = {
   sortFn: (a, b) => {
     // Sort order: folders first, then files. Sort folders and files alphabetically
     if ((!a.file && !b.file) || (a.file && b.file)) {
-      // sensitivity: "base": Only strings that differ in base letters compare as unequal. Examples: a ≠ b, a = á, a = A
       // numeric: true: Whether numeric collation should be used, such that "1" < "2" < "10"
+      // sensitivity: "base": Only strings that differ in base letters compare as unequal. Examples: a ≠ b, a = á, a = A
       return a.displayName.localeCompare(b.displayName, undefined, {
         numeric: true,
         sensitivity: "base",


### PR DESCRIPTION
# What

Improves default explorer `sortFn` by respecting numeric order in file names. Additional enhancement by using `sensitivity: "base"` for localeCompare (a ≠ b, a = á, a = A)

<img width="271" alt="image" src="https://github.com/jackyzha0/quartz/assets/31989404/596bc1fc-6bf2-47d6-b8fc-b7830a5d1382">

Also update docs with new default