### PR TITLE
Fix: RSS title escaping

### DIFF
--- a/quartz/plugins/emitters/contentIndex.ts
+++ b/quartz/plugins/emitters/contentIndex.ts
@@ -68,9 +68,9 @@ function generateRSSFeed(cfg: GlobalConfiguration, idx: ContentIndex, limit?: nu
     <channel>
       <title>${escapeHTML(cfg.pageTitle)}</title>
       <link>${root}</link>
-      <description>${!!limit ? `Last ${limit} notes` : "Recent notes"} on ${
-        escapeHTML(cfg.pageTitle)
-      }</description>
+      <description>${!!limit ? `Last ${limit} notes` : "Recent notes"} on ${escapeHTML(
+        cfg.pageTitle,
+      )}</description>
       <generator>Quartz -- quartz.jzhao.xyz</generator>
       ${items}
     </channel>

--- a/quartz/plugins/emitters/contentIndex.ts
+++ b/quartz/plugins/emitters/contentIndex.ts
@@ -69,7 +69,7 @@ function generateRSSFeed(cfg: GlobalConfiguration, idx: ContentIndex, limit?: nu
       <title>${escapeHTML(cfg.pageTitle)}</title>
       <link>${root}</link>
       <description>${!!limit ? `Last ${limit} notes` : "Recent notes"} on ${
-        cfg.pageTitle
+        escapeHTML(cfg.pageTitle)
       }</description>
       <generator>Quartz -- quartz.jzhao.xyz</generator>
       ${items}


### PR DESCRIPTION
Tiny fix, but the `cfg.pageTitle` was escaped in one place but not another. This led to some validation failures if a special character was in the page title.

Side note: I'm still encountering date bugs and inconsistent feed creation despite having a date in all pages' frontmatter. Will be looking into that issue further in future.