### PR TITLE
Add support for image popovers

### DIFF
--- a/docs/features/popover previews.md
+++ b/docs/features/popover previews.md
@@ -8,7 +8,7 @@ By default, Quartz only fetches previews for pages inside your vault due to [COR
 
 When [[creating components|creating your own components]], you can include this `popover-hint` class to also include it in the popover.
 
-Like in Obsidian, [[quartz layout.png|images referenced using wikilinks]] can also be viewed as popups.
+Similar to Obsidian, [[quartz layout.png|images referenced using wikilinks]] can also be viewed as popups.
 
 ## Configuration
 

--- a/docs/features/popover previews.md
+++ b/docs/features/popover previews.md
@@ -8,6 +8,8 @@ By default, Quartz only fetches previews for pages inside your vault due to [COR
 
 When [[creating components|creating your own components]], you can include this `popover-hint` class to also include it in the popover.
 
+Like in Obsidian, [[quartz layout.png|images referenced using wikilinks]] can also be viewed as popups.
+
 ## Configuration
 
 - Remove popovers: set the `enablePopovers` field in `quartz.config.ts` to be `false`.

--- a/quartz/components/scripts/popover.inline.ts
+++ b/quartz/components/scripts/popover.inline.ts
@@ -48,6 +48,7 @@ async function mouseEnterHandler(
 
   if (!response) return
   const contentType = response.headers.get("Content-Type")
+  const contentTypeCategory = contentType?.split("/")[0] ?? "text"
 
   const popoverElement = document.createElement("div")
   popoverElement.classList.add("popover")
@@ -55,7 +56,8 @@ async function mouseEnterHandler(
   popoverInner.classList.add("popover-inner")
   popoverElement.appendChild(popoverInner)
 
-  const contentTypeCategory = contentType?.split("/")[0] ?? "text"
+  popoverInner.dataset.contentType = contentTypeCategory
+
   switch (contentTypeCategory) {
     case "image":
       const img = document.createElement("img")
@@ -66,9 +68,7 @@ async function mouseEnterHandler(
       img.alt = targetUrl.pathname
 
       popoverInner.appendChild(img)
-      popoverInner.classList.add("popover-inner-img")
       break
-    case "text":
     default:
       const contents = await response.text()
       const html = p.parseFromString(contents, "text/html")

--- a/quartz/components/scripts/popover.inline.ts
+++ b/quartz/components/scripts/popover.inline.ts
@@ -55,30 +55,28 @@ async function mouseEnterHandler(
   popoverInner.classList.add("popover-inner")
   popoverElement.appendChild(popoverInner)
 
-  if (contentType && contentType.includes("image")) {
-    // const imgSrc = targetUrl.href
-    const img = document.createElement("img")
+  const contentTypeCategory = contentType?.split("/")[0] ?? "text"
+  switch (contentTypeCategory) {
+    case "image":
+      const img = document.createElement("img")
 
-    response.blob().then((blob) => {
-      img.src = URL.createObjectURL(blob)
-    })
-    img.alt = targetUrl.pathname
+      response.blob().then((blob) => {
+        img.src = URL.createObjectURL(blob)
+      })
+      img.alt = targetUrl.pathname
 
-    popoverInner.appendChild(img)
+      popoverInner.appendChild(img)
+      popoverInner.classList.add("popover-inner-img")
+      break
+    case "text":
+    default:
+      const contents = await response.text()
+      const html = p.parseFromString(contents, "text/html")
+      normalizeRelativeURLs(html, targetUrl)
+      const elts = [...html.getElementsByClassName("popover-hint")]
+      if (elts.length === 0) return
 
-    img.style.margin = "0"
-    img.style.verticalAlign = "bottom"
-    img.style.display = "block"
-    popoverInner.style.padding = "0"
-    popoverInner.style.maxHeight = "100%"
-  } else {
-    const contents = await response.text()
-    const html = p.parseFromString(contents, "text/html")
-    normalizeRelativeURLs(html, targetUrl)
-    const elts = [...html.getElementsByClassName("popover-hint")]
-    if (elts.length === 0) return
-
-    elts.forEach((elt) => popoverInner.appendChild(elt))
+      elts.forEach((elt) => popoverInner.appendChild(elt))
   }
 
   setPosition(popoverElement)

--- a/quartz/components/scripts/popover.inline.ts
+++ b/quartz/components/scripts/popover.inline.ts
@@ -48,7 +48,7 @@ async function mouseEnterHandler(
 
   if (!response) return
   const contentType = response.headers.get("Content-Type")
-  
+
   const popoverElement = document.createElement("div")
   popoverElement.classList.add("popover")
   const popoverInner = document.createElement("div")
@@ -61,11 +61,11 @@ async function mouseEnterHandler(
 
     response.blob().then((blob) => {
       img.src = URL.createObjectURL(blob)
-    });
+    })
     img.alt = targetUrl.pathname
 
     popoverInner.appendChild(img)
-    
+
     img.style.margin = "0"
     img.style.verticalAlign = "bottom"
     img.style.display = "block"

--- a/quartz/components/styles/popover.scss
+++ b/quartz/components/styles/popover.scss
@@ -38,7 +38,7 @@
     white-space: normal;
   }
 
-  & > .popover-inner-img {
+  & > .popover-inner[data-content-type="image"] {
     padding: 0;
     max-height: 100%;
 

--- a/quartz/components/styles/popover.scss
+++ b/quartz/components/styles/popover.scss
@@ -38,6 +38,17 @@
     white-space: normal;
   }
 
+  & > .popover-inner-img {
+    padding: 0;
+    max-height: 100%;
+
+    img {
+      margin: 0;
+      border-radius: 0;
+      display: block;
+    }
+  }
+
   h1 {
     font-size: 1.5rem;
   }


### PR DESCRIPTION
Super simple implementation, I just check if the content type includes "image" in the existing popover script. Had to adjust styles for `popoverInner` a little since vertical images would have scrollbars otherwise. This still works with floating ui thankfully. 
Example of this functionality in Obsidian:
<img width="546" alt="Screenshot 2024-02-12 at 18 09 26" src="https://github.com/jackyzha0/quartz/assets/33621804/a4266ac2-bc5d-4948-9e99-e14319b86b42">

Example in the Quartz Docs:
<img width="855" alt="Screenshot 2024-02-12 at 18 11 47" src="https://github.com/jackyzha0/quartz/assets/33621804/faedcd31-216a-4210-a84e-cbe6354a7e3e">
