### PR TITLE
fix(links): show backdrop on links highlighted in headers alias

### DIFF
--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -261,7 +261,8 @@ thead {
 
   article > & > a {
     color: var(--dark);
-    &.internal {
+
+    &[data-icon] {
       background-color: transparent;
     }
   }


### PR DESCRIPTION
If you set an internal link within the headers, background would not show on the heading.

This PR fixes that.

<img width="223" alt="Screenshot 2024-02-06 at 00 06 31" src="https://github.com/jackyzha0/quartz/assets/29749331/4222a5f6-322e-45db-a98e-cf0cd447ec7f">
