### PR TITLE
feat: External link icons

### DIFF
--- a/quartz/plugins/transformers/links.ts
+++ b/quartz/plugins/transformers/links.ts
@@ -55,7 +55,29 @@ export const CrawlLinks: QuartzTransformerPlugin<Partial<Options> | undefined> =
               ) {
                 let dest = node.properties.href as RelativeURL
                 const classes = (node.properties.className ?? []) as string[]
-                classes.push(isAbsoluteUrl(dest) ? "external" : "internal")
+                const isExternal = isAbsoluteUrl(dest)
+                classes.push(isExternal ? "external" : "internal")
+
+                if (isExternal) {
+                  node.children.push({
+                    type: "element",
+                    tagName: "svg",
+                    properties: {
+                      class: "external-icon",
+                      viewBox: "0 0 512 512",
+                    },
+                    children: [
+                      {
+                        type: "element",
+                        tagName: "path",
+                        properties: {
+                          d: "M320 0H288V64h32 82.7L201.4 265.4 178.7 288 224 333.3l22.6-22.6L448 109.3V192v32h64V192 32 0H480 320zM32 32H0V64 480v32H32 456h32V480 352 320H424v32 96H64V96h96 32V32H160 32z",
+                        },
+                        children: [],
+                      },
+                    ],
+                  })
+                }
 
                 // Check if the link has alias text
                 if (

--- a/quartz/plugins/transformers/links.ts
+++ b/quartz/plugins/transformers/links.ts
@@ -21,6 +21,7 @@ interface Options {
   prettyLinks: boolean
   openLinksInNewTab: boolean
   lazyLoad: boolean
+  externalLinkIcon: boolean
 }
 
 const defaultOptions: Options = {
@@ -28,6 +29,7 @@ const defaultOptions: Options = {
   prettyLinks: true,
   openLinksInNewTab: false,
   lazyLoad: false,
+  externalLinkIcon: true,
 }
 
 export const CrawlLinks: QuartzTransformerPlugin<Partial<Options> | undefined> = (userOpts) => {
@@ -58,7 +60,7 @@ export const CrawlLinks: QuartzTransformerPlugin<Partial<Options> | undefined> =
                 const isExternal = isAbsoluteUrl(dest)
                 classes.push(isExternal ? "external" : "internal")
 
-                if (isExternal) {
+                if (isExternal && opts.externalLinkIcon) {
                   node.children.push({
                     type: "element",
                     tagName: "svg",

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -59,6 +59,7 @@ a {
   text-decoration: none;
   transition: color 0.2s ease;
   color: var(--secondary);
+  display: inline-block;
 
   &:hover {
     color: var(--tertiary) !important;
@@ -74,6 +75,16 @@ a {
       background-color: none;
       border-radius: 0;
       padding: 0;
+    }
+  }
+
+  &.external .external-icon {
+    text-align: bottom;
+    height: 1ex;
+    margin-left: 0.15em;
+
+    > path {
+      fill: var(--dark);
     }
   }
 }

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -79,9 +79,9 @@ a {
   }
 
   &.external .external-icon {
-    text-align: bottom;
+    vertical-align: bottom;
     height: 1ex;
-    margin-left: 0.15em;
+    margin: 0 0.15em;
 
     > path {
       fill: var(--dark);


### PR DESCRIPTION
## Fixes #690

I've added support for displaying link icons. It shows a [Font Awesome Icon](https://fontawesome.com/icons/arrow-up-right-from-square?f=sharp&s=solid) next to all external links, when the `externalLinkIcon` option is set to true, the default.

## Screenshots
![Light Mode](https://github.com/jackyzha0/quartz/assets/146651411/576b8cf3-88be-4301-a603-3195e490c3ca) ![Dark Mode](https://github.com/jackyzha0/quartz/assets/146651411/5a798101-3938-4038-8792-98b2ccca8f48) ![Light Mode](https://github.com/jackyzha0/quartz/assets/146651411/a0639e79-04cc-48a1-be30-548030fcd7d8) ![Dark Mode](https://github.com/jackyzha0/quartz/assets/146651411/9c31220a-0df7-4280-b8ec-2049e8701e89)

## Demo
[Screen recording 2024-01-16 01.10.05.webm](https://github.com/jackyzha0/quartz/assets/146651411/b95601f0-441e-49cf-9f21-a263c600df56)