### PR TITLE
feat: Enable custom callout

### DIFF
--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -106,9 +106,13 @@ const calloutMapping: Record<string, keyof typeof callouts> = {
   cite: "quote",
 }
 
+/**
+ *
+ *
+ ********************************/
 function canonicalizeCallout(calloutName: string): keyof typeof callouts {
   let callout = calloutName.toLowerCase() as keyof typeof calloutMapping
-  return calloutMapping[callout] ?? "note"
+  return calloutMapping[callout] ?? calloutName
 }
 
 export const externalLinkRegex = /^https?:\/\//i
@@ -431,7 +435,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
                   value: `<div
                   class="callout-title"
                 >
-                  <div class="callout-icon">${callouts[calloutType]}</div>
+                  <div class="callout-icon">${callouts[calloutType] ?? callouts.note}</div>
                   <div class="callout-title-inner">${title}</div>
                   ${collapse ? toggleIcon : ""}
                 </div>`,
@@ -457,7 +461,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
                 node.data = {
                   hProperties: {
                     ...(node.data?.hProperties ?? {}),
-                    className: `callout ${collapse ? "is-collapsible" : ""} ${
+                    className: `callout ${calloutType} ${collapse ? "is-collapsible" : ""} ${
                       defaultState === "collapsed" ? "is-collapsed" : ""
                     }`,
                     "data-callout": calloutType,

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -108,7 +108,7 @@ const calloutMapping: Record<string, keyof typeof callouts> = {
 
 function canonicalizeCallout(calloutName: string): keyof typeof callouts {
   let callout = calloutName.toLowerCase() as keyof typeof calloutMapping
-  //if callout is not recognized, make it a custom one
+  // if callout is not recognized, make it a custom one
   return calloutMapping[callout] ?? calloutName
 }
 

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -106,10 +106,6 @@ const calloutMapping: Record<string, keyof typeof callouts> = {
   cite: "quote",
 }
 
-/**
- *
- *
- ********************************/
 function canonicalizeCallout(calloutName: string): keyof typeof callouts {
   let callout = calloutName.toLowerCase() as keyof typeof calloutMapping
   //if callout is not recognized, make it a custom one

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -112,6 +112,7 @@ const calloutMapping: Record<string, keyof typeof callouts> = {
  ********************************/
 function canonicalizeCallout(calloutName: string): keyof typeof callouts {
   let callout = calloutName.toLowerCase() as keyof typeof calloutMapping
+  //if callout is not recognized, make it a custom one
   return calloutMapping[callout] ?? calloutName
 }
 
@@ -435,7 +436,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
                   value: `<div
                   class="callout-title"
                 >
-                  <div class="callout-icon">${callouts[calloutType] ?? callouts.note}</div>
+                  <div class="callout-icon">${callouts[calloutType] ?? callouts.note}</div> 
                   <div class="callout-title-inner">${title}</div>
                   ${collapse ? toggleIcon : ""}
                 </div>`,

--- a/quartz/styles/callouts.scss
+++ b/quartz/styles/callouts.scss
@@ -13,7 +13,7 @@
     margin-top: 0;
   }
 
-  &[data-callout="note"] {
+  &[data-callout] {
     --color: #448aff;
     --border: #448aff44;
     --bg: #448aff10;


### PR DESCRIPTION
[As reported to discord here](https://discord.com/channels/927628110009098281/1198704931167809557), customs callouts are not replicated on quartz. 
I made custom callouts defaulted to note css, and propagate calloutType to class and data.