### PR TITLE
fix: use joinSegments for `contentIndex.json` file path

### DIFF
--- a/quartz/plugins/emitters/contentIndex.ts
+++ b/quartz/plugins/emitters/contentIndex.ts
@@ -133,7 +133,7 @@ export const ContentIndex: QuartzEmitterPlugin<Partial<Options>> = (opts) => {
         )
       }
 
-      const fp = path.join("static", "contentIndex") as FullSlug
+      const fp = joinSegments("static", "contentIndex") as FullSlug
       const simplifiedIndex = Object.fromEntries(
         Array.from(linkIndex).map(([slug, content]) => {
           // remove description and from content index as nothing downstream


### PR DESCRIPTION
contentIndex.json is the only file path that has a backslash instead of a forward slash in the emit process. This doesn't affect correctness and is a minor change just for consistency.

Before
![before](https://github.com/jackyzha0/quartz/assets/15871468/2dc5ad83-64ba-4fdb-ae46-b491c0cebceb)

After
![after](https://github.com/jackyzha0/quartz/assets/15871468/6f1220f5-3beb-4317-9e5c-f903572eb14b)
