### PR TITLE
feat: Emit custom event when theme changes

### DIFF
--- a/docs/features/darkmode.md
+++ b/docs/features/darkmode.md
@@ -12,3 +12,12 @@ Quartz supports darkmode out of the box that respects the user's theme preferenc
 - Component: `quartz/components/Darkmode.tsx`
 - Style: `quartz/components/styles/darkmode.scss`
 - Script: `quartz/components/scripts/darkmode.inline.ts`
+
+You can also listen to the `themechange` event to perform any custom logic when the theme changes.
+
+```js
+document.addEventListener("themechange", (e) => {
+  console.log("Theme changed to " + e.detail.theme) // either "light" or "dark"
+  // your logic here
+})
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ declare module "*.scss" {
 // dom custom event
 interface CustomEventMap {
   nav: CustomEvent<{ url: FullSlug }>
+  themechange: CustomEvent<{ theme: "light" | "dark" }>
 }
 
 declare const fetchData: Promise<ContentIndex>

--- a/quartz/components/scripts/darkmode.inline.ts
+++ b/quartz/components/scripts/darkmode.inline.ts
@@ -2,15 +2,19 @@ const userPref = window.matchMedia("(prefers-color-scheme: light)").matches ? "l
 const currentTheme = localStorage.getItem("theme") ?? userPref
 document.documentElement.setAttribute("saved-theme", currentTheme)
 
+const emitThemeChangeEvent = (theme: "light" | "dark") => {
+  const event = new CustomEvent("themechange", {
+    detail: { url: document.body.dataset.slug, theme: theme },
+  })
+  document.dispatchEvent(event)
+}
+
 document.addEventListener("nav", () => {
   const switchTheme = (e: any) => {
-    if (e.target.checked) {
-      document.documentElement.setAttribute("saved-theme", "dark")
-      localStorage.setItem("theme", "dark")
-    } else {
-      document.documentElement.setAttribute("saved-theme", "light")
-      localStorage.setItem("theme", "light")
-    }
+    const newTheme = e.target.checked ? "dark" : "light"
+    document.documentElement.setAttribute("saved-theme", newTheme)
+    localStorage.setItem("theme", newTheme)
+    emitThemeChangeEvent(newTheme)
   }
 
   // Darkmode toggle
@@ -28,5 +32,6 @@ document.addEventListener("nav", () => {
     document.documentElement.setAttribute("saved-theme", newTheme)
     localStorage.setItem("theme", newTheme)
     toggleSwitch.checked = e.matches
+    emitThemeChangeEvent(newTheme)
   })
 })

--- a/quartz/components/scripts/darkmode.inline.ts
+++ b/quartz/components/scripts/darkmode.inline.ts
@@ -3,8 +3,8 @@ const currentTheme = localStorage.getItem("theme") ?? userPref
 document.documentElement.setAttribute("saved-theme", currentTheme)
 
 const emitThemeChangeEvent = (theme: "light" | "dark") => {
-  const event = new CustomEvent("themechange", {
-    detail: { url: document.body.dataset.slug, theme: theme },
+  const event: CustomEventMap["themechange"] = new CustomEvent("themechange", {
+    detail: { theme },
   })
   document.dispatchEvent(event)
 }


### PR DESCRIPTION
Users/plugin writers can now listen to theme changes, either from system-wide preference or quartz button click. Eg:
```js
document.addEventListener("themechange", (e) => {
  console.log("Theme changed to " + e.detail.theme)
})
```