### PR TITLE
fix: allow publish property to be a string (ExplicitPublish)

### DIFF
--- a/quartz/plugins/filters/explicit.ts
+++ b/quartz/plugins/filters/explicit.ts
@@ -5,7 +5,7 @@ export const ExplicitPublish: QuartzFilterPlugin = () => ({
   shouldPublish(_ctx, [_tree, vfile]) {
     const publishProperty = vfile.data?.frontmatter?.publish ?? false
     const publishFlag = typeof publishProperty === "string"
-      ? publishProperty.toLowerCase() === 'true'
+      ? publishProperty.toLowerCase() === "true"
       : Boolean(publishProperty)
     return publishFlag
   },

--- a/quartz/plugins/filters/explicit.ts
+++ b/quartz/plugins/filters/explicit.ts
@@ -3,7 +3,10 @@ import { QuartzFilterPlugin } from "../types"
 export const ExplicitPublish: QuartzFilterPlugin = () => ({
   name: "ExplicitPublish",
   shouldPublish(_ctx, [_tree, vfile]) {
-    const publishFlag: boolean = vfile.data?.frontmatter?.publish ?? false
+    const publishProperty = vfile.data?.frontmatter?.publish ?? false
+    const publishFlag = typeof publishProperty === "string"
+      ? publishProperty.toLowerCase() === 'true'
+      : Boolean(publishProperty)
     return publishFlag
   },
 })

--- a/quartz/plugins/filters/explicit.ts
+++ b/quartz/plugins/filters/explicit.ts
@@ -4,9 +4,10 @@ export const ExplicitPublish: QuartzFilterPlugin = () => ({
   name: "ExplicitPublish",
   shouldPublish(_ctx, [_tree, vfile]) {
     const publishProperty = vfile.data?.frontmatter?.publish ?? false
-    const publishFlag = typeof publishProperty === "string"
-      ? publishProperty.toLowerCase() === "true"
-      : Boolean(publishProperty)
+    const publishFlag =
+      typeof publishProperty === "string"
+        ? publishProperty.toLowerCase() === "true"
+        : Boolean(publishProperty)
     return publishFlag
   },
 })


### PR DESCRIPTION
Previously, the ExplicitPublish filter would publish if the `publish` property was truthy.

The filter expects the `publish` property to be a boolean:

```yaml
---
publish: true
---
```

However, Obsidian only shows the above if you are viewing a page in “Source” mode.

If you are not in Source view, and you choose Three Dots Menu (...), “Add file property”, you will get a string, not a boolean. It seems likely that many users will do this and get:

```yaml
publish: "true"
```

Notice that `"true"` is a string, not the boolean value `true`. If the user changes this to `"false"`, the page will still be published:

```yaml
publish: "false"
```

That is because the string value `"false"` is truthy.

This PR does the following:

- Allows the `publish` property to be either a boolean or a string.
- If it’s a string, it’s considered `true` if the string is `"true"` (not case-sensitive; it will also work if it is `"True"`, `"TRUE"`, etc.)
- Guarantees that the returned value from `shouldPublish` is a `boolean` -- previously it could be any truthy value even though it was cast to `boolean`