### PR TITLE
fix: incorrect link resolution for transclusion in root index file

### DIFF
--- a/quartz/plugins/transformers/links.ts
+++ b/quartz/plugins/transformers/links.ts
@@ -8,6 +8,7 @@ import {
   simplifySlug,
   splitAnchor,
   transformLink,
+  joinSegments,
 } from "../../util/path"
 import path from "path"
 import { visit } from "unist-util-visit"
@@ -107,7 +108,7 @@ export const CrawlLinks: QuartzTransformerPlugin<Partial<Options> | undefined> =
 
                   // url.resolve is considered legacy
                   // WHATWG equivalent https://nodejs.dev/en/api/v18/url/#urlresolvefrom-to
-                  const url = new URL(dest, `https://base.com/${curSlug}`)
+                  const url = new URL(dest, joinSegments(`https://base.com/`, curSlug))
                   const canonicalDest = url.pathname
                   let [destCanonical, _destAnchor] = splitAnchor(canonicalDest)
                   if (destCanonical.endsWith("/")) {


### PR DESCRIPTION
Hello,

I had an issue where trying to transclude files from the root index file wouldn't work. Like in the exact same file, having it as an index would replace otherwise working transcludes with just links saying "Transclude of X". I tracked it down to this:
https://github.com/jackyzha0/quartz/blob/226891b9b1630c90835d1bc1a239c2ebbb5c9ff1/quartz/plugins/transformers/links.ts#L110
Which works fine in general, but in the case of the root index, curSlug equals '/', which resolves the url to `base.com//other/page`, in which the path is `/other/page` and thus unrecognized because of the leading slash.
Here's a quick and dirty fix. There's probably a cleaner way to do it