### PR TITLE
Feature: Add favicon to quartz config

### DIFF
--- a/docs/features/private pages.md
+++ b/docs/features/private pages.md
@@ -14,7 +14,10 @@ If you'd like to only publish a select number of notes, you can instead use `Plu
 
 ## `ignorePatterns`
 
-This is a field in `quartz.config.ts` under the main [[configuration]] which allows you to specify a list of patterns to effectively exclude from parsing all together. Any valid [glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) pattern works here.
+This is a field in `quartz.config.ts` under the main [[configuration]] which allows you to specify a list of patterns to effectively exclude from parsing all together. Any valid [fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) pattern works here. 
+
+> [!note]
+> Bash's glob syntax is slightly different from fast-glob's and using bash's syntax may lead to unexpected results.
 
 Common examples include:
 

--- a/docs/features/private pages.md
+++ b/docs/features/private pages.md
@@ -12,6 +12,11 @@ There may be some notes you want to avoid publishing as a website. Quartz suppor
 
 If you'd like to only publish a select number of notes, you can instead use `Plugin.ExplicitPublish` which will filter out all notes except for any that have `publish: true` in the frontmatter.
 
+> [!warning]
+> Regardless of the filter plugin used, **all non-markdown files will be emitted and available publically in the final build.** This includes files such as images, voice recordings, PDFs, etc. One way to prevent this and still be able to embed local images is to create a folder specifically for public media and add the following two patterns to the ignorePatterns array.
+> 
+> `"!(PublicMedia)**/!(*.md)", "!(*.md)"` 
+
 ## `ignorePatterns`
 
 This is a field in `quartz.config.ts` under the main [[configuration]] which allows you to specify a list of patterns to effectively exclude from parsing all together. Any valid [fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) pattern works here. 

--- a/docs/features/private pages.md
+++ b/docs/features/private pages.md
@@ -14,12 +14,12 @@ If you'd like to only publish a select number of notes, you can instead use `Plu
 
 > [!warning]
 > Regardless of the filter plugin used, **all non-markdown files will be emitted and available publically in the final build.** This includes files such as images, voice recordings, PDFs, etc. One way to prevent this and still be able to embed local images is to create a folder specifically for public media and add the following two patterns to the ignorePatterns array.
-> 
-> `"!(PublicMedia)**/!(*.md)", "!(*.md)"` 
+>
+> `"!(PublicMedia)**/!(*.md)", "!(*.md)"`
 
 ## `ignorePatterns`
 
-This is a field in `quartz.config.ts` under the main [[configuration]] which allows you to specify a list of patterns to effectively exclude from parsing all together. Any valid [fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) pattern works here. 
+This is a field in `quartz.config.ts` under the main [[configuration]] which allows you to specify a list of patterns to effectively exclude from parsing all together. Any valid [fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) pattern works here.
 
 > [!note]
 > Bash's glob syntax is slightly different from fast-glob's and using bash's syntax may lead to unexpected results.

--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -4,6 +4,7 @@ import * as Plugin from "./quartz/plugins"
 const config: QuartzConfig = {
   configuration: {
     pageTitle: "🪴 Quartz 4.0",
+    favIcon: "icon.png",
     enableSPA: true,
     enablePopovers: true,
     analytics: {

--- a/quartz/cfg.ts
+++ b/quartz/cfg.ts
@@ -20,6 +20,8 @@ export type Analytics =
 export interface GlobalConfiguration {
   pageTitle: string
   /** Whether to enable single-page-app style rendering. this prevents flashes of unstyled content and improves smoothness of Quartz */
+  favIcon: string
+  /** The filename of the favicon to use. Must be placed in the quartz/static folder. */
   enableSPA: boolean
   /** Whether to display Wikipedia-style popovers when hovering over links */
   enablePopovers: boolean

--- a/quartz/cfg.ts
+++ b/quartz/cfg.ts
@@ -19,9 +19,9 @@ export type Analytics =
 
 export interface GlobalConfiguration {
   pageTitle: string
-  /** Whether to enable single-page-app style rendering. this prevents flashes of unstyled content and improves smoothness of Quartz */
-  favIcon: string
   /** The filename of the favicon to use. Must be placed in the quartz/static folder. */
+  favIcon: string
+  /** Whether to enable single-page-app style rendering. this prevents flashes of unstyled content and improves smoothness of Quartz */
   enableSPA: boolean
   /** Whether to display Wikipedia-style popovers when hovering over links */
   enablePopovers: boolean

--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -12,7 +12,7 @@ export default (() => {
     const path = url.pathname as FullSlug
     const baseDir = fileData.slug === "404" ? path : pathToRoot(fileData.slug!)
 
-    const iconPath = joinSegments(baseDir, "static/icon.png")
+    const iconPath = joinSegments(baseDir, `static/${cfg.favIcon}`)
     const ogImagePath = `https://${cfg.baseUrl}/static/og-image.png`
 
     return (


### PR DESCRIPTION
While configuring my repo, I realized how much more convenient (and easier for less computer-savvy folks) it would be if the quartz.config.ts had a property for specifying the favicon. So I made some small changes to `quartz.config.ts`, `cfg.t`s, and `Head.tsx`. Lemme know if I need to fix anything & feel free to just reject if this isn't in the scope of the project!