### PR TITLE
docs: workaround for shallow clones on Cloudflare Pages

### DIFF
--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -30,7 +30,7 @@ Press "Save and deploy" and Cloudflare should have a deployed version of your si
 To add a custom domain, check out [Cloudflare's documentation](https://developers.cloudflare.com/pages/platform/custom-domains/).
 
 > [!warning]
-> Cloudflare Pages only allows shallow `git` clones so if you rely on `git` for timestamps, it is recommended you either add dates to your frontmatter (see [[authoring content#Syntax]]) or use another hosting provider.
+> Cloudflare Pages performs a shallow clone by default, so if you rely on `git` for timestamps, it is recommended that you add `git fetch --unshallow &&` to the beginning of the build command (e.g., `git fetch --unshallow && npx quartz build`).
 
 ## GitHub Pages
 


### PR DESCRIPTION
Rather than recommend a different hosting provider, Cloudflare Pages users that prioritize the `git` method for their `CreatedModifiedDate` configuration can preface the build command with a means of fetching the required repository history.

See:
- https://gohugo.io/methods/page/gitinfo/#hosting-considerations