### PR TITLE
feat: Handling cssclasses properties in Quartz

### DIFF
--- a/quartz/components/pages/Content.tsx
+++ b/quartz/components/pages/Content.tsx
@@ -1,6 +1,5 @@
 import { htmlToJsx } from "../../util/jsx"
 import { QuartzComponentConstructor, QuartzComponentProps } from "../types"
-import assert from "node:assert"
 
 function Content({ fileData, tree }: QuartzComponentProps) {
   const content = htmlToJsx(fileData.filePath!, tree)

--- a/quartz/components/pages/Content.tsx
+++ b/quartz/components/pages/Content.tsx
@@ -1,9 +1,14 @@
 import { htmlToJsx } from "../../util/jsx"
 import { QuartzComponentConstructor, QuartzComponentProps } from "../types"
+import assert from 'node:assert';
 
 function Content({ fileData, tree }: QuartzComponentProps) {
-  const content = htmlToJsx(fileData.filePath!, tree)
-  return <article class="popover-hint">{content}</article>
+  const content = htmlToJsx(fileData.filePath!, tree);
+  let CSSclass: string[] = fileData.frontmatter?.cssclasses || [];
+  CSSclass.push("popover-hint");
+  const finalClass = CSSclass.join(" ");
+  //const  = "popover-hint"+fileData.frontmatter?.cssclasses
+  return <article class={finalClass}>{content}</article>
 }
 
 export default (() => Content) satisfies QuartzComponentConstructor

--- a/quartz/components/pages/Content.tsx
+++ b/quartz/components/pages/Content.tsx
@@ -4,11 +4,9 @@ import assert from "node:assert"
 
 function Content({ fileData, tree }: QuartzComponentProps) {
   const content = htmlToJsx(fileData.filePath!, tree)
-  let CSSclass: string[] = fileData.frontmatter?.cssclasses || []
-  CSSclass.push("popover-hint")
-  const finalClass = CSSclass.join(" ")
-  //const  = "popover-hint"+fileData.frontmatter?.cssclasses
-  return <article class={finalClass}>{content}</article>
+  const classes: string[] = fileData.frontmatter?.cssclasses ?? []
+  const classString = ["popover-hint", ...classes].join(" ")
+  return <article class={classString}>{content}</article>
 }
 
 export default (() => Content) satisfies QuartzComponentConstructor

--- a/quartz/components/pages/Content.tsx
+++ b/quartz/components/pages/Content.tsx
@@ -1,12 +1,12 @@
 import { htmlToJsx } from "../../util/jsx"
 import { QuartzComponentConstructor, QuartzComponentProps } from "../types"
-import assert from 'node:assert';
+import assert from "node:assert"
 
 function Content({ fileData, tree }: QuartzComponentProps) {
-  const content = htmlToJsx(fileData.filePath!, tree);
-  let CSSclass: string[] = fileData.frontmatter?.cssclasses || [];
-  CSSclass.push("popover-hint");
-  const finalClass = CSSclass.join(" ");
+  const content = htmlToJsx(fileData.filePath!, tree)
+  let CSSclass: string[] = fileData.frontmatter?.cssclasses || []
+  CSSclass.push("popover-hint")
+  const finalClass = CSSclass.join(" ")
   //const  = "popover-hint"+fileData.frontmatter?.cssclasses
   return <article class={finalClass}>{content}</article>
 }


### PR DESCRIPTION
As [Obsidian as some default properties](https://help.obsidian.md/Editing+and+formatting/Properties#Default+properties) i think quartz should handle them.

Quartz handling |Property |Description 
--- | -- | --
✔️ | tags |	See [Tags](https://help.obsidian.md/Editing+and+formatting/Tags).
✔️ | aliases |	See [Aliases](https://help.obsidian.md/Linking+notes+and+files/Aliases).
✔️ | description | Description for social media link
✔️ | publish | Select notes to publish. (Quartz handle this with [private page](https://quartz.jzhao.xyz/features/private-pages) )

## Properties that this PR should enable
[✔️](https://github.com/jackyzha0/quartz/commit/8eeb0fe735c6456694506b8f54fd8e6f7dd8e48d) | cssclasses |	Allows you to style individual notes using [CSS snippets](https://help.obsidian.md/Extending+Obsidian/CSS+snippets).
🔴 | permalink | If someone visits a note using the original URL, they'll be automatically redirected to the permalink.
🔴 | image/cover | custom image for the link preview
