### PR TITLE
fix(search): should only blur once hover is not a `result`

### DIFF
--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -224,7 +224,7 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
 
     if (currentHover) {
       currentHover.classList.remove("focus")
-      currentHover.blur()
+      if (!currentHover.classList.contains("result-card")) currentHover.blur()
     }
 
     // If search is active, then we will render the first result and display accordingly


### PR DESCRIPTION
We should only blur only if the item is not a `result-card`, otherwise `S-Tab` won't work, and `Tab` will infinitely run down to all subsequent div.

https://github.com/jackyzha0/quartz/assets/29749331/4f69d409-4d2e-4a5d-ba46-3c1861205fa0

