### PR TITLE
fix(breadcrumbs): problem with folder whitespace

### DIFF
--- a/quartz/components/Breadcrumbs.tsx
+++ b/quartz/components/Breadcrumbs.tsx
@@ -1,7 +1,6 @@
 import { QuartzComponentConstructor, QuartzComponentProps } from "./types"
 import breadcrumbsStyle from "./styles/breadcrumbs.scss"
 import { FullSlug, SimpleSlug, resolveRelative } from "../util/path"
-import { capitalize } from "../util/lang"
 import { QuartzPluginData } from "../plugins/vfile"
 
 type CrumbData = {
@@ -68,7 +67,7 @@ export default ((opts?: Partial<BreadcrumbOptions>) => {
     }
 
     // Format entry for root element
-    const firstEntry = formatCrumb(capitalize(options.rootName), fileData.slug!, "/" as SimpleSlug)
+    const firstEntry = formatCrumb(options.rootName, fileData.slug!, "/" as SimpleSlug)
     const crumbs: CrumbData[] = [firstEntry]
 
     // Split slug into hierarchy/parts
@@ -92,17 +91,13 @@ export default ((opts?: Partial<BreadcrumbOptions>) => {
         currentPath += slugParts[i] + "/"
 
         // Format and add current crumb
-        const crumb = formatCrumb(
-          capitalize(currentTitle),
-          fileData.slug!,
-          currentPath as SimpleSlug,
-        )
+        const crumb = formatCrumb(currentTitle, fileData.slug!, currentPath as SimpleSlug)
         crumbs.push(crumb)
       }
 
       // Add current file to crumb (can directly use frontmatter title)
       crumbs.push({
-        displayName: capitalize(fileData.frontmatter!.title),
+        displayName: fileData.frontmatter!.title,
         path: "",
       })
     }

--- a/quartz/components/Breadcrumbs.tsx
+++ b/quartz/components/Breadcrumbs.tsx
@@ -69,12 +69,14 @@ export default ((opts?: Partial<BreadcrumbOptions>) => {
     const crumbs: CrumbData[] = [firstEntry]
 
     // Get parts of filePath (every folder)
-    const parts = fileData.filePath?.split("/")?.splice(1)
-    if (parts) {
+    const pathParts = fileData.filePath?.split("/")?.splice(1)
+    // No need to slice, since slugs dont contain initial "content" folder like pathParts
+    const slugParts = fileData.slug?.split("/")
+    if (pathParts && slugParts) {
       // full path until current part
       let current = ""
-      for (let i = 0; i < parts.length - 1; i++) {
-        const folderName = parts[i]
+      for (let i = 0; i < pathParts.length - 1; i++) {
+        const folderName = pathParts[i]
         let currentTitle = folderName
 
         // TODO: performance optimizations/memoizing
@@ -86,8 +88,8 @@ export default ((opts?: Partial<BreadcrumbOptions>) => {
             currentTitle = currentFile.frontmatter!.title
           }
         }
-        // Add current path to full path
-        current += folderName + "/"
+        // Add current slug to full path
+        current += slugParts[i] + "/"
 
         // Format and add current crumb
         const crumb = formatCrumb(capitalize(currentTitle), fileData.slug!, current as SimpleSlug)
@@ -95,7 +97,7 @@ export default ((opts?: Partial<BreadcrumbOptions>) => {
       }
 
       // Add current file to crumb (can directly use frontmatter title)
-      if (parts.length > 0) {
+      if (pathParts.length > 0) {
         crumbs.push({
           displayName: capitalize(fileData.frontmatter!.title),
           path: "",


### PR DESCRIPTION
(closing #520)

Now uses `fileData.slug` for constructing folder hrefs so folder paths get resolved properly (fixes problem with whitespaces in folder paths