### PR TITLE
feat: Feature/custom callout icon

### DIFF
--- a/docs/features/callouts.md
+++ b/docs/features/callouts.md
@@ -24,7 +24,22 @@ See [documentation on supported types and syntax here](https://help.obsidian.md
 ## Customization
 
 - Disable callouts: simply pass `callouts: false` to the plugin: `Plugin.ObsidianFlavoredMarkdown({ callouts: false })`
-- Editing icons: `quartz/plugins/transformers/ofm.ts`
+- Editing icons: `quartz\styles\callouts.scss`
+
+### Add custom callouts
+By default, custom callouts are handled by applying the "note" style. To make fancy ones, you have to add thes lines to `quartz\styles\custom.scss`
+```css
+.callout {
+  &[data-callout="custom"] {
+    --color: #customcolor;
+    --border: #custombordercolor;
+    --bg: #custombg;
+    --callout-icon: url('data:image/svg+xml; utf8, <custom formatted svg>'); //SVG icon code
+
+  }
+```
+> [!warning]
+> Don't forget to parse SVG code for url. You can use tools like [this one](https://yoksel.github.io/url-encoder/) F
 
 ## Showcase
 

--- a/docs/features/callouts.md
+++ b/docs/features/callouts.md
@@ -41,7 +41,7 @@ By default, custom callouts are handled by applying the `note` style. To make fa
 ```
 
 > [!warning]
-> Don't forget to ensure that the SVG is URL encoded before putting it in the CSS. You can use tools like [this one](https://yoksel.github.io/url-encoder/)
+> Don't forget to ensure that the SVG is URL encoded before putting it in the CSS. You can use tools like [this one](https://yoksel.github.io/url-encoder/) to help you do that.
 
 ## Showcase
 

--- a/docs/features/callouts.md
+++ b/docs/features/callouts.md
@@ -41,7 +41,7 @@ By default, custom callouts are handled by applying the `note` style. To make fa
 ```
 
 > [!warning]
-> Don't forget to parse SVG code for url. You can use tools like [this one](https://yoksel.github.io/url-encoder/) F
+> Don't forget to ensure that the SVG is URL encoded before putting it in the CSS. You can use tools like [this one](https://yoksel.github.io/url-encoder/)
 
 ## Showcase
 

--- a/docs/features/callouts.md
+++ b/docs/features/callouts.md
@@ -30,17 +30,15 @@ See [documentation on supported types and syntax here](https://help.obsidian.md
 
 By default, custom callouts are handled by applying the `note` style. To make fancy ones, you have to add these lines to `custom.scss`.
 
-```scss title="`quartz/styles/custom.scss"  
-.callout {  
- &[data-callout="custom"] {  
- --color: #customcolor;  
- --border: #custombordercolor;  
- --bg: #custombg;  
+```scss title="quartz/styles/custom.scss"
+.callout {
+ &[data-callout="custom"] {
+ --color: #customcolor;
+ --border: #custombordercolor;
+ --bg: #custombg;
  --callout-icon: url('data:image/svg+xml; utf8, <custom formatted svg>'); //SVG icon code
 }
-
 ```
-
 
 > [!warning]
 > Don't forget to parse SVG code for url. You can use tools like [this one](https://yoksel.github.io/url-encoder/) F
@@ -103,4 +101,3 @@ By default, custom callouts are handled by applying the `note` style. To make fa
 > [!quote] Quote
 >
 > Aliases: quote, cite
-```

--- a/docs/features/callouts.md
+++ b/docs/features/callouts.md
@@ -24,20 +24,24 @@ See [documentation on supported types and syntax here](https://help.obsidian.md
 ## Customization
 
 - Disable callouts: simply pass `callouts: false` to the plugin: `Plugin.ObsidianFlavoredMarkdown({ callouts: false })`
-- Editing icons: `quartz\styles\callouts.scss`
+- Editing icons: `quartz/styles/callouts.scss`
 
 ### Add custom callouts
-By default, custom callouts are handled by applying the "note" style. To make fancy ones, you have to add thes lines to `quartz\styles\custom.scss`
-```css
-.callout {
-  &[data-callout="custom"] {
-    --color: #customcolor;
-    --border: #custombordercolor;
-    --bg: #custombg;
-    --callout-icon: url('data:image/svg+xml; utf8, <custom formatted svg>'); //SVG icon code
 
-  }
+By default, custom callouts are handled by applying the `note` style. To make fancy ones, you have to add these lines to `custom.scss`.
+
+```scss title="`quartz/styles/custom.scss"  
+.callout {  
+ &[data-callout="custom"] {  
+ --color: #customcolor;  
+ --border: #custombordercolor;  
+ --bg: #custombg;  
+ --callout-icon: url('data:image/svg+xml; utf8, <custom formatted svg>'); //SVG icon code
+}
+
 ```
+
+
 > [!warning]
 > Don't forget to parse SVG code for url. You can use tools like [this one](https://yoksel.github.io/url-encoder/) F
 
@@ -99,3 +103,4 @@ By default, custom callouts are handled by applying the "note" style. To make fa
 > [!quote] Quote
 >
 > Aliases: quote, cite
+```

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -76,6 +76,7 @@ const calloutMapping = {
 
 function canonicalizeCallout(calloutName: string): keyof typeof calloutMapping {
   const normalizedCallout = calloutName.toLowerCase() as keyof typeof calloutMapping
+  // if callout is not recognized, make it a custom one
   return calloutMapping[normalizedCallout] ?? calloutName
 }
 

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -401,7 +401,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
                 }
                 const title = mdastToHtml(titleNode)
 
-                const toggleIcon = `<div class="fold"></div>`
+                const toggleIcon = `<div class="fold-callout-icon"></div>`
 
                 const titleHtml: Html = {
                   type: "html",

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -44,56 +44,42 @@ const defaultOptions: Options = {
   enableVideoEmbed: true,
 }
 
-const callouts = {
-  note: "note",
-  abstract: "abstract",
-  info: "info",
-  todo: "todo",
-  tip: "tip",
-  success: "success",
-  question: "question",
-  warning: "warning",
-  failure: "failure",
-  danger: "danger",
-  bug: "bug",
-  example: "example",
-  quote: "quote",
+enum callouts {
+  note = "note",
+  abstract = "abstract",
+  summary = "abstract",
+  tldr = "abstract",
+  info = "info",
+  todo = "todo",
+  tip = "tip",
+  hint = "tip",
+  important = "tip",
+  success = "success",
+  check = "success",
+  done = "success",
+  question = "question",
+  help = "question",
+  faq = "question",
+  warning = "warning",
+  attention = "warning",
+  caution = "warning",
+  failure = "failure",
+  missing = "failure",
+  fail = "failure",
+  danger = "danger",
+  error = "danger",
+  bug = "bug",
+  example = "example",
+  quote = "quote",
+  cite = "quote",
 }
 
-const calloutMapping: Record<string, keyof typeof callouts> = {
-  note: "note",
-  abstract: "abstract",
-  summary: "abstract",
-  tldr: "abstract",
-  info: "info",
-  todo: "todo",
-  tip: "tip",
-  hint: "tip",
-  important: "tip",
-  success: "success",
-  check: "success",
-  done: "success",
-  question: "question",
-  help: "question",
-  faq: "question",
-  warning: "warning",
-  attention: "warning",
-  caution: "warning",
-  failure: "failure",
-  missing: "failure",
-  fail: "failure",
-  danger: "danger",
-  error: "danger",
-  bug: "bug",
-  example: "example",
-  quote: "quote",
-  cite: "quote",
-}
+type calloutMapping = `${callouts}`
 
 function canonicalizeCallout(calloutName: string): keyof typeof callouts {
-  let callout = calloutName.toLowerCase() as keyof typeof calloutMapping
+  let callout = calloutName.toLowerCase() as calloutMapping
   // if callout is not recognized, make it a custom one
-  return calloutMapping[callout] ?? calloutName
+  return callout ?? calloutName
 }
 
 export const externalLinkRegex = /^https?:\/\//i
@@ -400,9 +386,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
               const match = firstLine.match(calloutRegex)
               if (match && match.input) {
                 const [calloutDirective, typeString, collapseChar] = match
-                const calloutType = canonicalizeCallout(
-                  typeString.toLowerCase() as keyof typeof calloutMapping,
-                )
+                const calloutType = canonicalizeCallout(typeString.toLowerCase() as calloutMapping)
                 const collapse = collapseChar === "+" || collapseChar === "-"
                 const defaultState = collapseChar === "-" ? "collapsed" : "expanded"
                 const titleContent =

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -44,40 +44,40 @@ const defaultOptions: Options = {
   enableVideoEmbed: true,
 }
 
-enum callouts {
-  note = "note",
-  abstract = "abstract",
-  summary = "abstract",
-  tldr = "abstract",
-  info = "info",
-  todo = "todo",
-  tip = "tip",
-  hint = "tip",
-  important = "tip",
-  success = "success",
-  check = "success",
-  done = "success",
-  question = "question",
-  help = "question",
-  faq = "question",
-  warning = "warning",
-  attention = "warning",
-  caution = "warning",
-  failure = "failure",
-  missing = "failure",
-  fail = "failure",
-  danger = "danger",
-  error = "danger",
-  bug = "bug",
-  example = "example",
-  quote = "quote",
-  cite = "quote",
+const calloutMapping: Record<string, string> = {
+  note: "note",
+  abstract: "abstract",
+  summary: "abstract",
+  tldr: "abstract",
+  info: "info",
+  todo: "todo",
+  tip: "tip",
+  hint: "tip",
+  important: "tip",
+  success: "success",
+  check: "success",
+  done: "success",
+  question: "question",
+  help: "question",
+  faq: "question",
+  warning: "warning",
+  attention: "warning",
+  caution: "warning",
+  failure: "failure",
+  missing: "failure",
+  fail: "failure",
+  danger: "danger",
+  error: "danger",
+  bug: "bug",
+  example: "example",
+  quote: "quote",
+  cite: "quote",
 }
 
-function canonicalizeCallout(calloutName: string): string {
+function canonicalizeCallout(calloutName: string): keyof typeof calloutMapping {
   const normalizedCalloutName = calloutName.toLowerCase()
-  if (normalizedCalloutName in callouts) {
-    return (callouts as Record<string, string>)[normalizedCalloutName]
+  if (normalizedCalloutName in calloutMapping) {
+    return calloutMapping[normalizedCalloutName]
   }
   // if callout is not recognized, make it a custom one
   return calloutName

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -44,36 +44,20 @@ const defaultOptions: Options = {
   enableVideoEmbed: true,
 }
 
-const icons = {
-  infoIcon: `<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="16" x2="12" y2="12"></line><line x1="12" y1="8" x2="12.01" y2="8"></line></svg>`,
-  pencilIcon: `<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="2" x2="22" y2="6"></line><path d="M7.5 20.5 19 9l-4-4L3.5 16.5 2 22z"></path></svg>`,
-  clipboardListIcon: `<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path><path d="M12 11h4"></path><path d="M12 16h4"></path><path d="M8 11h.01"></path><path d="M8 16h.01"></path></svg>`,
-  checkCircleIcon: `<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z"></path><path d="m9 12 2 2 4-4"></path></svg>`,
-  flameIcon: `<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z"></path></svg>`,
-  checkIcon: `<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>`,
-  helpCircleIcon: `<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>`,
-  alertTriangleIcon: `<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>`,
-  xIcon: `<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>`,
-  zapIcon: `<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>`,
-  bugIcon: `<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="8" height="14" x="8" y="6" rx="4"></rect><path d="m19 7-3 2"></path><path d="m5 7 3 2"></path><path d="m19 19-3-2"></path><path d="m5 19 3-2"></path><path d="M20 13h-4"></path><path d="M4 13h4"></path><path d="m10 4 1 2"></path><path d="m14 4-1 2"></path></svg>`,
-  listIcon: `<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"></line><line x1="8" y1="12" x2="21" y2="12"></line><line x1="8" y1="18" x2="21" y2="18"></line><line x1="3" y1="6" x2="3.01" y2="6"></line><line x1="3" y1="12" x2="3.01" y2="12"></line><line x1="3" y1="18" x2="3.01" y2="18"></line></svg>`,
-  quoteIcon: `<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 21c3 0 7-1 7-8V5c0-1.25-.756-2.017-2-2H4c-1.25 0-2 .75-2 1.972V11c0 1.25.75 2 2 2 1 0 1 0 1 1v1c0 1-1 2-2 2s-1 .008-1 1.031V20c0 1 0 1 1 1z"></path><path d="M15 21c3 0 7-1 7-8V5c0-1.25-.757-2.017-2-2h-4c-1.25 0-2 .75-2 1.972V11c0 1.25.75 2 2 2h.75c0 2.25.25 4-2.75 4v3c0 1 0 1 1 1z"></path></svg>`,
-}
-
 const callouts = {
-  note: icons.pencilIcon,
-  abstract: icons.clipboardListIcon,
-  info: icons.infoIcon,
-  todo: icons.checkCircleIcon,
-  tip: icons.flameIcon,
-  success: icons.checkIcon,
-  question: icons.helpCircleIcon,
-  warning: icons.alertTriangleIcon,
-  failure: icons.xIcon,
-  danger: icons.zapIcon,
-  bug: icons.bugIcon,
-  example: icons.listIcon,
-  quote: icons.quoteIcon,
+  note: "note",
+  abstract: "abstract",
+  info: "info",
+  todo: "todo",
+  tip: "tip",
+  success: "success",
+  question: "question",
+  warning: "warning",
+  failure: "failure",
+  danger: "danger",
+  bug: "bug",
+  example: "example",
+  quote: "quote",
 }
 
 const calloutMapping: Record<string, keyof typeof callouts> = {

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -401,9 +401,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
                 }
                 const title = mdastToHtml(titleNode)
 
-                const toggleIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fold">
-                  <polyline points="6 9 12 15 18 9"></polyline>
-                </svg>`
+                const toggleIcon = `<div class="fold"></div>`
 
                 const titleHtml: Html = {
                   type: "html",

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -410,7 +410,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
                   value: `<div
                   class="callout-title"
                 >
-                  <div class="callout-icon">${callouts[calloutType] ?? callouts.note}</div>
+                  <div class="callout-icon"></div>
                   <div class="callout-title-inner">${title}</div>
                   ${collapse ? toggleIcon : ""}
                 </div>`,

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -44,7 +44,7 @@ const defaultOptions: Options = {
   enableVideoEmbed: true,
 }
 
-const calloutMapping: Record<string, string> = {
+const calloutMapping = {
   note: "note",
   abstract: "abstract",
   summary: "abstract",
@@ -72,15 +72,11 @@ const calloutMapping: Record<string, string> = {
   example: "example",
   quote: "quote",
   cite: "quote",
-}
+} as const
 
 function canonicalizeCallout(calloutName: string): keyof typeof calloutMapping {
-  const normalizedCalloutName = calloutName.toLowerCase()
-  if (normalizedCalloutName in calloutMapping) {
-    return calloutMapping[normalizedCalloutName]
-  }
-  // if callout is not recognized, make it a custom one
-  return calloutName
+  const normalizedCallout = calloutName.toLowerCase() as keyof typeof calloutMapping
+  return calloutMapping[normalizedCallout] ?? calloutName
 }
 
 export const externalLinkRegex = /^https?:\/\//i

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -74,12 +74,13 @@ enum callouts {
   cite = "quote",
 }
 
-type calloutMapping = `${callouts}`
-
-function canonicalizeCallout(calloutName: string): keyof typeof callouts {
-  let callout = calloutName.toLowerCase() as calloutMapping
+function canonicalizeCallout(calloutName: string): string {
+  const normalizedCalloutName = calloutName.toLowerCase()
+  if (normalizedCalloutName in callouts) {
+    return (callouts as Record<string, string>)[normalizedCalloutName]
+  }
   // if callout is not recognized, make it a custom one
-  return callout ?? calloutName
+  return calloutName
 }
 
 export const externalLinkRegex = /^https?:\/\//i
@@ -386,7 +387,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
               const match = firstLine.match(calloutRegex)
               if (match && match.input) {
                 const [calloutDirective, typeString, collapseChar] = match
-                const calloutType = canonicalizeCallout(typeString.toLowerCase() as calloutMapping)
+                const calloutType = canonicalizeCallout(typeString.toLowerCase())
                 const collapse = collapseChar === "+" || collapseChar === "-"
                 const defaultState = collapseChar === "-" ? "collapsed" : "expanded"
                 const titleContent =

--- a/quartz/styles/callouts.scss
+++ b/quartz/styles/callouts.scss
@@ -26,6 +26,7 @@
   --callout-icon-bug: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="8" height="14" x="8" y="6" rx="4"></rect><path d="m19 7-3 2"></path><path d="m5 7 3 2"></path><path d="m19 19-3-2"></path><path d="m5 19 3-2"></path><path d="M20 13h-4"></path><path d="M4 13h4"></path><path d="m10 4 1 2"></path><path d="m14 4-1 2"></path></svg>');
   --callout-icon-example: url('data:image/svg+xml; utf8,<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"></line><line x1="8" y1="12" x2="21" y2="12"></line><line x1="8" y1="18" x2="21" y2="18"></line><line x1="3" y1="6" x2="3.01" y2="6"></line><line x1="3" y1="12" x2="3.01" y2="12"></line><line x1="3" y1="18" x2="3.01" y2="18"></line></svg> ');
   --callout-icon-quote: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 21c3 0 7-1 7-8V5c0-1.25-.756-2.017-2-2H4c-1.25 0-2 .75-2 1.972V11c0 1.25.75 2 2 2 1 0 1 0 1 1v1c0 1-1 2-2 2s-1 .008-1 1.031V20c0 1 0 1 1 1z"></path><path d="M15 21c3 0 7-1 7-8V5c0-1.25-.757-2.017-2-2h-4c-1.25 0-2 .75-2 1.972V11c0 1.25.75 2 2 2h.75c0 2.25.25 4-2.75 4v3c0 1 0 1 1 1z"></path></svg>');
+  --callout-icon-fold: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"%3E%3Cpolyline points="6 9 12 15 18 9"%3E%3C/polyline%3E%3C/svg%3E');
 
   &[data-callout] {
     --color: #448aff;
@@ -134,29 +135,31 @@
     cursor: pointer;
     width: var(--icon-size);
     height: var(--icon-size);
+    --callout-icon: var(--callout-icon-fold)
   }
 
   & > .callout-title-inner > p {
     color: var(--color);
     margin: 0;
   }
-}
 
-.callout-icon {
-  width: var(--icon-size);
-  height: var(--icon-size);
-  //flex: 0 0 18px;
+  .callout-icon,
+  & .fold {
+    width: var(--icon-size);
+    height: var(--icon-size);
+    //flex: 0 0 18px;
 
-  // icon support
-  background-size: var(--icon-size) var(--icon-size);
-  background-position: center;
-  background-color: var(--color);
-  mask-image: var(--callout-icon);
-  mask-size: var(--icon-size) var(--icon-size);
-  mask-position: center;
-  mask-repeat: no-repeat;
-}
+    // icon support
+    background-size: var(--icon-size) var(--icon-size);
+    background-position: center;
+    background-color: var(--color);
+    mask-image: var(--callout-icon);
+    mask-size: var(--icon-size) var(--icon-size);
+    mask-position: center;
+    mask-repeat: no-repeat;
+  }
 
-.callout-title-inner {
-  font-weight: 700;
+  .callout-title-inner {
+    font-weight: 700;
+  }
 }

--- a/quartz/styles/callouts.scss
+++ b/quartz/styles/callouts.scss
@@ -49,6 +49,10 @@
     --callout-icon: var(--callout-icon-info);
   }
 
+  &[data-callout="todo"] {
+    --callout-icon: var(--callout-icon-todo);
+  }
+
   &[data-callout="tip"] {
     --color: #00bfa5;
     --border: #00bfa544;
@@ -84,6 +88,14 @@
     --border: #db424244;
     --bg: #db424210;
     --callout-icon: var(--callout-icon-failure);
+  }
+
+  &[data-callout="bug"] {
+    --callout-icon: var(--callout-icon-bug);
+  }
+
+  &[data-callout="danger"] {
+    --callout-icon: var(--callout-icon-danger);
   }
 
   &[data-callout="example"] {

--- a/quartz/styles/callouts.scss
+++ b/quartz/styles/callouts.scss
@@ -135,7 +135,7 @@
     cursor: pointer;
     width: var(--icon-size);
     height: var(--icon-size);
-    --callout-icon: var(--callout-icon-fold)
+    --callout-icon: var(--callout-icon-fold);
   }
 
   & > .callout-title-inner > p {

--- a/quartz/styles/callouts.scss
+++ b/quartz/styles/callouts.scss
@@ -13,16 +13,32 @@
     margin-top: 0;
   }
 
+  --callout-icon-note: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="2" x2="22" y2="6"></line><path d="M7.5 20.5 19 9l-4-4L3.5 16.5 2 22z"></path></svg>');
+  --callout-icon-abstract: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path><path d="M12 11h4"></path><path d="M12 16h4"></path><path d="M8 11h.01"></path><path d="M8 16h.01"></path></svg>');
+  --callout-icon-info: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="16" x2="12" y2="12"></line><line x1="12" y1="8" x2="12.01" y2="8"></line></svg>');
+  --callout-icon-todo: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z"></path><path d="m9 12 2 2 4-4"></path></svg>');
+  --callout-icon-tip: url('data:image/svg+xml; utf8,<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z"></path></svg> ');
+  --callout-icon-success: url('data:image/svg+xml; utf8,<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg> ');
+  --callout-icon-question: url('data:image/svg+xml; utf8,<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path><line x1="12" y1="17" x2="12.01" y2="17"></line></svg> ');
+  --callout-icon-warning: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>');
+  --callout-icon-failure: url('data:image/svg+xml; utf8,<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg> ');
+  --callout-icon-danger: url('data:image/svg+xml; utf8,<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg> ');
+  --callout-icon-bug: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="8" height="14" x="8" y="6" rx="4"></rect><path d="m19 7-3 2"></path><path d="m5 7 3 2"></path><path d="m19 19-3-2"></path><path d="m5 19 3-2"></path><path d="M20 13h-4"></path><path d="M4 13h4"></path><path d="m10 4 1 2"></path><path d="m14 4-1 2"></path></svg>');
+  --callout-icon-example: url('data:image/svg+xml; utf8,<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"></line><line x1="8" y1="12" x2="21" y2="12"></line><line x1="8" y1="18" x2="21" y2="18"></line><line x1="3" y1="6" x2="3.01" y2="6"></line><line x1="3" y1="12" x2="3.01" y2="12"></line><line x1="3" y1="18" x2="3.01" y2="18"></line></svg> ');
+  --callout-icon-quote: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 21c3 0 7-1 7-8V5c0-1.25-.756-2.017-2-2H4c-1.25 0-2 .75-2 1.972V11c0 1.25.75 2 2 2 1 0 1 0 1 1v1c0 1-1 2-2 2s-1 .008-1 1.031V20c0 1 0 1 1 1z"></path><path d="M15 21c3 0 7-1 7-8V5c0-1.25-.757-2.017-2-2h-4c-1.25 0-2 .75-2 1.972V11c0 1.25.75 2 2 2h.75c0 2.25.25 4-2.75 4v3c0 1 0 1 1 1z"></path></svg>');
+
   &[data-callout] {
     --color: #448aff;
     --border: #448aff44;
     --bg: #448aff10;
+    --callout-icon: var(--callout-icon-note);
   }
 
   &[data-callout="abstract"] {
     --color: #00b0ff;
     --border: #00b0ff44;
     --bg: #00b0ff10;
+    --callout-icon: var(--callout-icon-abstract);
   }
 
   &[data-callout="info"],
@@ -30,30 +46,35 @@
     --color: #00b8d4;
     --border: #00b8d444;
     --bg: #00b8d410;
+    --callout-icon: var(--callout-icon-info);
   }
 
   &[data-callout="tip"] {
     --color: #00bfa5;
     --border: #00bfa544;
     --bg: #00bfa510;
+    --callout-icon: var(--callout-icon-tip);
   }
 
   &[data-callout="success"] {
     --color: #09ad7a;
     --border: #09ad7144;
     --bg: #09ad7110;
+    --callout-icon: var(--callout-icon-success);
   }
 
   &[data-callout="question"] {
     --color: #dba642;
     --border: #dba64244;
     --bg: #dba64210;
+    --callout-icon: var(--callout-icon-question);
   }
 
   &[data-callout="warning"] {
     --color: #db8942;
     --border: #db894244;
     --bg: #db894210;
+    --callout-icon: var(--callout-icon-warning);
   }
 
   &[data-callout="failure"],
@@ -62,17 +83,20 @@
     --color: #db4242;
     --border: #db424244;
     --bg: #db424210;
+    --callout-icon: var(--callout-icon-failure);
   }
 
   &[data-callout="example"] {
     --color: #7a43b5;
     --border: #7a43b544;
     --bg: #7a43b510;
+    --callout-icon: var(--callout-icon-example);
   }
 
   &[data-callout="quote"] {
     --color: var(--secondary);
     --border: var(--lightgray);
+    --callout-icon: var(--callout-icon-quote);
   }
 
   &.is-collapsed > .callout-title > .fold {
@@ -104,6 +128,16 @@
   height: 18px;
   flex: 0 0 18px;
   padding-top: 4px;
+
+  //Handling icons
+  background-size: 18px 18px;
+  background-position: center;
+  background-color: var(--color);
+  -webkit-mask-image: var(--callout-icon);
+  mask-image: var(--callout-icon);
+  mask-size: 18px 18px;
+  mask-position: center;
+  mask-repeat: no-repeat;
 }
 
 .callout-title-inner {

--- a/quartz/styles/callouts.scss
+++ b/quartz/styles/callouts.scss
@@ -112,7 +112,7 @@
     --callout-icon: var(--callout-icon-quote);
   }
 
-  &.is-collapsed > .callout-title > .fold {
+  &.is-collapsed > .callout-title > .fold-callout-icon {
     transform: rotateZ(-90deg);
   }
 }
@@ -129,7 +129,7 @@
 
   --icon-size: 18px;
 
-  & .fold {
+  & .fold-callout-icon {
     transition: transform 0.15s ease;
     opacity: 0.8;
     cursor: pointer;
@@ -144,10 +144,9 @@
   }
 
   .callout-icon,
-  & .fold {
+  & .fold-callout-icon {
     width: var(--icon-size);
     height: var(--icon-size);
-    //flex: 0 0 18px;
 
     // icon support
     background-size: var(--icon-size) var(--icon-size);

--- a/quartz/styles/callouts.scss
+++ b/quartz/styles/callouts.scss
@@ -119,9 +119,6 @@
 
 .callout-title {
   display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  align-content: center;
   align-items: center;
   gap: 5px;
   padding: 1rem 0;

--- a/quartz/styles/callouts.scss
+++ b/quartz/styles/callouts.scss
@@ -106,15 +106,22 @@
 
 .callout-title {
   display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-content: center;
+  align-items: center;
   gap: 5px;
   padding: 1rem 0;
   color: var(--color);
 
+  --icon-size: 18px;
+
   & .fold {
-    margin-left: 0.5rem;
-    transition: transform 0.3s ease;
+    transition: transform 0.15s ease;
     opacity: 0.8;
     cursor: pointer;
+    width: var(--icon-size);
+    height: var(--icon-size);
   }
 
   & > .callout-title-inner > p {
@@ -124,17 +131,16 @@
 }
 
 .callout-icon {
-  width: 18px;
-  height: 18px;
-  flex: 0 0 18px;
-  padding-top: 4px;
+  width: var(--icon-size);
+  height: var(--icon-size);
+  //flex: 0 0 18px;
 
   // icon support
-  background-size: 18px 18px;
+  background-size: var(--icon-size) var(--icon-size);
   background-position: center;
   background-color: var(--color);
   mask-image: var(--callout-icon);
-  mask-size: 18px 18px;
+  mask-size: var(--icon-size) var(--icon-size);
   mask-position: center;
   mask-repeat: no-repeat;
 }

--- a/quartz/styles/callouts.scss
+++ b/quartz/styles/callouts.scss
@@ -129,11 +129,10 @@
   flex: 0 0 18px;
   padding-top: 4px;
 
-  //Handling icons
+  // icon support
   background-size: 18px 18px;
   background-position: center;
   background-color: var(--color);
-  -webkit-mask-image: var(--callout-icon);
   mask-image: var(--callout-icon);
   mask-size: 18px 18px;
   mask-position: center;


### PR DESCRIPTION
As say in #724, i wanted a simple way to add custom icons for callouts.

To handle that, i made it pure css. Icon are now a mask for the callout-icon div, so they always follow the --color form the current callout.

Now to add a custom icon, you simply add

```css
.callout {
  &[data-callout="custom"] {
    --color: #customcolor;
    --border: #custombordercolor;
    --bg: #custombg;
    --callout-icon: url('data:image/svg+xml; utf8, <custom formatted svg>');

  }
```

to custom.scss