### PR TITLE
fix: breadcrumbs displayName issue for file names ending with index

### DIFF
--- a/quartz/components/Breadcrumbs.tsx
+++ b/quartz/components/Breadcrumbs.tsx
@@ -68,8 +68,8 @@ export default ((opts?: Partial<BreadcrumbOptions>) => {
       folderIndex = new Map()
       // construct the index for the first time
       for (const file of allFiles) {
-        if (file.slug?.endsWith("index")) {
-          const folderParts = file.slug?.split("/")
+        const folderParts = file.slug?.split("/")
+        if (folderParts?.at(-1) === "index") {
           // 2nd last to exclude the /index
           const folderName = folderParts?.at(-2)
           if (folderName) {


### PR DESCRIPTION
**Context:**
- If a filename ends with `index`, then the breadcrumb names would be incorrect.
- Example: For filename: `/areas/computer_science/in/what_no_one_told_you_about_z_index`
- In this case, the `index` at the end of path would be interpreted as root file, for the `areas/computer_science/in` directory
- And hence, the display name for the folder `/areas/computer_science/in` would be mapped as `what_no_one_told_you_about_z_index`
- To fix this, added an explicit check for `index`, instead of endingWith check.