### PR TITLE
feat: add 2 columns layout for medium size media

### DIFF
--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -94,9 +94,15 @@ a {
 
 .page {
   @media all and (max-width: $fullPageWidth) {
-    margin: 0 auto;
-    padding: 0 1rem;
     max-width: $pageWidth;
+    @media all and (min-width: $mediumPageWidth) {
+      margin-left: calc(calc(100vw - $mediumPageWidth) / 2 + $sidePanelWidth);
+    }
+
+    @media all and (max-width: $mediumPageWidth) {
+      margin: 0 auto;
+      padding: 0 1rem;
+    }
   }
 
   & article {
@@ -143,7 +149,18 @@ a {
       box-sizing: border-box;
       padding: 0 4rem;
       position: fixed;
-      @media all and (max-width: $fullPageWidth) {
+    }
+
+    & .sidebar.left {
+      left: calc(calc(100vw - $fullPageWidth) / 2);
+
+      @media all and (max-width: $fullPageWidth) and (min-width: $mediumPageWidth) {
+        left: calc(calc(100vw - $mediumPageWidth) / 2);
+      }
+
+      @media all and (max-width: $mediumPageWidth) {
+        gap: 0;
+        align-items: center;
         position: initial;
         flex-direction: row;
         padding: 0;
@@ -152,16 +169,15 @@ a {
       }
     }
 
-    & .sidebar.left {
-      left: calc(calc(100vw - $pageWidth) / 2 - $sidePanelWidth);
-      @media all and (max-width: $fullPageWidth) {
-        gap: 0;
-        align-items: center;
-      }
-    }
-
     & .sidebar.right {
       right: calc(calc(100vw - $pageWidth) / 2 - $sidePanelWidth);
+      @media all and (max-width: $fullPageWidth) {
+        position: initial;
+        flex-direction: row;
+        padding: 0;
+        width: initial;
+        margin-top: 2rem;
+      }
       & > * {
         @media all and (max-width: $fullPageWidth) {
           flex: 1;
@@ -184,6 +200,7 @@ a {
     margin-left: auto;
     margin-right: auto;
     width: $pageWidth;
+
     @media all and (max-width: $fullPageWidth) {
       width: initial;
       margin-left: 0;

--- a/quartz/styles/variables.scss
+++ b/quartz/styles/variables.scss
@@ -4,3 +4,4 @@ $tabletBreakpoint: 1200px;
 $sidePanelWidth: 380px;
 $topSpacing: 6rem;
 $fullPageWidth: $pageWidth + 2 * $sidePanelWidth;
+$mediumPageWidth: $pageWidth + $sidePanelWidth;


### PR DESCRIPTION
Add a 2 columns layout for medium size media (between 1510px and 1130px). In this layout, `right` collapses under `center`. Below is a simple illustration.
```
-----------------
| left | center |
|      | right  |
-----------------
```

Close https://github.com/jackyzha0/quartz/issues/455