### PR TITLE
fix(search): set correct attribute on hover icon

### DIFF
--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -155,7 +155,7 @@
           }
 
           a.internal {
-            background-color: none;
+            background-color: inherit;
           }
         }
 


### PR DESCRIPTION
Hmm it should be `inherit` instead of `none` here 😄 