### PR TITLE
fix: external link icon shouldn't be vertical aligned

### DIFF
--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -79,7 +79,6 @@ a {
   }
 
   &.external .external-icon {
-    vertical-align: bottom;
     height: 1ex;
     margin: 0 0.15em;
 


### PR DESCRIPTION
Turns out `vertical-align: bottom` wasn't supposed to be there.