### PR TITLE
fix(css): improve wrapping when right sidebar has more than two items

### DIFF
--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -171,9 +171,11 @@ a {
 
     & .sidebar.right {
       right: calc(calc(100vw - $pageWidth) / 2 - $sidePanelWidth);
+      flex-wrap: wrap;
       & > * {
         @media all and (max-width: $fullPageWidth) {
           flex: 1;
+          min-width: 150px;
         }
       }
     }

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -175,7 +175,7 @@ a {
       & > * {
         @media all and (max-width: $fullPageWidth) {
           flex: 1;
-          min-width: 150px;
+          min-width: 140px;
         }
       }
     }


### PR DESCRIPTION
The right sidebar, which appears beneath body content on mobile, doesn't display >2 components very well on mobile. This fix gives each item a min-width and enables wrapping.

Example:
![CleanShot 2024-01-29 at 21 39 02@2x](https://github.com/jackyzha0/quartz/assets/7053644/3af5a956-0512-431c-8d74-e2a2af5138be)
