### PR TITLE
docs: clarity for `RecentNotes`

### DIFF
--- a/docs/features/recent notes.md
+++ b/docs/features/recent notes.md
@@ -3,7 +3,7 @@ title: Recent Notes
 tags: component
 ---
 
-Quartz can generate a list of recent notes for based on some filtering and sorting criteria. Though this component isn't included in any [[layout]] by default, you can add it by using `Component.RecentNotes`.
+Quartz can generate a list of recent notes based on some filtering and sorting criteria. Though this component isn't included in any [[layout]] by default, you can add it by using `Component.RecentNotes` in `quartz.layout.ts`.
 
 ## Customization
 


### PR DESCRIPTION
- Removed a word for clarity
- added reference to layout file