### PR TITLE
fix/feat(fast rebuild): re-render transclusions in normal and fastRebuild mode

### DIFF
--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -3,10 +3,9 @@ import { QuartzComponent, QuartzComponentProps } from "./types"
 import HeaderConstructor from "./Header"
 import BodyConstructor from "./Body"
 import { JSResourceToScriptElement, StaticResources } from "../util/resources"
-import { FullSlug, RelativeURL, joinSegments, normalizeHastElement } from "../util/path"
+import { clone, FullSlug, RelativeURL, joinSegments, normalizeHastElement } from "../util/path"
 import { visit } from "unist-util-visit"
 import { Root, Element, ElementContent } from "hast"
-import { QuartzPluginData } from "../plugins/vfile"
 import { GlobalConfiguration } from "../cfg"
 import { i18n } from "../i18n"
 
@@ -61,7 +60,7 @@ export function renderPage(
 ): string {
   // make a deep copy of the tree so we don't remove the transclusion references
   // for the file cached in contentMap in build.ts
-  const root = structuredClone(componentData.tree) as Root
+  const root = clone(componentData.tree) as Root
 
   // process transcludes in componentData
   visit(root, "element", (node, _index, _parent) => {

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -52,18 +52,6 @@ export function pageResources(
   }
 }
 
-let pageIndex: Map<FullSlug, QuartzPluginData> | undefined = undefined
-function getOrComputeFileIndex(allFiles: QuartzPluginData[]): Map<FullSlug, QuartzPluginData> {
-  if (!pageIndex) {
-    pageIndex = new Map()
-    for (const file of allFiles) {
-      pageIndex.set(file.slug!, file)
-    }
-  }
-
-  return pageIndex
-}
-
 export function renderPage(
   cfg: GlobalConfiguration,
   slug: FullSlug,
@@ -71,14 +59,18 @@ export function renderPage(
   components: RenderComponents,
   pageResources: StaticResources,
 ): string {
+  // make a deep copy of the tree so we don't remove the transclusion references
+  // for the file cached in contentMap in build.ts
+  const root = structuredClone(componentData.tree) as Root
+
   // process transcludes in componentData
-  visit(componentData.tree as Root, "element", (node, _index, _parent) => {
+  visit(root, "element", (node, _index, _parent) => {
     if (node.tagName === "blockquote") {
       const classNames = (node.properties?.className ?? []) as string[]
       if (classNames.includes("transclude")) {
         const inner = node.children[0] as Element
         const transcludeTarget = inner.properties["data-slug"] as FullSlug
-        const page = getOrComputeFileIndex(componentData.allFiles).get(transcludeTarget)
+        const page = componentData.allFiles.find((f) => f.slug === transcludeTarget)
         if (!page) {
           return
         }
@@ -180,6 +172,9 @@ export function renderPage(
       }
     }
   })
+
+  // set componentData.tree to the edited html that has transclusions rendered
+  componentData.tree = root
 
   const {
     head: Head,

--- a/quartz/plugins/emitters/contentPage.tsx
+++ b/quartz/plugins/emitters/contentPage.tsx
@@ -1,15 +1,51 @@
+import path from "path"
+import { visit } from "unist-util-visit"
+import { Root } from "hast"
+import { VFile } from "vfile"
 import { QuartzEmitterPlugin } from "../types"
 import { QuartzComponentProps } from "../../components/types"
 import HeaderConstructor from "../../components/Header"
 import BodyConstructor from "../../components/Body"
 import { pageResources, renderPage } from "../../components/renderPage"
 import { FullPageLayout } from "../../cfg"
-import { FilePath, joinSegments, pathToRoot } from "../../util/path"
+import { FilePath, isRelativeURL, joinSegments, pathToRoot } from "../../util/path"
 import { defaultContentPageLayout, sharedPageComponents } from "../../../quartz.layout"
 import { Content } from "../../components"
 import chalk from "chalk"
 import { write } from "./helpers"
 import DepGraph from "../../depgraph"
+
+// get all the dependencies for the markdown file
+// eg. images, scripts, stylesheets, transclusions
+const parseDependencies = (hast: Root, file: VFile): string[] => {
+  const dependencies: string[] = []
+
+  visit(hast, "element", (elem): void => {
+    let ref: string | null = null
+
+    if (["img", "script"].includes(elem.tagName) && elem?.properties?.src) {
+      ref = elem.properties.src.toString()
+    } else if (["a", "link"].includes(elem.tagName) && elem?.properties?.href) {
+      // transclusions will create a tags with relative hrefs
+      ref = elem.properties.href.toString()
+    }
+
+    // if it is a relative url, its a local file and we need to add
+    // it to the dependency graph. otherwise, ignore
+    if (ref === null || !isRelativeURL(ref)) {
+      return
+    }
+
+    let fp = path.join(file.data.filePath!, "..", ref).replace(/\\/g, "/")
+    // markdown files have the .md extension stripped in hrefs, add it back here
+    if (!fp.split("/").pop()?.includes(".")) {
+      fp += ".md"
+    }
+    dependencies.push(fp)
+  })
+
+  return dependencies
+}
 
 export const ContentPage: QuartzEmitterPlugin<Partial<FullPageLayout>> = (userOpts) => {
   const opts: FullPageLayout = {
@@ -29,13 +65,16 @@ export const ContentPage: QuartzEmitterPlugin<Partial<FullPageLayout>> = (userOp
       return [Head, Header, Body, ...header, ...beforeBody, pageBody, ...left, ...right, Footer]
     },
     async getDependencyGraph(ctx, content, _resources) {
-      // TODO handle transclusions
       const graph = new DepGraph<FilePath>()
 
-      for (const [_tree, file] of content) {
+      for (const [tree, file] of content) {
         const sourcePath = file.data.filePath!
         const slug = file.data.slug!
         graph.addEdge(sourcePath, joinSegments(ctx.argv.output, slug + ".html") as FilePath)
+
+        parseDependencies(tree as Root, file).forEach((dep) => {
+          graph.addEdge(dep as FilePath, sourcePath)
+        })
       }
 
       return graph


### PR DESCRIPTION
## Motivation
Currently `npx quartz build --serve` does not show changes to transcluded files. For eg. if 2.md embeds 1.md, and 1.md is changed, that change shows up on localhost:8080/1 but not localhost:8080/2. See https://github.com/jackyzha0/quartz/issues/791 for more details.

This PR fixes that behaviour, and also updates the `ContentPage` emitter so that transclusions are refreshed when run with [--fastRebuild](https://github.com/jackyzha0/quartz/pull/716) too.

## Changes
- Clone html ast so that transclusion reference is maintained rather than being overwritten by embedded file contents at time of first build
- Update `getFileDependencies` to get included files, scripts, imgs and links

https://github.com/jackyzha0/quartz/assets/15871468/a5f2713c-5fcc-404f-8f4a-030be9513fb3


