### PR TITLE
feat: allow embedding youtube videos with the obsidian markdown syntax

### DIFF
--- a/docs/features/Obsidian compatibility.md
+++ b/docs/features/Obsidian compatibility.md
@@ -26,6 +26,7 @@ Finally, Quartz also provides `Plugin.CrawlLinks` which allows you to customize 
     - `mermaid`: whether to enable [[Mermaid diagrams]]. Defaults to `true`
     - `parseTags`: whether to try and parse tags in the content body. Defaults to `true`
     - `enableInHtmlEmbed`: whether to try and parse Obsidian flavoured markdown in raw HTML. Defaults to `false`
+    - `enableYouTubeEmbed`: whether to enable embedded YouTube videos using external image Markdown syntax. Defaults to `false`
 - Link resolution behaviour:
   - Disabling: remove all instances of `Plugin.CrawlLinks()` from `quartz.config.ts`
   - Changing link resolution preference: set `markdownLinkResolution` to one of `absolute`, `relative` or `shortest`


### PR DESCRIPTION
Updated the `ObsidianFlavoredMarkdown` transformer to optionally embed YouTube videos using the Markdown image syntax ([same as Obsidian](https://help.obsidian.md/Editing+and+formatting/Embedding+web+pages#Embed+a+YouTube+video)).