### PR TITLE
fix: #676

### DIFF
--- a/quartz/components/Breadcrumbs.tsx
+++ b/quartz/components/Breadcrumbs.tsx
@@ -71,7 +71,7 @@ export default ((opts?: Partial<BreadcrumbOptions>) => {
         if (file.slug?.endsWith("index")) {
           const folderParts = file.slug?.split("/")
           // 2nd last to exclude the /index
-          const folderName = folderParts?.at(-2)
+          const folderName = folderParts.slice(0, folderParts?.length - 1).join("_")
           if (folderName) {
             folderIndex.set(folderName, file)
           }
@@ -88,7 +88,7 @@ export default ((opts?: Partial<BreadcrumbOptions>) => {
         let curPathSegment = slugParts[i]
 
         // Try to resolve frontmatter folder title
-        const currentFile = folderIndex?.get(curPathSegment)
+        const currentFile = folderIndex?.get(slugParts.slice(0, i + 1).join("_"))
         if (currentFile) {
           const title = currentFile.frontmatter!.title
           if (title !== "index") {


### PR DESCRIPTION
**Context:**
- Adds a patch to fix #676 
- Quartz uses `FolderIndex` to keep mapping of folders which want to be named using the `index` files inside of them.
- `FolderIndex` is a map, with the structure - `Map<string, QuartzPluginData>`
- Here the `string` is the folder name, which originally was just the name of the folder.
- In the bug stated in #676 since both the folders have the same name of - `Snippet`, there are clashes here.
- Hence, added a patch, where instead of relying just on the folder name for mapping, we are using parent names as well.