### PR TITLE
feat(i18n): Add Japanese to i18n

### DIFF
--- a/quartz/i18n/index.ts
+++ b/quartz/i18n/index.ts
@@ -1,10 +1,12 @@
 import { Translation } from "./locales/definition"
 import en from "./locales/en-US"
 import fr from "./locales/fr-FR"
+import ja from "./locales/ja-JP"
 
 export const TRANSLATIONS = {
   "en-US": en,
   "fr-FR": fr,
+  "ja-JP": ja,
 } as const
 
 export const i18n = (locale: ValidLocale): Translation => TRANSLATIONS[locale]

--- a/quartz/i18n/locales/ja-JP.ts
+++ b/quartz/i18n/locales/ja-JP.ts
@@ -1,0 +1,63 @@
+import { Translation } from "./definition"
+
+export default {
+  propertyDefaults: {
+    title: "無題",
+    description: "説明なし",
+  },
+  components: {
+    backlinks: {
+      title: "バックリンク",
+      noBacklinksFound: "バックリンクはありません",
+    },
+    themeToggle: {
+      lightMode: "ライトモード",
+      darkMode: "ダークモード",
+    },
+    explorer: {
+      title: "エクスプローラー",
+    },
+    footer: {
+      createdWith: "作成",
+    },
+    graph: {
+      title: "グラフビュー",
+    },
+    recentNotes: {
+      title: "最近の記事",
+      seeRemainingMore: ({ remaining }) => `さらに${remaining}件 →`,
+    },
+    transcludes: {
+      transcludeOf: ({ targetSlug }) => `${targetSlug}のまとめ`,
+      linkToOriginal: "元記事へのリンク",
+    },
+    search: {
+      title: "検索",
+      searchBarPlaceholder: "検索ワードを入力",
+    },
+    tableOfContents: {
+      title: "目次",
+    },
+  },
+  pages: {
+    rss: {
+      recentNotes: "最近の記事",
+      lastFewNotes: ({ count }) => `最新の${count}件`,
+    },
+    error: {
+      title: "Not Found",
+      notFound: "ページが存在しないか、非公開設定になっています。",
+    },
+    folderContent: {
+      folder: "フォルダ",
+      itemsUnderFolder: ({ count }) => `${count}件のページ`,
+    },
+    tagContent: {
+      tag: "タグ",
+      tagIndex: "タグ一覧",
+      itemsUnderTag: ({ count }) => `${count}件のページ`,
+      showingFirst: ({ count }) => `のうち最初の${count}件を表示しています`,
+      totalTags: ({ count }) => `全${count}個のタグを表示中`,
+    },
+  },
+} as const satisfies Translation


### PR DESCRIPTION
Added basic translation.

Note that the translation for the "Created with" sounds a bit awkward but I could not find the way to change the order of word that contains an anchor link. If possible "Created with [Quartz v4.2.2] © 2024" should be like "[Quartz v4.2.2] で作成, © 2024".