### PR TITLE
docs: remove dead link

### DIFF
--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -9,7 +9,6 @@ Want to see what Quartz can do? Here are some cool community gardens:
 - [Brandon Boswell's Garden](https://brandonkboswell.com)
 - [Scaling Synthesis - A hypertext research notebook](https://scalingsynthesis.com/)
 - [AWAGMI Intern Notes](https://notes.awagmi.xyz/)
-- [Course notes for Information Technology Advanced Theory](https://a2itnotes.github.io/quartz/)
 - [Data Dictionary 🧠](https://glossary.airbyte.com/)
 - [sspaeti.com's Second Brain](https://brain.sspaeti.com/)
 - [oldwinter の数字花园](https://garden.oldwinter.top/)


### PR DESCRIPTION
Removed a dead link on the examples showcase for quartz.

(Sorry for this super minor pull request, i was just poking around and saw that sadly this example seems to have been taken down by its creator)