### PR TITLE
feat: add "folderNote" Exlorer Mode

### DIFF
--- a/quartz/components/ExplorerNode.tsx
+++ b/quartz/components/ExplorerNode.tsx
@@ -7,7 +7,7 @@ import {
   simplifySlug,
   SimpleSlug,
   FilePath,
-  slugToFileName
+  slugToFileName,
 } from "../util/path"
 
 type OrderEntries = "sort" | "filter" | "map"
@@ -170,9 +170,10 @@ type ExplorerNodeProps = {
 export function ExplorerNode({ node, opts, fullPath, fileData }: ExplorerNodeProps) {
   // Get options
   const folderBehavior = opts.folderClickBehavior[0] //folderClickBehavior name
-  const folderNoteRegex = Array.isArray(opts.folderClickBehavior) && folderBehavior === "folderNote" //extract regex if in "folderNote" mode
-  ? opts.folderClickBehavior[1]
-  : undefined;
+  const folderNoteRegex =
+    Array.isArray(opts.folderClickBehavior) && folderBehavior === "folderNote" //extract regex if in "folderNote" mode
+      ? opts.folderClickBehavior[1]
+      : undefined
   const isDefaultOpen = opts.folderDefaultState === "open"
 
   // Calculate current folderPath
@@ -181,37 +182,41 @@ export function ExplorerNode({ node, opts, fullPath, fileData }: ExplorerNodePro
     folderPath = joinSegments(fullPath ?? "", node.name)
   }
 
-  /** 
- * @var mainChild file to open when clicking on folder (if in "folderNote" mode)*/
+  /**
+   * @var mainChild file to open when clicking on folder (if in "folderNote" mode)*/
   let mainChild = null
   if (folderBehavior === "folderNote" && !node.file) {
     //search mainChild inside folder by matching their fileName with regex
     for (const child of node.children) {
       let childName = slugToFileName(child.name)
-      if (folderNoteRegex!.test(childName) && child.depth<=node.depth+1 && child.file ){
+      if (folderNoteRegex!.test(childName) && child.depth <= node.depth + 1 && child.file) {
         //remove matching regex group from mainChild displayname
-        if(folderNoteRegex!.test(child.displayName)){
+        if (folderNoteRegex!.test(child.displayName)) {
           const flags = child.displayName.match(folderNoteRegex!)!.slice(1)! //shift to remove first result = entire child.displayname
-          flags.forEach(flag => {
+          flags.forEach((flag) => {
             child.displayName = child.displayName.replace(flag, "")
           })
         }
         mainChild = child
         break
-    }}
+      }
+    }
   }
 
   return (
     <>
       {node.file ? ( // Single file node
-        folderBehavior !== "folderNote" || !folderNoteRegex!.test(slugToFileName(node.name)) ? (   // include file in tree IF it's NOT the mainChild
+        folderBehavior !== "folderNote" || !folderNoteRegex!.test(slugToFileName(node.name)) ? ( // include file in tree IF it's NOT the mainChild
           <li key={node.file.slug}>
             <a href={resolveRelative(fileData.slug!, node.file.slug!)} data-for={node.file.slug}>
               {node.displayName}
             </a>
           </li>
-        ) : ("")  // include nothing IF node = folderNote (foldeNote hidden from tree as i will be displayed thx to folder)
-      ) : (       // folder node case
+        ) : (
+          ""
+        ) // include nothing IF node = folderNote (foldeNote hidden from tree as i will be displayed thx to folder)
+      ) : (
+        // folder node case
         <li>
           {node.name !== "" && (
             // Node with entire folder
@@ -248,7 +253,8 @@ export function ExplorerNode({ node, opts, fullPath, fileData }: ExplorerNodePro
                   >
                     <u>{mainChild.displayName}</u>
                   </a>
-                ) : ( // default case = "collapse"
+                ) : (
+                  // default case = "collapse"
                   <button class="folder-button">
                     <span class="folder-title">{node.displayName}</span>
                   </button>

--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -225,7 +225,7 @@ export function transformLink(src: FullSlug, target: string, opts: TransformOpti
   }
 }
 
-export function slugToFileName (slug: SimpleSlug | string | FullSlug){
+export function slugToFileName(slug: SimpleSlug | string | FullSlug) {
   return slug.split("/").at(-1)!
 }
 

--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -225,6 +225,10 @@ export function transformLink(src: FullSlug, target: string, opts: TransformOpti
   }
 }
 
+export function slugToFileName (slug: SimpleSlug | string | FullSlug){
+  return slug.split("/").at(-1)!
+}
+
 function _isFolderPath(fplike: string): boolean {
   return (
     fplike.endsWith("/") ||


### PR DESCRIPTION
Implement simplified version of [Obsidian Folder Notes](https://github.com/LostPaul/obsidian-folder-notes) to the "Explorer" component.

- **Use:** In `quartz.layout.ts`, when adding the "Explorer" component, select array `folderClickBehavior: ["folderNote", REGEX]`. Now, create a .md file inside any folder that matches with that REGEX: that's the folder's `mainChild`.
- **Effect:** In the explorer you'll NOT see the `mainChild` but you can open it by clicking on its folder. In the meantime, that folder has changed its name to the `mainChild`'s one while also removing any capturing group of the `REGEX`.
- **Example:** 
   - In: `quartz.layout.ts` → `Component.Explorer({
        folderClickBehavior: [
          "folderNote",
          /($).*/
        ]}`
  - File tree: 
    -  Folder 1
        - $file1 (that the `mainChild` as it satisfies the `REGEX`)
        - file2
    - Folder 2
       - file3  
   - Explorer:
      -  file1 (folder that, when clicked, link to $file1. Quartz has sanitize its name from the `REGEX `capturing group `($)`)
         - file 2
      - Folder 2
         - file 3
         
If it's even good, I'm open to update the documentation.
Cheers

_PS: I'm a noob... this took me like hours_
