### PR TITLE
feat: Self-hosted Plausible support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "mdast-util-to-hast": "^13.0.2",
         "mdast-util-to-string": "^4.0.0",
         "micromorph": "^0.4.5",
-        "plausible-tracker": "^0.3.8",
         "preact": "^10.19.3",
         "preact-render-to-string": "^6.3.1",
         "pretty-bytes": "^6.1.1",
@@ -4449,14 +4448,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/plausible-tracker": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/plausible-tracker/-/plausible-tracker-0.3.8.tgz",
-      "integrity": "sha512-lmOWYQ7s9KOUJ1R+YTOR3HrjdbxIS2Z4de0P/Jx2dQPteznJl2eX3tXxKClpvbfyGP59B5bbhW8ftN59HbbFSg==",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/preact": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "mdast-util-to-hast": "^13.0.2",
     "mdast-util-to-string": "^4.0.0",
     "micromorph": "^0.4.5",
-    "plausible-tracker": "^0.3.8",
     "preact": "^10.19.3",
     "preact-render-to-string": "^6.3.1",
     "pretty-bytes": "^6.1.1",

--- a/quartz/cfg.ts
+++ b/quartz/cfg.ts
@@ -7,6 +7,7 @@ export type Analytics =
   | null
   | {
       provider: "plausible"
+      host?: string
     }
   | {
       provider: "google"

--- a/quartz/components/scripts/plausible.inline.ts
+++ b/quartz/components/scripts/plausible.inline.ts
@@ -1,3 +1,0 @@
-import Plausible from "plausible-tracker"
-const { trackPageview } = Plausible()
-document.addEventListener("nav", () => trackPageview())

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -95,7 +95,20 @@ function addGlobalPageResources(
         });
       });`)
   } else if (cfg.analytics?.provider === "plausible") {
-    componentResources.afterDOMLoaded.push(plausibleScript)
+    const plausibleHost = cfg.analytics.host ?? "https://plausible.io"
+    componentResources.afterDOMLoaded.push(`
+      const plausibleScript = document.createElement("script")
+      plausibleScript.src = "${plausibleHost}/js/script.manual.js"
+      plausibleScript.setAttribute("data-domain", location.hostname)
+      plausibleScript.defer = true
+      document.head.appendChild(plausibleScript)
+
+      window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }
+
+      document.addEventListener("nav", () => {
+        plausible("pageview")
+      })
+    `)
   } else if (cfg.analytics?.provider === "umami") {
     componentResources.afterDOMLoaded.push(`
       const umamiScript = document.createElement("script")

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -4,8 +4,6 @@ import { QuartzEmitterPlugin } from "../types"
 // @ts-ignore
 import spaRouterScript from "../../components/scripts/spa.inline"
 // @ts-ignore
-import plausibleScript from "../../components/scripts/plausible.inline"
-// @ts-ignore
 import popoverScript from "../../components/scripts/popover.inline"
 import styles from "../../styles/custom.scss"
 import popoverStyle from "../../components/styles/popover.scss"


### PR DESCRIPTION
This PR adds support for optionally pointing the Plausible script to a custom Plausible instance.

I didn't find a way to "parameterize" the existing inline Plausible script, so I reverted to using a plain string code snippet like all other analytics implementations.

A few technical notes:
- I followed [the official script snippet guide](https://plausible.io/docs/plausible-script)
- I also followed [Plausible's guide](https://plausible.io/docs/script-extensions#scriptmanualjs) for manually tracking page views using a custom navigation framework. Note the `script.manual.js` part that avoids double-tracking.