### PR TITLE
Fixed broken RSS item's link

### DIFF
--- a/quartz/plugins/emitters/contentIndex.ts
+++ b/quartz/plugins/emitters/contentIndex.ts
@@ -48,12 +48,11 @@ function generateSiteMap(cfg: GlobalConfiguration, idx: ContentIndex): string {
 
 function generateRSSFeed(cfg: GlobalConfiguration, idx: ContentIndex, limit?: number): string {
   const base = cfg.baseUrl ?? ""
-  const root = `https://${base}`
 
   const createURLEntry = (slug: SimpleSlug, content: ContentDetails): string => `<item>
     <title>${escapeHTML(content.title)}</title>
-    <link>${joinSegments(root, encodeURI(slug))}</link>
-    <guid>${joinSegments(root, encodeURI(slug))}</guid>
+    <link>https://${joinSegments(base, encodeURI(slug))}</link>
+    <guid>https://${joinSegments(base, encodeURI(slug))}</guid>
     <description>${content.richContent ?? content.description}</description>
     <pubDate>${content.date?.toUTCString()}</pubDate>
   </item>`
@@ -78,7 +77,7 @@ function generateRSSFeed(cfg: GlobalConfiguration, idx: ContentIndex, limit?: nu
 <rss version="2.0">
     <channel>
       <title>${escapeHTML(cfg.pageTitle)}</title>
-      <link>${root}</link>
+      <link>https://${base}</link>
       <description>${!!limit ? `Last ${limit} notes` : "Recent notes"} on ${escapeHTML(
         cfg.pageTitle,
       )}</description>


### PR DESCRIPTION
Generated RSS item's link was broken like below, so I fixed it.

```diff
<item>
  <title>Explorer</title>
- <link>https:/quartz.jzhao.xyz/features/explorer</link>
+ <link>https://quartz.jzhao.xyz/features/explorer</link>
- <guid>https:/quartz.jzhao.xyz/features/explorer</guid>
+ <guid>https:/quartz.jzhao.xyz/features/explorer</guid>
  <description>Quartz features an explorer that allows you to navigate all files and folders on your site. It supports nested folders and is highly customizable. By default, it shows all folders and files on your page.</description>
  <pubDate>Sat, 13 Jan 2024 09:54:20 GMT</pubDate>
</item>
```