### PR TITLE
docs(explorer): Fixed small typo with extra } in explorer.md 

### DIFF
--- a/docs/features/explorer.md
+++ b/docs/features/explorer.md
@@ -196,7 +196,7 @@ Component.Explorer({
       }
     }
   },
-}})
+})
 ```
 
 ### Putting it all together


### PR DESCRIPTION
removed the } from the file so the code has the correct syntax