### PR TITLE
fix: Continue setup even if a file to delete is not found

### DIFF
--- a/quartz/cli/handlers.js
+++ b/quartz/cli/handlers.js
@@ -113,7 +113,7 @@ export async function handleCreate(argv) {
     }
   }
 
-  await fs.promises.unlink(path.join(contentFolder, ".gitkeep"))
+  await fs.promises.unlink(path.join(contentFolder, ".gitkeep")).catch((err) => {})
   if (setupStrategy === "copy" || setupStrategy === "symlink") {
     let originalFolder = sourceDirectory
 

--- a/quartz/cli/handlers.js
+++ b/quartz/cli/handlers.js
@@ -113,7 +113,10 @@ export async function handleCreate(argv) {
     }
   }
 
-  await fs.promises.unlink(path.join(contentFolder, ".gitkeep")).catch((err) => {})
+  const gitkeepPath = path.join(contentFolder, ".gitkeep")
+  if (fs.existsSync(gitkeepPath)) {
+    await fs.promises.unlink(gitkeepPath)
+  }
   if (setupStrategy === "copy" || setupStrategy === "symlink") {
     let originalFolder = sourceDirectory
 


### PR DESCRIPTION
For various reasons, `.gitkeep` may be deleted already. 

(In my case, even though I followed the [Getting Started](https://quartz.jzhao.xyz) instructions exactly, my first run resulted in an `fatal: 'upstream' does not appear to be a git repository`)
 
If we then try to delete `.gitkeep` again and _don't_ ignore `ENOENT`, then the whole setup fails. Since this really isn't an error state, we should ignore if deletion fails.

https://github.com/jackyzha0/quartz/assets/417267/8fa0168f-4ecc-478a-9533-5baf07fa0bf3