### PR TITLE
chore: CDNJS instead of JSDelivr

### DIFF
--- a/docs/advanced/making plugins.md
+++ b/docs/advanced/making plugins.md
@@ -87,7 +87,7 @@ export const Latex: QuartzTransformerPlugin<Options> = (opts?: Options) => {
           css: ["https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.css"],
           js: [
             {
-              src: "https://cdn.jsdelivr.net/npm/katex@0.16.7/dist/contrib/copy-tex.min.js",
+              src: "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.7/contrib/copy-tex.min.js",
               loadTime: "afterDOMReady",
               contentType: "external",
             },

--- a/quartz/plugins/transformers/latex.ts
+++ b/quartz/plugins/transformers/latex.ts
@@ -26,12 +26,12 @@ export const Latex: QuartzTransformerPlugin<Options> = (opts?: Options) => {
         return {
           css: [
             // base css
-            "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css",
+            "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.9/katex.min.css",
           ],
           js: [
             {
               // fix copy behaviour: https://github.com/KaTeX/KaTeX/blob/main/contrib/copy-tex/README.md
-              src: "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/copy-tex.min.js",
+              src: "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.9/contrib/copy-tex.min.js",
               loadTime: "afterDOMReady",
               contentType: "external",
             },

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -619,7 +619,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
           let mermaidImport = undefined
           document.addEventListener('nav', async () => {
             if (document.querySelector("code.mermaid")) {
-              mermaidImport ||= await import('https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.esm.min.mjs')
+              mermaidImport ||= await import('https://cdnjs.cloudflare.com/ajax/libs/mermaid/10.7.0/mermaid.esm.min.mjs')
               const mermaid = mermaidImport.default
               const darkMode = document.documentElement.getAttribute('saved-theme') === 'dark'
               mermaid.initialize({


### PR DESCRIPTION
Many instances of quartz are hosted on cloudflare pages, and having the packages come from the same source may give a minuscule bump to speed and one less domain to connect to. For github pages and others, there is no difference.

This also removes "[Latest version](https://github.com/cdnjs/packages#latest-version-url-support)" support which can prevent some bugs from happening since a package is not auto-updating.