### PR TITLE
feat(preview): manual disabled given files

### DIFF
--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -213,7 +213,10 @@ export function renderPage(
   const doc = (
     <html lang={lang}>
       <Head {...componentData} />
-      <body data-slug={slug}>
+      <body
+        data-slug={slug}
+        data-enable-preview={componentData.fileData.frontmatter?.preview ?? true}
+      >
         <div id="quartz-root" class="page">
           <Body {...componentData}>
             {LeftComponent}

--- a/quartz/components/scripts/popover.inline.ts
+++ b/quartz/components/scripts/popover.inline.ts
@@ -51,7 +51,13 @@ async function mouseEnterHandler(
   if (!contents) return
   const html = p.parseFromString(contents, "text/html")
   normalizeRelativeURLs(html, targetUrl)
-  const elts = [...html.getElementsByClassName("popover-hint")]
+  let elts: Element[]
+  if (html.body.dataset.enablePreview === "false") {
+    const noPreview = document.createElement("div")
+    noPreview.innerHTML = `<p>Preview is disabled for this page.</p>`
+    elts = [noPreview]
+  } else elts = [...html.getElementsByClassName("popover-hint")]
+
   if (elts.length === 0) return
 
   const popoverElement = document.createElement("div")

--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -371,6 +371,11 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
           throw new Error(`Could not fetch ${targetUrl}`)
         }
         const html = p.parseFromString(contents ?? "", "text/html")
+        if (html.body.dataset.enablePreview === "false") {
+          const noPreview = document.createElement("div")
+          noPreview.innerHTML = `<p>Preview is disabled for this page.</p>`
+          return [noPreview]
+        }
         normalizeRelativeURLs(html, targetUrl)
         return [...html.getElementsByClassName("popover-hint")]
       })


### PR DESCRIPTION
Ideally, we want to have a loading skeleton for larger files, but for now, users can disable showing the preview and popover by passing `preview: false` into the front matter.

This is also helpful for custom pages and items that have additional CSS styling and javascript, since we only fetch the popover-hint content, and there is no guarantee the js would work within nested view.
