### PR TITLE
feat: add ofm option to transform `<img>` tags with video exts into `<video>` (closes #463)

### DIFF
--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -361,7 +361,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
           return (tree: Root, _file) => {
             visit(tree, "image", (node, index, parent) => {
               const match = node.url.match(videoExtensionRegex)
-              if (match && parent) {
+              if (parent && match) {
                 const htmlNode: PhrasingContent = {
                   type: "html",
                   value: `<video controls src="${node.url}" controls></video>`,

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -132,10 +132,7 @@ const calloutLineRegex = new RegExp(/^> *\[\!\w+\][+-]?.*$/, "gm")
 const tagRegex = new RegExp(/(?:^| )#((?:[-_\p{L}\p{Emoji}\d])+(?:\/[-_\p{L}\p{Emoji}\d]+)*)/, "gu")
 const blockReferenceRegex = new RegExp(/\^([A-Za-z0-9]+)$/, "g")
 const ytLinkRegex = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/
-const videoExtensionRegex = new RegExp(
-  /\.(mp4|webm|ogg|avi|mov|flv|wmv|mkv|mpg|mpeg|3gp|m4v)$/,
-  "g",
-)
+const videoExtensionRegex = new RegExp(/\.(mp4|webm|ogg|avi|mov|flv|wmv|mkv|mpg|mpeg|3gp|m4v)$/)
 
 export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> | undefined> = (
   userOpts,
@@ -366,10 +363,10 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
                   type: "html",
                   value: `<video controls src="${node.url}" controls></video>`,
                 }
-                if (index && (index >= 0 && index < parent.children.length)) {
+                if (index && index >= 0 && index < parent.children.length) {
                   parent.children.splice(index, 1, htmlNode)
                 } else {
-                  console.warn("Warning: Invalid index, htmlNode not added");
+                  console.warn("Warning: Invalid index, htmlNode not added")
                 }
               }
             })

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -366,10 +366,10 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
                   type: "html",
                   value: `<video controls src="${node.url}" controls></video>`,
                 }
-                if (typeof index === "number") {
+                if (index && (index >= 0 && index < parent.children.length)) {
                   parent.children.splice(index, 1, htmlNode)
                 } else {
-                  console.log("Error: index is not a number")
+                  console.warn("Warning: Invalid index, htmlNode not added");
                 }
               }
             })

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -16,7 +16,6 @@ import { PhrasingContent } from "mdast-util-find-and-replace/lib"
 import { capitalize } from "../../util/lang"
 import { PluggableList } from "unified"
 
-
 export interface Options {
   comments: boolean
   highlight: boolean
@@ -133,8 +132,10 @@ const calloutLineRegex = new RegExp(/^> *\[\!\w+\][+-]?.*$/, "gm")
 const tagRegex = new RegExp(/(?:^| )#((?:[-_\p{L}\p{Emoji}\d])+(?:\/[-_\p{L}\p{Emoji}\d]+)*)/, "gu")
 const blockReferenceRegex = new RegExp(/\^([A-Za-z0-9]+)$/, "g")
 const ytLinkRegex = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/
-const videoExtensionRegex = new RegExp(/\.(mp4|webm|ogg|avi|mov|flv|wmv|mkv|mpg|mpeg|3gp|m4v)\b/, "g")
-
+const videoExtensionRegex = new RegExp(
+  /\.(mp4|webm|ogg|avi|mov|flv|wmv|mkv|mpg|mpeg|3gp|m4v)\b/,
+  "g",
+)
 
 export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> | undefined> = (
   userOpts,
@@ -161,12 +162,12 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
         })
       }
 
-        // pre-transform wikilinks (fix anchors to things that may contain illegal syntax e.g. codeblocks, latex)
-        if (opts.wikilinks) {
+      // pre-transform wikilinks (fix anchors to things that may contain illegal syntax e.g. codeblocks, latex)
+      if (opts.wikilinks) {
         if (src instanceof Buffer) {
           src = src.toString()
         }
-        
+
         src = src.replace(wikilinkRegex, (value, ...capture) => {
           const [rawFp, rawHeader, rawAlias]: (string | undefined)[] = capture
 
@@ -270,8 +271,6 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
               },
             ])
           }
-          
-          
 
           if (opts.highlight) {
             replacements.push([
@@ -366,10 +365,10 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
               if (match && parent) {
                 const htmlNode: PhrasingContent = {
                   type: "html",
-                  value: `<video controls autoplay src="${node.url}" controls></video>`
+                  value: `<video controls autoplay src="${node.url}" controls></video>`,
                 }
-                if (typeof index === 'number') {
-                  parent.children.splice(index, 1, htmlNode);
+                if (typeof index === "number") {
+                  parent.children.splice(index, 1, htmlNode)
                 } else {
                   console.log("Error: index is not a number")
                 }
@@ -378,7 +377,6 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
           }
         })
       }
-      
 
       if (opts.callouts) {
         plugins.push(() => {
@@ -536,7 +534,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
           }
         })
       }
-      
+
       if (opts.enableYouTubeEmbed) {
         plugins.push(() => {
           return (tree: HtmlRoot) => {
@@ -607,4 +605,3 @@ declare module "vfile" {
     htmlAst: HtmlRoot
   }
 }
-

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -365,7 +365,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
               if (match && parent) {
                 const htmlNode: PhrasingContent = {
                   type: "html",
-                  value: `<video controls autoplay src="${node.url}" controls></video>`,
+                  value: `<video controls src="${node.url}" controls></video>`,
                 }
                 if (typeof index === "number") {
                   parent.children.splice(index, 1, htmlNode)

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -133,7 +133,7 @@ const tagRegex = new RegExp(/(?:^| )#((?:[-_\p{L}\p{Emoji}\d])+(?:\/[-_\p{L}\p{E
 const blockReferenceRegex = new RegExp(/\^([A-Za-z0-9]+)$/, "g")
 const ytLinkRegex = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/
 const videoExtensionRegex = new RegExp(
-  /\.(mp4|webm|ogg|avi|mov|flv|wmv|mkv|mpg|mpeg|3gp|m4v)\b/,
+  /\.(mp4|webm|ogg|avi|mov|flv|wmv|mkv|mpg|mpeg|3gp|m4v)$/,
   "g",
 )
 

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -154,6 +154,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
         if (src instanceof Buffer) {
           src = src.toString()
         }
+
         src = src.replace(calloutLineRegex, (value) => {
           // force newline after title of callout
           return value + "\n> "
@@ -165,6 +166,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
         if (src instanceof Buffer) {
           src = src.toString()
         }
+        
         src = src.replace(wikilinkRegex, (value, ...capture) => {
           const [rawFp, rawHeader, rawAlias]: (string | undefined)[] = capture
 

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -156,7 +156,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
           src = src.toString()
         }
 
-        src = src.replace(calloutLineRegex, (value) => {
+        src = src.replaceAll(calloutLineRegex, (value) => {
           // force newline after title of callout
           return value + "\n> "
         })
@@ -168,7 +168,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
           src = src.toString()
         }
 
-        src = src.replace(wikilinkRegex, (value, ...capture) => {
+        src = src.replaceAll(wikilinkRegex, (value, ...capture) => {
           const [rawFp, rawHeader, rawAlias]: (string | undefined)[] = capture
 
           const fp = rawFp ?? ""

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -356,7 +356,6 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
         }
       })
 
-      //go through mdast, find img nodes with video extension, convert them to html nodes
       if (opts.enableVideoEmbed) {
         plugins.push(() => {
           return (tree: Root, _file) => {

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -154,7 +154,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
         if (src instanceof Buffer) {
           src = src.toString()
         }
-        src = src.replaceAll(calloutLineRegex, (value) => {
+        src = src.replace(calloutLineRegex, (value) => {
           // force newline after title of callout
           return value + "\n> "
         })
@@ -165,7 +165,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
         if (src instanceof Buffer) {
           src = src.toString()
         }
-        src = src.replaceAll(wikilinkRegex, (value, ...capture) => {
+        src = src.replace(wikilinkRegex, (value, ...capture) => {
           const [rawFp, rawHeader, rawAlias]: (string | undefined)[] = capture
 
           const fp = rawFp ?? ""


### PR DESCRIPTION
This pull request introduces a new command-line tool for converting img tags with video file extensions to video tags in markdown files. The ParagraphToVideo plugin parses markdown content and applies a transformation on all img tags with video extensions.