### PR TITLE
Add per-folder RSS feeds

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -66,6 +66,7 @@ const config: QuartzConfig = {
       Plugin.ContentIndex({
         enableSiteMap: true,
         enableRSS: true,
+        feedDirectories: ["index"], // For a feed for only pages in content/Folder/, add "Folder" to the array
       }),
       Plugin.Assets(),
       Plugin.Static(),

--- a/quartz/plugins/emitters/contentIndex.ts
+++ b/quartz/plugins/emitters/contentIndex.ts
@@ -24,6 +24,7 @@ interface Options {
   rssLimit?: number
   rssFullHtml: boolean
   includeEmptyFiles: boolean
+  feedDirectories: string[]
 }
 
 const defaultOptions: Options = {
@@ -32,6 +33,7 @@ const defaultOptions: Options = {
   rssLimit: 10,
   rssFullHtml: false,
   includeEmptyFiles: true,
+  feedDirectories: ["index"],
 }
 
 function generateSiteMap(cfg: GlobalConfiguration, idx: ContentIndex): string {
@@ -46,7 +48,10 @@ function generateSiteMap(cfg: GlobalConfiguration, idx: ContentIndex): string {
   return `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">${urls}</urlset>`
 }
 
-function generateRSSFeed(cfg: GlobalConfiguration, idx: ContentIndex, limit?: number): string {
+function generateRSSFeed(cfg: GlobalConfiguration, idx?: ContentIndex, limit?: number): string {
+  if (idx == undefined) {
+    return ""
+  }
   const base = cfg.baseUrl ?? ""
   const root = `https://${base}`
 
@@ -84,29 +89,34 @@ export const ContentIndex: QuartzEmitterPlugin<Partial<Options>> = (opts) => {
     async emit(ctx, content, _resources, emit) {
       const cfg = ctx.cfg.configuration
       const emitted: FilePath[] = []
-      const linkIndex: ContentIndex = new Map()
-      for (const [tree, file] of content) {
-        const slug = file.data.slug!
-        const date = getDate(ctx.cfg.configuration, file.data) ?? new Date()
-        if (opts?.includeEmptyFiles || (file.data.text && file.data.text !== "")) {
-          linkIndex.set(slug, {
-            title: file.data.frontmatter?.title!,
-            links: file.data.links ?? [],
-            tags: file.data.frontmatter?.tags ?? [],
-            content: file.data.text ?? "",
-            richContent: opts?.rssFullHtml
-              ? escapeHTML(toHtml(tree as Root, { allowDangerousHtml: true }))
-              : undefined,
-            date: date,
-            description: file.data.description ?? "",
-          })
+      const feedIndices: Map<String, ContentIndex> = new Map()
+      for (const feed of opts?.feedDirectories) {
+        const linkIndex: ContentIndex = new Map()
+        for (const [tree, file] of content) {
+          const slug = file.data.slug!
+
+          const date = getDate(ctx.cfg.configuration, file.data) ?? new Date()
+          if ((opts?.includeEmptyFiles || (file.data.text && file.data.text !== "")) && (slug.startsWith(feed) || feed == "index")) {
+            linkIndex.set(slug, {
+              title: file.data.frontmatter?.title!,
+              links: file.data.links ?? [],
+              tags: file.data.frontmatter?.tags ?? [],
+              content: file.data.text ?? "",
+              richContent: opts?.rssFullHtml
+                ? escapeHTML(toHtml(tree as Root, { allowDangerousHtml: true }))
+                : undefined,
+              date: date,
+              description: file.data.description ?? "",
+            })
+          }
         }
+        feedIndices.set(feed, linkIndex)
       }
 
       if (opts?.enableSiteMap) {
         emitted.push(
           await emit({
-            content: generateSiteMap(cfg, linkIndex),
+            content: generateSiteMap(cfg, feedIndices.get("index")),
             slug: "sitemap" as FullSlug,
             ext: ".xml",
           }),
@@ -114,18 +124,19 @@ export const ContentIndex: QuartzEmitterPlugin<Partial<Options>> = (opts) => {
       }
 
       if (opts?.enableRSS) {
-        emitted.push(
-          await emit({
-            content: generateRSSFeed(cfg, linkIndex, opts.rssLimit),
-            slug: "index" as FullSlug,
+        opts?.feedDirectories?.map(async (feed) => {
+          const emittedFeed = await emit({
+            content: generateRSSFeed(cfg, feedIndices.get(feed), opts?.rssLimit),
+            slug: feed as FullSlug,
             ext: ".xml",
-          }),
-        )
+          })
+          emitted.push(emittedFeed)
+        })
       }
 
       const fp = path.join("static", "contentIndex") as FullSlug
       const simplifiedIndex = Object.fromEntries(
-        Array.from(linkIndex).map(([slug, content]) => {
+        Array.from(feedIndices.get("index") ?? [] ).map(([slug, content]) => {
           // remove description and from content index as nothing downstream
           // actually uses it. we only keep it in the index as we need it
           // for the RSS feed

--- a/quartz/plugins/emitters/contentIndex.ts
+++ b/quartz/plugins/emitters/contentIndex.ts
@@ -96,7 +96,10 @@ export const ContentIndex: QuartzEmitterPlugin<Partial<Options>> = (opts) => {
           const slug = file.data.slug!
 
           const date = getDate(ctx.cfg.configuration, file.data) ?? new Date()
-          if ((opts?.includeEmptyFiles || (file.data.text && file.data.text !== "")) && (slug.startsWith(feed) || feed == "index")) {
+          if (
+            (opts?.includeEmptyFiles || (file.data.text && file.data.text !== "")) &&
+            (slug.startsWith(feed) || feed == "index")
+          ) {
             linkIndex.set(slug, {
               title: file.data.frontmatter?.title!,
               links: file.data.links ?? [],
@@ -136,7 +139,7 @@ export const ContentIndex: QuartzEmitterPlugin<Partial<Options>> = (opts) => {
 
       const fp = path.join("static", "contentIndex") as FullSlug
       const simplifiedIndex = Object.fromEntries(
-        Array.from(feedIndices.get("index") ?? [] ).map(([slug, content]) => {
+        Array.from(feedIndices.get("index") ?? []).map(([slug, content]) => {
           // remove description and from content index as nothing downstream
           // actually uses it. we only keep it in the index as we need it
           // for the RSS feed


### PR DESCRIPTION
This pull adds a config option to specify relative folder paths for their own feeds.

Basically, if the `slug` of a file starts with a string in the `feedDirectories` config array, it'll be added to a feed of the same name in the root directory.

An improvement I'm not sure how to do would be to place each resulting feed in the directory of its entries and just title it `index.xml` as well, ex. `Folder/index.xml` for all posts in `content/Folder` instead of `/folder.xml`.

closes https://discord.com/channels/927628110009098281/1149197588084572161/1159320781633884200