### PR TITLE
docs: clarifications about globs

### DIFF
--- a/docs/features/private pages.md
+++ b/docs/features/private pages.md
@@ -14,7 +14,10 @@ If you'd like to only publish a select number of notes, you can instead use `Plu
 
 ## `ignorePatterns`
 
-This is a field in `quartz.config.ts` under the main [[configuration]] which allows you to specify a list of patterns to effectively exclude from parsing all together. Any valid [glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) pattern works here.
+This is a field in `quartz.config.ts` under the main [[configuration]] which allows you to specify a list of patterns to effectively exclude from parsing all together. Any valid [fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) pattern works here. 
+
+> [!note]
+> Bash's glob syntax is slightly different from fast-glob's and using bash's syntax may lead to unexpected results.
 
 Common examples include:
 

--- a/docs/features/private pages.md
+++ b/docs/features/private pages.md
@@ -12,6 +12,11 @@ There may be some notes you want to avoid publishing as a website. Quartz suppor
 
 If you'd like to only publish a select number of notes, you can instead use `Plugin.ExplicitPublish` which will filter out all notes except for any that have `publish: true` in the frontmatter.
 
+> [!warning]
+> Regardless of the filter plugin used, **all non-markdown files will be emitted and available publically in the final build.** This includes files such as images, voice recordings, PDFs, etc. One way to prevent this and still be able to embed local images is to create a folder specifically for public media and add the following two patterns to the ignorePatterns array.
+> 
+> `"!(PublicMedia)**/!(*.md)", "!(*.md)"` 
+
 ## `ignorePatterns`
 
 This is a field in `quartz.config.ts` under the main [[configuration]] which allows you to specify a list of patterns to effectively exclude from parsing all together. Any valid [fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) pattern works here. 

--- a/docs/features/private pages.md
+++ b/docs/features/private pages.md
@@ -14,12 +14,12 @@ If you'd like to only publish a select number of notes, you can instead use `Plu
 
 > [!warning]
 > Regardless of the filter plugin used, **all non-markdown files will be emitted and available publically in the final build.** This includes files such as images, voice recordings, PDFs, etc. One way to prevent this and still be able to embed local images is to create a folder specifically for public media and add the following two patterns to the ignorePatterns array.
-> 
-> `"!(PublicMedia)**/!(*.md)", "!(*.md)"` 
+>
+> `"!(PublicMedia)**/!(*.md)", "!(*.md)"`
 
 ## `ignorePatterns`
 
-This is a field in `quartz.config.ts` under the main [[configuration]] which allows you to specify a list of patterns to effectively exclude from parsing all together. Any valid [fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) pattern works here. 
+This is a field in `quartz.config.ts` under the main [[configuration]] which allows you to specify a list of patterns to effectively exclude from parsing all together. Any valid [fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) pattern works here.
 
 > [!note]
 > Bash's glob syntax is slightly different from fast-glob's and using bash's syntax may lead to unexpected results.


### PR DESCRIPTION
Updated documentation to warn the user about non-markdown files being added to the public build, and providing a ignore pattern as a workaround. Please feel free to edit or let me know if I need to change any wording!