### PR TITLE
fix(type): make sure dispatchEvent also accept UIEvent

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -4,7 +4,7 @@ export declare global {
       type: K,
       listener: (this: Document, ev: CustomEventMap[K]) => void,
     ): void
-    dispatchEvent<K extends keyof CustomEventMap>(ev: CustomEventMap[K]): void
+    dispatchEvent<K extends keyof CustomEventMap>(ev: CustomEventMap[K] | UIEvent): void
   }
   interface Window {
     spaNavigate(url: URL, isBack: boolean = false)


### PR DESCRIPTION
This is fix so that typescript will understand in cases plugins dev wants to dispatchEvent other than CustomEventMap

```tsx
function handleKeybindClick(ev: MouseEvent) {
  ev.preventDefault()

  const keybind = (ev?.target as HTMLElement).dataset.keybind
  if (!keybind) return
  const [modifier, key] = keybind.split("--")
  const eventProps = {
    ctrKey: modifier === "ctrl",
    metaKey: modifier === "cmd",
    shiftKey: modifier === "shift",
    altKey: modifier === "alt",
  }
  const sim = new KeyboardEvent("keydown", {
    ...eventProps,
    key: key.length === 1 ? key : key.toLowerCase(),
    bubbles: true,
    cancelable: true,
  })
  document.dispatchEvent(sim)
}
```

Here `document.dispatchEvent(sim)` would raise a ts error with the current code on main.

this PR will make sure that all UIEvent can also be accepted.