### PR TITLE
fix(search): improve more general usability (closes #781)

### DIFF
--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -293,7 +293,7 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
       innerHTML: `<h3>${title}</h3>${htmlTags}${resultContent}`,
     })
 
-    const resultsMouseEnter = async (ev: MouseEvent) => {
+    async function onMouseEnter(ev: MouseEvent) {
       // Actually when we hover, we need to clean all highlights within the result childs
       if (!ev.target) return
       for (const el of document.getElementsByClassName(
@@ -309,14 +309,14 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
       currentHover.classList.remove("focus")
     }
 
-    const resultsMouseLeave = async (ev: MouseEvent) => {
+    async function onMouseLeave(ev: MouseEvent) {
       const target = ev.target as HTMLAnchorElement
       target.classList.remove("focus", "mouse")
     }
 
     const events = [
-      ["mouseenter", resultsMouseEnter],
-      ["mouseleave", resultsMouseLeave],
+      ["mouseenter", onMouseEnter],
+      ["mouseleave", onMouseLeave],
       [
         "click",
         (event: MouseEvent) => {

--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -122,6 +122,9 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
     if (preview) {
       removeAllChildren(preview)
     }
+    if (searchLayout) {
+      searchLayout.style.opacity = "0"
+    }
 
     searchType = "basic" // reset search type after closing
   }
@@ -134,6 +137,8 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
     container?.classList.add("active")
     searchBar?.focus()
   }
+
+  let currentHover: HTMLInputElement | null = null
 
   async function shortcutHandler(e: HTMLElementEventMap["keydown"]) {
     if (e.key === "k" && (e.ctrlKey || e.metaKey) && !e.shiftKey) {
@@ -150,51 +155,59 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
       if (searchBar) searchBar.value = "#"
     }
 
-    const resultCards = document.getElementsByClassName("result-card")
+    if (currentHover) {
+      currentHover.classList.remove("focus")
+    }
 
     // If search is active, then we will render the first result and display accordingly
     if (!container?.classList.contains("active")) return
-    else if (results?.contains(document.activeElement)) {
-      const active = document.activeElement as HTMLInputElement
-      await displayPreview(active)
-      if (e.key === "Enter") {
+    else if (e.key === "Enter") {
+      // If result has focus, navigate to that one, otherwise pick first result
+      if (results?.contains(document.activeElement)) {
+        const active = document.activeElement as HTMLInputElement
+        await displayPreview(active)
         active.click()
-      }
-    } else {
-      const anchor = resultCards[0] as HTMLInputElement | null
-      await displayPreview(anchor)
-      if (e.key === "Enter") {
+      } else {
+        const anchor = document.getElementsByClassName("result-card")[0] as HTMLInputElement | null
+        await displayPreview(anchor)
         anchor?.click()
       }
-    }
-
-    if (e.key === "ArrowUp" || (e.shiftKey && e.key === "Tab")) {
+    } else if (e.key === "ArrowUp" || (e.shiftKey && e.key === "Tab")) {
       e.preventDefault()
       if (results?.contains(document.activeElement)) {
         // If an element in results-container already has focus, focus previous one
-        const currentResult = document.activeElement as HTMLInputElement | null
+        const currentResult = currentHover
+          ? currentHover
+          : (document.activeElement as HTMLInputElement | null)
         const prevResult = currentResult?.previousElementSibling as HTMLInputElement | null
         currentResult?.classList.remove("focus")
         await displayPreview(prevResult)
         prevResult?.focus()
+        currentHover = prevResult
       }
     } else if (e.key === "ArrowDown" || e.key === "Tab") {
       e.preventDefault()
       // The results should already been focused, so we need to find the next one.
       // The activeElement is the search bar, so we need to find the first result and focus it.
       if (!results?.contains(document.activeElement)) {
-        const firstResult = resultCards[0] as HTMLInputElement | null
+        const firstResult = currentHover
+          ? currentHover
+          : (document.getElementsByClassName("result-card")[0] as HTMLInputElement | null)
         const secondResult = firstResult?.nextElementSibling as HTMLInputElement | null
         firstResult?.classList.remove("focus")
         await displayPreview(secondResult)
         secondResult?.focus()
+        currentHover = secondResult
       } else {
         // If an element in results-container already has focus, focus next one
-        const active = document.activeElement as HTMLInputElement | null
+        const active = currentHover
+          ? currentHover
+          : (document.activeElement as HTMLInputElement | null)
         active?.classList.remove("focus")
         const nextResult = active?.nextElementSibling as HTMLInputElement | null
         await displayPreview(nextResult)
         nextResult?.focus()
+        currentHover = nextResult
       }
     }
   }
@@ -280,27 +293,30 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
       innerHTML: `<h3>${title}</h3>${htmlTags}${resultContent}`,
     })
 
-    async function onMouseEnter(ev: MouseEvent) {
+    const resultsMouseEnter = async (ev: MouseEvent) => {
       // Actually when we hover, we need to clean all highlights within the result childs
+      if (!ev.target) return
       for (const el of document.getElementsByClassName(
         "result-card",
       ) as HTMLCollectionOf<HTMLElement>) {
         el.classList.remove("focus")
         el.blur()
       }
-      const target = ev.target as HTMLAnchorElement
-      target.classList.add("focus")
+      const target = ev.target as HTMLInputElement
+      target.classList.add("mouse")
       await displayPreview(target)
+      currentHover = target
+      currentHover.classList.remove("focus")
     }
 
-    async function onMouseLeave(ev: MouseEvent) {
+    const resultsMouseLeave = async (ev: MouseEvent) => {
       const target = ev.target as HTMLAnchorElement
-      target.classList.remove("focus")
+      target.classList.remove("focus", "mouse")
     }
 
     const events = [
-      ["mouseenter", onMouseEnter],
-      ["mouseleave", onMouseLeave],
+      ["mouseenter", resultsMouseEnter],
+      ["mouseleave", resultsMouseLeave],
       [
         "click",
         (event: MouseEvent) => {
@@ -320,7 +336,7 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
 
     removeAllChildren(results)
     if (finalResults.length === 0) {
-      results.innerHTML = `<a class="result-card">
+      results.innerHTML = `<a class="result-card no-match">
                     <h3>No results.</h3>
                     <p>Try another search term?</p>
                 </a>`
@@ -329,8 +345,13 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
     }
     // focus on first result, then also dispatch preview immediately
     if (results?.firstElementChild) {
-      results?.firstElementChild?.classList.add("focus")
-      await displayPreview(results?.firstElementChild as HTMLElement)
+      const firstChild = results.firstElementChild as HTMLElement
+      if (firstChild.classList.contains("no-match")) {
+        removeAllChildren(preview as HTMLElement)
+      } else {
+        firstChild.classList.add("focus")
+        await displayPreview(firstChild)
+      }
     }
   }
 

--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -165,10 +165,12 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
       // If result has focus, navigate to that one, otherwise pick first result
       if (results?.contains(document.activeElement)) {
         const active = document.activeElement as HTMLInputElement
+        if (active.classList.contains("no-match")) return
         await displayPreview(active)
         active.click()
       } else {
         const anchor = document.getElementsByClassName("result-card")[0] as HTMLInputElement | null
+        if (anchor?.classList.contains("no-match")) return
         await displayPreview(anchor)
         anchor?.click()
       }

--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -305,7 +305,6 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
         el.blur()
       }
       const target = ev.target as HTMLInputElement
-      target.classList.add("mouse")
       await displayPreview(target)
       currentHover = target
       currentHover.classList.remove("focus")
@@ -313,7 +312,7 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
 
     async function onMouseLeave(ev: MouseEvent) {
       const target = ev.target as HTMLAnchorElement
-      target.classList.remove("focus", "mouse")
+      target.classList.remove("focus")
     }
 
     const events = [

--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -170,9 +170,9 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
         active.click()
       } else {
         const anchor = document.getElementsByClassName("result-card")[0] as HTMLInputElement | null
-        if (anchor?.classList.contains("no-match")) return
+        if (!anchor || anchor?.classList.contains("no-match")) return
         await displayPreview(anchor)
-        anchor?.click()
+        anchor.click()
       }
     } else if (e.key === "ArrowUp" || (e.shiftKey && e.key === "Tab")) {
       e.preventDefault()


### PR DESCRIPTION
- when there is not a single match, then we shouldn't show anything
<img width="981" alt="Screenshot 2024-02-01 at 02 26 32" src="https://github.com/jackyzha0/quartz/assets/29749331/d41e3c60-4031-4930-bbc9-04f086996ab1">

- When mouse hovering and tab is used, it should set start index from the hover div instead of the beginning div


https://github.com/jackyzha0/quartz/assets/29749331/a41916f6-873a-4158-b5fc-4be0d560e099

- fixed a weird cmd+k behaviour described in #781 

- remove empty container after hide.

<img width="984" alt="Screenshot 2024-02-01 at 02 29 31" src="https://github.com/jackyzha0/quartz/assets/29749331/5de9063b-0a91-4020-9b14-4c7b32906689">
