### PR TITLE
feat: support modification date reading from parent git repo

### DIFF
--- a/quartz/plugins/transformers/lastmod.ts
+++ b/quartz/plugins/transformers/lastmod.ts
@@ -66,7 +66,12 @@ export const CreatedModifiedDate: QuartzTransformerPlugin<Partial<Options> | und
                 try {
                   modified ||= await repo.getFileLatestModifiedDateAsync(file.data.filePath!)
                 } catch {
-                  console.log(chalk.yellow(`Warning: ${file.data.filePath!} isn't yet tracked by git, last modification date is not available for this file`))
+                  console.log(
+                    chalk.yellow(
+                      `Warning: ${file.data
+                        .filePath!} isn't yet tracked by git, last modification date is not available for this file`,
+                    ),
+                  )
                 }
               }
             }

--- a/quartz/plugins/transformers/lastmod.ts
+++ b/quartz/plugins/transformers/lastmod.ts
@@ -68,7 +68,7 @@ export const CreatedModifiedDate: QuartzTransformerPlugin<Partial<Options> | und
                 } catch {
                   console.log(
                     chalk.yellow(
-                      `Warning: ${file.data
+                      `\nWarning: ${file.data
                         .filePath!} isn't yet tracked by git, last modification date is not available for this file`,
                     ),
                   )

--- a/quartz/plugins/transformers/lastmod.ts
+++ b/quartz/plugins/transformers/lastmod.ts
@@ -66,7 +66,7 @@ export const CreatedModifiedDate: QuartzTransformerPlugin<Partial<Options> | und
                 try {
                   modified ||= await repo.getFileLatestModifiedDateAsync(file.data.filePath!)
                 } catch {
-                  // ignore
+                  console.log(chalk.yellow(`Warning: ${file.data.filePath!} isn't yet tracked by git, last modification date is not available for this file`))
                 }
               }
             }

--- a/quartz/plugins/transformers/lastmod.ts
+++ b/quartz/plugins/transformers/lastmod.ts
@@ -57,10 +57,17 @@ export const CreatedModifiedDate: QuartzTransformerPlugin<Partial<Options> | und
                 published ||= file.data.frontmatter.publishDate
               } else if (source === "git") {
                 if (!repo) {
-                  repo = new Repository(file.cwd)
+                  // Get a reference to the main git repo.
+                  // It's either the same as the workdir,
+                  // or 1+ level higher in case of a submodule/subtree setup
+                  repo = Repository.discover(file.cwd)
                 }
 
-                modified ||= await repo.getFileLatestModifiedDateAsync(file.data.filePath!)
+                try {
+                  modified ||= await repo.getFileLatestModifiedDateAsync(file.data.filePath!)
+                } catch {
+                  // ignore
+                }
               }
             }
 


### PR DESCRIPTION
I'm storing the quartz repo as a git subtree in another repo. This PR changes the git repo reading logic to open either the working directory (existing behavior) or the parent (or parent of parent) directory (new behavior).

I also added a try-catch block to swallow errors from reading git dates, I think it makes sense for this priority list behavior. I ran into a build error with my priority list of `["frontmatter", "git", "filesystem"]` (probably because I had a dirty git state.