### PR TITLE
fix(frontmatter): delimiters parameter was not passed

### DIFF
--- a/quartz/plugins/transformers/frontmatter.ts
+++ b/quartz/plugins/transformers/frontmatter.ts
@@ -8,12 +8,12 @@ import { QuartzPluginData } from "../vfile"
 import { i18n } from "../../i18n"
 
 export interface Options {
-  delims: string | string[]
+  delimiters: string | [string, string] | undefined
   language: "yaml" | "toml"
 }
 
 const defaultOptions: Options = {
-  delims: "---",
+  delimiters: "---",
   language: "yaml",
 }
 

--- a/quartz/plugins/transformers/frontmatter.ts
+++ b/quartz/plugins/transformers/frontmatter.ts
@@ -8,7 +8,7 @@ import { QuartzPluginData } from "../vfile"
 import { i18n } from "../../i18n"
 
 export interface Options {
-  delimiters: string | [string, string] | undefined
+  delimiters: string | [string, string]
   language: "yaml" | "toml"
 }
 


### PR DESCRIPTION
The delimiters parameter was passed in a deprecated format to the underlying library. This is probably a result of following the official README... which is unfortunately broken (see https://github.com/jonschlinkert/gray-matter/issues/91).

The library method signature in TS correctly shows that `delimiters` needs to be used.

Also the option types are a little bit different than set in Quartz (it can be 1 or 2 strings, not more).