### PR TITLE
chore(search): check for input type and assignment of focus

### DIFF
--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -191,7 +191,7 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
       e.preventDefault()
       // The results should already been focused, so we need to find the next one.
       // The activeElement is the search bar, so we need to find the first result and focus it.
-      if (!results?.contains(document.activeElement)) {
+      if (document.activeElement === searchBar || currentHover !== null) {
         const firstResult = currentHover
           ? currentHover
           : (document.getElementsByClassName("result-card")[0] as HTMLInputElement | null)
@@ -351,6 +351,7 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
         removeAllChildren(preview as HTMLElement)
       } else {
         firstChild.classList.add("focus")
+        currentHover = firstChild as HTMLInputElement
         await displayPreview(firstChild)
       }
     }


### PR DESCRIPTION
In some cases where the activeElement is the result[0], then you have to double tab to get to the element after that.

Probably irrelevant since @jackyzha0 you are refactoring this right?