### PR TITLE
feat(breadcrumbs): add option to hide current page

### DIFF
--- a/docs/features/breadcrumbs.md
+++ b/docs/features/breadcrumbs.md
@@ -20,6 +20,7 @@ Component.Breadcrumbs({
   rootName: "Home", // name of first/root element
   resolveFrontmatterTitle: true, // whether to resolve folder names through frontmatter titles
   hideOnRoot: true, // whether to hide breadcrumbs on root `index.md` page
+  showCurrentPage: true, // wether to display the current page in the breadcrumbs
 })
 ```
 

--- a/quartz/components/Breadcrumbs.tsx
+++ b/quartz/components/Breadcrumbs.tsx
@@ -101,8 +101,6 @@ export default ((opts?: Partial<BreadcrumbOptions>) => {
 
       // Add current file to crumb (can directly use frontmatter title)
       if (options.showCurrentPage) {
-        console.log("Show current page in breadcrumbs is set to: " + options.showCurrentPage)
-        console.log("Adding cumb: " + fileData.frontmatter!.title)
         crumbs.push({
           displayName: fileData.frontmatter!.title,
           path: "",

--- a/quartz/components/Breadcrumbs.tsx
+++ b/quartz/components/Breadcrumbs.tsx
@@ -25,6 +25,10 @@ interface BreadcrumbOptions {
    * Wether to display breadcrumbs on root `index.md`
    */
   hideOnRoot: boolean
+  /**
+   * Wether to display the current page in the breadcrumbs.
+   */
+  showCurrentPage: boolean
 }
 
 const defaultOptions: BreadcrumbOptions = {
@@ -32,6 +36,7 @@ const defaultOptions: BreadcrumbOptions = {
   rootName: "Home",
   resolveFrontmatterTitle: true,
   hideOnRoot: true,
+  showCurrentPage: true,
 }
 
 function formatCrumb(displayName: string, baseSlug: FullSlug, currentSlug: SimpleSlug): CrumbData {
@@ -95,10 +100,14 @@ export default ((opts?: Partial<BreadcrumbOptions>) => {
       }
 
       // Add current file to crumb (can directly use frontmatter title)
-      crumbs.push({
-        displayName: fileData.frontmatter!.title,
-        path: "",
-      })
+      if (options.showCurrentPage) {
+        console.log("Show current page in breadcrumbs is set to: " + options.showCurrentPage)
+        console.log("Adding cumb: " + fileData.frontmatter!.title)
+        crumbs.push({
+          displayName: fileData.frontmatter!.title,
+          path: "",
+        })
+      }
     }
     return (
       <nav class={`breadcrumb-container ${displayClass ?? ""}`} aria-label="breadcrumbs">


### PR DESCRIPTION
I find it nicer to not show the current page your on in the breadcrumbs.