### PR TITLE
feat: allow title transform e.g. add site name as suffix

### DIFF
--- a/quartz/cfg.ts
+++ b/quartz/cfg.ts
@@ -19,6 +19,8 @@ export type Analytics =
 
 export interface GlobalConfiguration {
   pageTitle: string
+  /** Allow transform the title rendered in html head tag */
+  htmlTitleTransform?: (title: string) => string
   /** Whether to enable single-page-app style rendering. this prevents flashes of unstyled content and improves smoothness of Quartz */
   enableSPA: boolean
   /** Whether to display Wikipedia-style popovers when hovering over links */

--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -4,7 +4,9 @@ import { QuartzComponentConstructor, QuartzComponentProps } from "./types"
 
 export default (() => {
   function Head({ cfg, fileData, externalResources }: QuartzComponentProps) {
-    const title = fileData.frontmatter?.title ?? "Untitled"
+    const titleTransformer = cfg.htmlTitleTransform ?? ((s: string) => s)
+    const rawTitle = fileData.frontmatter?.title ?? "Untitled"
+    const title = titleTransformer(rawTitle)
     const description = fileData.description?.trim() ?? "No description provided"
     const { css, js } = externalResources
 


### PR DESCRIPTION
<img width="224" alt="image" src="https://github.com/jackyzha0/quartz/assets/50045289/e23000e7-29f5-4715-9761-ba6d38e5a9b6">

<img width="393" alt="image" src="https://github.com/jackyzha0/quartz/assets/50045289/28a0002a-e92d-49b2-bc0a-8473456be7ef">


Allow user to transform the site title in html head tag by configuring `htmlTitleTransform` (optional), optimizing SEO.

Just an experimental PR, and better options are welcome