### PR TITLE
fix: rebuild errors on windows

### DIFF
--- a/quartz/build.ts
+++ b/quartz/build.ts
@@ -2,7 +2,6 @@ import sourceMapSupport from "source-map-support"
 sourceMapSupport.install(options)
 import path from "path"
 import { PerfTimer } from "./util/perf"
-import { rimraf } from "rimraf"
 import { isGitIgnored } from "globby"
 import chalk from "chalk"
 import { parseMarkdown } from "./processors/parse"
@@ -13,6 +12,7 @@ import { FilePath, joinSegments, slugifyFilePath } from "./util/path"
 import chokidar from "chokidar"
 import { ProcessedContent } from "./plugins/vfile"
 import { Argv, BuildCtx } from "./util/ctx"
+import { rmrf } from "./util/fs"
 import { glob, toPosixPath } from "./util/glob"
 import { trace } from "./util/trace"
 import { options } from "./util/sourcemap"
@@ -40,7 +40,7 @@ async function buildQuartz(argv: Argv, mut: Mutex, clientRefresh: () => void) {
 
   const release = await mut.acquire()
   perf.addEvent("clean")
-  await rimraf(output)
+  await rmrf(output)
   console.log(`Cleaned output directory \`${output}\` in ${perf.timeSince("clean")}`)
 
   perf.addEvent("glob")
@@ -145,7 +145,7 @@ async function startServing(
 
       // TODO: we can probably traverse the link graph to figure out what's safe to delete here
       // instead of just deleting everything
-      await rimraf(argv.output)
+      await rmrf(argv.output)
       await emitContent(ctx, filteredContent)
       console.log(chalk.green(`Done rebuilding in ${perf.timeSince()}`))
     } catch (err) {

--- a/quartz/cli/handlers.js
+++ b/quartz/cli/handlers.js
@@ -5,7 +5,6 @@ import chalk from "chalk"
 import { sassPlugin } from "esbuild-sass-plugin"
 import fs from "fs"
 import { intro, outro, select, text } from "@clack/prompts"
-import { rimraf } from "rimraf"
 import chokidar from "chokidar"
 import prettyBytes from "pretty-bytes"
 import { execSync, spawnSync } from "child_process"
@@ -21,6 +20,7 @@ import {
   gitPull,
   popContentFolder,
   stashContentFolder,
+  rmrf,
 } from "./helpers.js"
 import {
   UPSTREAM_NAME,
@@ -109,7 +109,7 @@ export async function handleCreate(argv) {
     if (contentStat.isSymbolicLink()) {
       await fs.promises.unlink(contentFolder)
     } else {
-      await rimraf(contentFolder)
+      await rmrf(contentFolder)
     }
   }
 

--- a/quartz/cli/helpers.js
+++ b/quartz/cli/helpers.js
@@ -3,6 +3,7 @@ import chalk from "chalk"
 import { contentCacheFolder } from "./constants.js"
 import { spawnSync } from "child_process"
 import fs from "fs"
+import { rimraf } from "rimraf"
 
 export function escapePath(fp) {
   return fp
@@ -51,4 +52,12 @@ export async function popContentFolder(contentFolder) {
     preserveTimestamps: true,
   })
   await fs.promises.rm(contentCacheFolder, { force: true, recursive: true })
+}
+
+export async function rmrf(path) {
+  if (os.platform() == "win32") {
+    return rimraf.windows(path)
+  } else {
+    return rimraf(path)
+  }
 }

--- a/quartz/util/fs.ts
+++ b/quartz/util/fs.ts
@@ -1,0 +1,13 @@
+import os from "os"
+import { rimraf, RimrafAsyncOptions } from "rimraf"
+
+export async function rmrf(
+  path: string | string[],
+  opt?: RimrafAsyncOptions | undefined,
+): Promise<boolean> {
+  if (os.platform() == "win32") {
+    return rimraf.windows(path, opt)
+  } else {
+    return rimraf(path, opt)
+  }
+}


### PR DESCRIPTION
This PR fixes https://github.com/jackyzha0/quartz/issues/644.

I get frequent rebuild errors when typing due to EPERM on Windows 10. Choosing the [windows implementation of rimraf](https://github.com/isaacs/rimraf#rimrafwindowsf-opts) seems to fix the problem.