### PR TITLE
feat: Support space-delimited tags in `FrontMatter` transformer

### DIFF
--- a/quartz/plugins/transformers/frontmatter.ts
+++ b/quartz/plugins/transformers/frontmatter.ts
@@ -8,11 +8,13 @@ import { slugTag } from "../../util/path"
 export interface Options {
   delims: string | string[]
   language: "yaml" | "toml"
+  oneLineTagDelim: string
 }
 
 const defaultOptions: Options = {
   delims: "---",
   language: "yaml",
+  oneLineTagDelim: ",",
 }
 
 export const FrontMatter: QuartzTransformerPlugin<Partial<Options> | undefined> = (userOpts) => {
@@ -20,6 +22,8 @@ export const FrontMatter: QuartzTransformerPlugin<Partial<Options> | undefined> 
   return {
     name: "FrontMatter",
     markdownPlugins() {
+      const { oneLineTagDelim } = opts
+
       return [
         [remarkFrontmatter, ["yaml", "toml"]],
         () => {
@@ -45,7 +49,7 @@ export const FrontMatter: QuartzTransformerPlugin<Partial<Options> | undefined> 
             if (data.tags && !Array.isArray(data.tags)) {
               data.tags = data.tags
                 .toString()
-                .split(",")
+                .split(oneLineTagDelim)
                 .map((tag: string) => tag.trim())
             }
 


### PR DESCRIPTION
Hi, thanks for creating Quartz! I wanted to offer this PR for a tiny feature I ended up needing: an option to support the syntax `tags: tag1 tag2 tag3` in frontmatter.

## Use case
I've found this syntax is the best "common denominator" between the several different tools I use for my notes ([vimwiki](https://github.com/vimwiki/vimwiki) on desktop, and Obsidian on mobile). Obsidian natively supports space-delimited `tags:`. Vimwiki doesn't by default, but can be [finagled into doing so](https://github.com/samstokes/dotfiles/commit/35444d3c793e886ee0eac1ec6e52ac78f95ebe4a).

## Approach
I made this an option because it would break existing sites using the `tags: tag1,tag2,tag3` syntax, as well as sites whose tags actually contained spaces.