### PR TITLE
Add abandoned.zone to quartz Showcase

### DIFF
--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -12,6 +12,7 @@ Want to see what Quartz can do? Here are some cool community gardens:
 - [Data Dictionary 🧠](https://glossary.airbyte.com/)
 - [sspaeti.com's Second Brain](https://brain.sspaeti.com/)
 - [oldwinter の数字花园](https://garden.oldwinter.top/)
+- [The Abandoned Zone - notes on digital space preservation](https://abandoned.zone/)
 - [Abhijeet's Math Wiki](https://abhmul.github.io/quartz/Math-Wiki/)
 - [Mike's AI Garden 🤖🪴](https://mwalton.me/)
 - [Matt Dunn's Second Brain](https://mattdunn.info/)


### PR DESCRIPTION
(Apologies if there's anything awkward about this PR, some of it was performed automatically by github)

I would like to add the site I've been working on : [abandoned.zone](https://abandoned.zone/), which uses Quartz. I've done some fun things to it like added an animated logo e.g. The source code is on github [here](https://github.com/Kezzsim/abandoned.zone).

Let me know if there are any issues~