### PR TITLE
fix: code block overflow scroll

### DIFF
--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -356,6 +356,7 @@ pre {
     counter-increment: line 0;
     display: grid;
     padding: 0.5rem 0;
+    overflow-x: scroll;
 
     & [data-highlighted-chars] {
       background-color: var(--highlight);


### PR DESCRIPTION
The `overflow: scroll` CSS property for `<code>` isn't enabled, and it causes two UI issues. This pull request addresses these two issues.

**1. Clipboard icon is stuck**
<img width="500" alt="Screenshot 2024-01-25 at 11 54 42 PM" src="https://github.com/jackyzha0/quartz/assets/47915643/a6d61b77-d6cb-4c8a-86e8-dbbb0eb6005f">


**2. Background color got cut off when [`keepBackground`](https://github.com/xy-241/CS-Notes/blob/v4/quartz/plugins/transformers/syntax.ts#L13) is `true`**
<img width="500" alt="Screenshot 2024-01-25 at 11 53 42 PM" src="https://github.com/jackyzha0/quartz/assets/47915643/1928334b-7e47-4127-b616-ca8e3d5bd90c">
