### PR TITLE
feat: add different color on missing internal links + option to "hide" them

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -28,6 +28,7 @@ const config: QuartzConfig = {
           secondary: "#284b63",
           tertiary: "#84a59d",
           highlight: "rgba(143, 159, 169, 0.15)",
+          error: "#ff8484", // light red
         },
         darkMode: {
           light: "#161618",
@@ -38,6 +39,7 @@ const config: QuartzConfig = {
           secondary: "#7b97aa",
           tertiary: "#84a59d",
           highlight: "rgba(143, 159, 169, 0.15)",
+          error: "#ff8484",
         },
       },
     },

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -70,6 +70,21 @@ a {
     padding: 0 0.1rem;
     border-radius: 5px;
   }
+
+  &.missing-link {
+    color: var(--error);
+    font-weight: normal;
+    &:hover {
+      color: color-mix(in srgb, var(--error) 65%, transparent) !important;
+    }
+  }
+
+  &.removed-link {
+    pointer-events: none; /* trick to disable Popover Previews */
+    background-color: unset;
+    font-weight: unset;
+    color: unset;
+  }
 }
 
 .desktop-only {

--- a/quartz/util/theme.ts
+++ b/quartz/util/theme.ts
@@ -7,6 +7,7 @@ export interface ColorScheme {
   secondary: string
   tertiary: string
   highlight: string
+  error: string
 }
 
 export interface Theme {
@@ -43,6 +44,7 @@ ${stylesheet.join("\n\n")}
   --secondary: ${theme.colors.lightMode.secondary};
   --tertiary: ${theme.colors.lightMode.tertiary};
   --highlight: ${theme.colors.lightMode.highlight};
+  --error: ${theme.colors.lightMode.error};
 
   --headerFont: "${theme.typography.header}", ${DEFAULT_SANS_SERIF};
   --bodyFont: "${theme.typography.body}", ${DEFAULT_SANS_SERIF};
@@ -58,6 +60,7 @@ ${stylesheet.join("\n\n")}
   --secondary: ${theme.colors.darkMode.secondary};
   --tertiary: ${theme.colors.darkMode.tertiary};
   --highlight: ${theme.colors.darkMode.highlight};
+  --error: ${theme.colors.darkMode.error};
 }
 `
 }


### PR DESCRIPTION
New to Quartz, I did a quick evolution to #454, hope it won't break anything ...

In `quartz.config.ts` color theme, a new 'error' color attribute is configured (default : #ff8484 = a light red) it modifies missing links color (if none is configured, it fallback to "--darkgray")

\+ a new option `hideMissingLinks: true` (default = false) on `Plugin.CrawlLinks()` so the Popover Previews and clicks on missing links and CSS style is "unset"