### PR TITLE
fix(fast rebuild): call only required emitters, don't always copy assets

### DIFF
--- a/quartz/build.ts
+++ b/quartz/build.ts
@@ -203,8 +203,9 @@ async function partialRebuildFromEntrypoint(
           const emitterGraph =
             (await emitter.getDependencyGraph?.(ctx, processedFiles, staticResources)) ?? null
 
-          // emmiter may not define a dependency graph. nothing to update if so
-          if (emitterGraph) {
+          // only update the graph if the emitter plugin uses the changed file
+          // eg. Assets plugin ignores md files, so we skip updating the graph
+          if (emitterGraph?.hasNode(fp)) {
             // merge the new dependencies into the dep graph
             dependencies[emitter.name]?.updateIncomingEdgesForNode(emitterGraph, fp)
           }

--- a/quartz/plugins/emitters/assets.ts
+++ b/quartz/plugins/emitters/assets.ts
@@ -5,6 +5,11 @@ import fs from "fs"
 import { glob } from "../../util/glob"
 import DepGraph from "../../depgraph"
 
+const filesToCopy = async (argv: any, cfg: any) => {
+  // glob all non MD files in content folder and copy it over
+  return await glob("**", argv.directory, ["**/*.md", ...cfg.configuration.ignorePatterns])
+}
+
 export const Assets: QuartzEmitterPlugin = () => {
   return {
     name: "Assets",
@@ -15,7 +20,7 @@ export const Assets: QuartzEmitterPlugin = () => {
       const { argv, cfg } = ctx
       const graph = new DepGraph<FilePath>()
 
-      const fps = await glob("**", argv.directory, ["**/*.md", ...cfg.configuration.ignorePatterns])
+      const fps = await filesToCopy(argv, cfg)
 
       for (const fp of fps) {
         const ext = path.extname(fp)
@@ -30,9 +35,8 @@ export const Assets: QuartzEmitterPlugin = () => {
       return graph
     },
     async emit({ argv, cfg }, _content, _resources): Promise<FilePath[]> {
-      // glob all non MD/MDX/HTML files in content folder and copy it over
       const assetsPath = argv.output
-      const fps = await glob("**", argv.directory, ["**/*.md", ...cfg.configuration.ignorePatterns])
+      const fps = await filesToCopy(argv, cfg)
       const res: FilePath[] = []
       for (const fp of fps) {
         const ext = path.extname(fp)

--- a/quartz/plugins/emitters/assets.ts
+++ b/quartz/plugins/emitters/assets.ts
@@ -4,8 +4,10 @@ import path from "path"
 import fs from "fs"
 import { glob } from "../../util/glob"
 import DepGraph from "../../depgraph"
+import { Argv } from "../../util/ctx"
+import { QuartzConfig } from "../../cfg"
 
-const filesToCopy = async (argv: any, cfg: any) => {
+const filesToCopy = async (argv: Argv, cfg: QuartzConfig) => {
   // glob all non MD files in content folder and copy it over
   return await glob("**", argv.directory, ["**/*.md", ...cfg.configuration.ignorePatterns])
 }


### PR DESCRIPTION
There was a bug in the partial rebuild implementation that added a file to every emitters dependency graph if it was edited. 

This PR fixes that bug. The most useful result is that the Assets emitter is not called when markdown files are changed.