### PR TITLE
Add a <link rel=canonical> to each page

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,7 @@ This part of the configuration concerns anything that can affect the whole site.
   - `{ provider: 'google', tagId: <your-google-tag> }`: use Google Analytics
 - `baseUrl`: this is used for sitemaps and RSS feeds that require an absolute URL to know where the canonical 'home' of your site lives. This is normally the deployed URL of your site (e.g. `quartz.jzhao.xyz` for this site). Do not include the protocol (i.e. `https://`) or any leading or trailing slashes.
   - This should also include the subpath if you are [[hosting]] on GitHub pages without a custom domain. For example, if my repository is `jackyzha0/quartz`, GitHub pages would deploy to `https://jackyzha0.github.io/quartz` and the `baseUrl` would be `jackyzha0.github.io/quartz`
+  - This is also used to generate a [canonical link](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#rel-canonical-link-method) for each page, for better search engine ranking and compatibility with certain hosting setups.
   - Note that Quartz 4 will avoid using this as much as possible and use relative URLs whenever it can to make sure your site works no matter _where_ you end up actually deploying it.
 - `ignorePatterns`: a list of [glob](<https://en.wikipedia.org/wiki/Glob_(programming)>) patterns that Quartz should ignore and not search through when looking for files inside the `content` folder. See [[private pages]] for more details.
 - `defaultDateType`: whether to use created, modified, or published as the default date to display on pages and page listings.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,8 +29,9 @@ This part of the configuration concerns anything that can affect the whole site.
   - `{ provider: 'google', tagId: <your-google-tag> }`: use Google Analytics
 - `baseUrl`: this is used for sitemaps and RSS feeds that require an absolute URL to know where the canonical 'home' of your site lives. This is normally the deployed URL of your site (e.g. `quartz.jzhao.xyz` for this site). Do not include the protocol (i.e. `https://`) or any leading or trailing slashes.
   - This should also include the subpath if you are [[hosting]] on GitHub pages without a custom domain. For example, if my repository is `jackyzha0/quartz`, GitHub pages would deploy to `https://jackyzha0.github.io/quartz` and the `baseUrl` would be `jackyzha0.github.io/quartz`
-  - This is also used to generate a [canonical link](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#rel-canonical-link-method) for each page, for better search engine ranking and compatibility with certain hosting setups.
   - Note that Quartz 4 will avoid using this as much as possible and use relative URLs whenever it can to make sure your site works no matter _where_ you end up actually deploying it.
+- `includeRelCanonical`: generate a [canonical link](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#rel-canonical-link-method) for each page, for better search engine ranking and compatibility with certain hosting setups.
+  - If you are specifying `baseUrl` you should also set this to `true` unless you have a good reason not to (e.g. it does the wrong thing for your hosting setup).
 - `ignorePatterns`: a list of [glob](<https://en.wikipedia.org/wiki/Glob_(programming)>) patterns that Quartz should ignore and not search through when looking for files inside the `content` folder. See [[private pages]] for more details.
 - `defaultDateType`: whether to use created, modified, or published as the default date to display on pages and page listings.
 - `theme`: configure how the site looks.

--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -10,6 +10,7 @@ const config: QuartzConfig = {
       provider: "plausible",
     },
     baseUrl: "quartz.jzhao.xyz",
+    includeRelCanonical: false,
     ignorePatterns: ["private", "templates", ".obsidian"],
     defaultDateType: "created",
     theme: {

--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -10,9 +10,9 @@ const config: QuartzConfig = {
       provider: "plausible",
     },
     baseUrl: "quartz.jzhao.xyz",
-    includeRelCanonical: false,
     ignorePatterns: ["private", "templates", ".obsidian"],
     defaultDateType: "created",
+    includeRelCanonical: false,
     theme: {
       typography: {
         header: "Schibsted Grotesk",

--- a/quartz/cfg.ts
+++ b/quartz/cfg.ts
@@ -33,6 +33,8 @@ export interface GlobalConfiguration {
    *   Quartz will avoid using this as much as possible and use relative URLs most of the time
    */
   baseUrl?: string
+  /** Whether to generate a rel=canonical link for each page (requires baseUrl to be set). */
+  includeRelCanonical: boolean
   theme: Theme
 }
 

--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -21,6 +21,8 @@ export default (() => {
     const path = rootUrl.pathname as FullSlug
     const baseDir = fileData.slug === "404" ? path : pathToRoot(slug)
 
+    const absoluteUrl = cfg.includeRelCanonical && cfg.baseUrl && canonicalURL(cfg.baseUrl, slug) || null;
+
     const iconPath = joinSegments(baseDir, "static/icon.png")
     const ogImagePath = `https://${cfg.baseUrl}/static/og-image.png`
 
@@ -29,7 +31,7 @@ export default (() => {
         <title>{title}</title>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        {cfg.baseUrl && <link rel="canonical" href={canonicalURL(cfg.baseUrl, slug)} />}
+        {absoluteUrl && <link rel="canonical" href={absoluteUrl} />}
         <meta property="og:title" content={title} />
         <meta property="og:description" content={description} />
         {cfg.baseUrl && <meta property="og:image" content={ogImagePath} />}

--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -21,7 +21,8 @@ export default (() => {
     const path = rootUrl.pathname as FullSlug
     const baseDir = fileData.slug === "404" ? path : pathToRoot(slug)
 
-    const absoluteUrl = cfg.includeRelCanonical && cfg.baseUrl && canonicalURL(cfg.baseUrl, slug) || null;
+    const absoluteUrl =
+      (cfg.includeRelCanonical && cfg.baseUrl && canonicalURL(cfg.baseUrl, slug)) || null
 
     const iconPath = joinSegments(baseDir, "static/icon.png")
     const ogImagePath = `https://${cfg.baseUrl}/static/og-image.png`

--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -1,4 +1,4 @@
-import { FullSlug, _stripSlashes, joinSegments, pathToRoot, simplifySlug } from "../util/path"
+import { FullSlug, _stripSlashes, canonicalURL, joinSegments, pathToRoot, simplifySlug } from "../util/path"
 import { JSResourceToScriptElement } from "../util/resources"
 import { QuartzComponentConstructor, QuartzComponentProps } from "./types"
 
@@ -14,8 +14,6 @@ export default (() => {
     const path = rootUrl.pathname as FullSlug
     const baseDir = fileData.slug === "404" ? path : pathToRoot(slug)
 
-    const canonicalSlug = simplifySlug(slug)
-    const canonicalUrl = cfg.baseUrl ? `https://${joinSegments(cfg.baseUrl, canonicalSlug)}` : null
     const iconPath = joinSegments(baseDir, "static/icon.png")
     const ogImagePath = `https://${cfg.baseUrl}/static/og-image.png`
 
@@ -24,7 +22,7 @@ export default (() => {
         <title>{title}</title>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
+        {cfg.baseUrl && <link rel="canonical" href={canonicalURL(cfg.baseUrl, slug)} />}
         <meta property="og:title" content={title} />
         <meta property="og:description" content={description} />
         {cfg.baseUrl && <meta property="og:image" content={ogImagePath} />}

--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -1,4 +1,11 @@
-import { FullSlug, _stripSlashes, canonicalURL, joinSegments, pathToRoot, simplifySlug } from "../util/path"
+import {
+  FullSlug,
+  _stripSlashes,
+  canonicalURL,
+  joinSegments,
+  pathToRoot,
+  simplifySlug,
+} from "../util/path"
 import { JSResourceToScriptElement } from "../util/resources"
 import { QuartzComponentConstructor, QuartzComponentProps } from "./types"
 

--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -1,4 +1,4 @@
-import { FullSlug, _stripSlashes, joinSegments, pathToRoot } from "../util/path"
+import { FullSlug, _stripSlashes, joinSegments, pathToRoot, simplifySlug } from "../util/path"
 import { JSResourceToScriptElement } from "../util/resources"
 import { QuartzComponentConstructor, QuartzComponentProps } from "./types"
 
@@ -8,10 +8,14 @@ export default (() => {
     const description = fileData.description?.trim() ?? "No description provided"
     const { css, js } = externalResources
 
-    const url = new URL(`https://${cfg.baseUrl ?? "example.com"}`)
-    const path = url.pathname as FullSlug
-    const baseDir = fileData.slug === "404" ? path : pathToRoot(fileData.slug!)
+    const slug = fileData.slug!
 
+    const rootUrl = new URL(`https://${cfg.baseUrl ?? "example.com"}`)
+    const path = rootUrl.pathname as FullSlug
+    const baseDir = fileData.slug === "404" ? path : pathToRoot(slug)
+
+    const canonicalSlug = simplifySlug(slug)
+    const canonicalUrl = cfg.baseUrl ? `https://${joinSegments(cfg.baseUrl, canonicalSlug)}` : null
     const iconPath = joinSegments(baseDir, "static/icon.png")
     const ogImagePath = `https://${cfg.baseUrl}/static/og-image.png`
 
@@ -20,6 +24,7 @@ export default (() => {
         <title>{title}</title>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
         <meta property="og:title" content={title} />
         <meta property="og:description" content={description} />
         {cfg.baseUrl && <meta property="og:image" content={ogImagePath} />}

--- a/quartz/plugins/emitters/contentIndex.ts
+++ b/quartz/plugins/emitters/contentIndex.ts
@@ -79,10 +79,10 @@ function generateRSSFeed(cfg: GlobalConfiguration, idx: ContentIndex, limit?: nu
 <rss version="2.0">
     <channel>
       <title>${escapeHTML(cfg.pageTitle)}</title>
-      <link>${canonicalURL(base, '' as FullSlug)}</link>
+      <link>${canonicalURL(base, "" as FullSlug)}</link>
       <description>${!!limit ? `Last ${limit} notes` : "Recent notes"} on ${escapeHTML(
-    cfg.pageTitle,
-  )}</description>
+        cfg.pageTitle,
+      )}</description>
       <generator>Quartz -- quartz.jzhao.xyz</generator>
       ${items}
     </channel>

--- a/quartz/util/path.test.ts
+++ b/quartz/util/path.test.ts
@@ -154,6 +154,22 @@ describe("transforms", () => {
       path.isRelativeURL,
     )
   })
+
+  test("canonicalURL", () => {
+    asserts(
+      [
+        ["", "https://example.com/subdir/"],
+        ["index", "https://example.com/subdir/"],
+        ["abc", "https://example.com/subdir/abc"],
+        ["abc/index", "https://example.com/subdir/abc/"],
+        ["abc/def", "https://example.com/subdir/abc/def"],
+        ["abc-def", "https://example.com/subdir/abc-def"],
+      ],
+      slug => path.canonicalURL("example.com/subdir", slug),
+      path.isFullSlug,
+      (_x: string): _x is string => true,
+    )
+  })
 })
 
 describe("link strategies", () => {

--- a/quartz/util/path.test.ts
+++ b/quartz/util/path.test.ts
@@ -165,7 +165,7 @@ describe("transforms", () => {
         ["abc/def", "https://example.com/subdir/abc/def"],
         ["abc-def", "https://example.com/subdir/abc-def"],
       ],
-      slug => path.canonicalURL("example.com/subdir", slug),
+      (slug) => path.canonicalURL("example.com/subdir", slug),
       path.isFullSlug,
       (_x: string): _x is string => true,
     )

--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -86,6 +86,12 @@ export function transformInternalLink(link: string): RelativeURL {
   return res
 }
 
+export function canonicalURL(baseUrl: string | undefined, slug: FullSlug): string {
+  const base = baseUrl ?? ''
+  const simpleSlug = simplifySlug(slug)
+  return `https://${joinSegments(base, encodeURI(simpleSlug))}`
+}
+
 // from micromorph/src/utils.ts
 // https://github.com/natemoo-re/micromorph/blob/main/src/utils.ts#L5
 const _rebaseHtmlElement = (el: Element, attr: string, newBase: string | URL) => {

--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -87,7 +87,7 @@ export function transformInternalLink(link: string): RelativeURL {
 }
 
 export function canonicalURL(baseUrl: string | undefined, slug: FullSlug): string {
-  const base = baseUrl ?? ''
+  const base = baseUrl ?? ""
   const simpleSlug = simplifySlug(slug)
   return `https://${joinSegments(base, encodeURI(simpleSlug))}`
 }


### PR DESCRIPTION
This is a feature I needed that I thought might be generally useful. This adds a `<link rel="canonical">` to each page's `<head>` section linking to the page's canonical absolute URL (according to `baseUrl`).

I noticed this was very similar to logic already done by the RSS and sitemap code, so I refactored slightly so all three could share the same URL generation code.

It seemed like this might want to fit into the [path types](https://quartz.jzhao.xyz/advanced/paths) structure (e.g. as a new `type AbsoluteUrl`), but I didn't understand that quite well enough to extend it.

## Motivation

I believe this is considered a [best practice for SEO](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#rel-canonical-link-method), as e.g. it combines the Google juice for https://your-site.com/page and https://your-site.com/page?utm-tracking=nonsense.

In my case I had a more concrete need for this to work around a quirk of my hosting setup. I wanted to host my digital garden at a subdirectory of my existing blog domain (https://five-eights.com/garden). I'm using Netlify for hosting, which [supports this setup via proxy rewrites](https://answers.netlify.com/t/support-guide-can-i-deploy-multiple-repositories-in-a-single-site/179). This mostly worked out of the box (thanks to Quartz's careful use of relative URLs!). However, it bumps into a couple of Netlify edge cases:
* Netlify is opinionated about `canonical` links, and if the page itself doesn't define one, it infers one (!) and adds it as an HTTP response header
* the inferred canonical URL is apparently just wrong for proxy-rewritten requests (it just gets set to https://five-eights.com/, no suffix, regardless of which /garden page is being requested)

I found that setting a canonical link in the page suppressed the weird Netlify behaviour.