### PR TITLE
feat: support custom title tag name

### DIFF
--- a/quartz/plugins/transformers/frontmatter.ts
+++ b/quartz/plugins/transformers/frontmatter.ts
@@ -10,13 +10,13 @@ import { i18n } from "../../i18n"
 export interface Options {
   delimiters: string | [string, string]
   language: "yaml" | "toml"
-  titleTag: string
+  titleKey: string
 }
 
 const defaultOptions: Options = {
   delimiters: "---",
   language: "yaml",
-  titleTag: "title",
+  titleKey: "title",
 }
 
 function coalesceAliases(data: { [key: string]: any }, aliases: string[]) {
@@ -59,8 +59,8 @@ export const FrontMatter: QuartzTransformerPlugin<Partial<Options> | undefined> 
               },
             })
 
-            if (data[opts.titleTag] !== undefined && data[opts.titleTag] !== null) {
-              data.title = data[opts.titleTag].toString()
+            if (data[opts.titleKey] !== undefined && data[opts.titleKey] !== null) {
+              data.title = data[opts.titleKey].toString()
             } else {
               data.title = file.stem ?? i18n(cfg.configuration.locale).propertyDefaults.title
             }

--- a/quartz/plugins/transformers/frontmatter.ts
+++ b/quartz/plugins/transformers/frontmatter.ts
@@ -10,11 +10,13 @@ import { i18n } from "../../i18n"
 export interface Options {
   delimiters: string | [string, string]
   language: "yaml" | "toml"
+  titleTag: string
 }
 
 const defaultOptions: Options = {
   delimiters: "---",
   language: "yaml",
+  titleTag: "title",
 }
 
 function coalesceAliases(data: { [key: string]: any }, aliases: string[]) {
@@ -57,9 +59,9 @@ export const FrontMatter: QuartzTransformerPlugin<Partial<Options> | undefined> 
               },
             })
 
-            if (data.title) {
-              data.title = data.title.toString()
-            } else if (data.title === null || data.title === undefined) {
+            if (data[opts.titleTag] !== undefined && data[opts.titleTag] !== null) {
+              data.title = data[opts.titleTag].toString()
+            } else {
               data.title = file.stem ?? i18n(cfg.configuration.locale).propertyDefaults.title
             }
 


### PR DESCRIPTION
While using the `title` key in frontmatter for the page title is a common convention, some people (including me) use another key for the page title. For example, I use `note: Title` instead of `title: Title`, because `title` has already another meaning in my vault.

This PR adds support for a custom property to use as the title. The default is of course still `title`, so no user action is required.

Also, the titles `0`, `-0` and `false` previously crashed Quartz because of JS falsyness... Now they are displayed properly. Hope it's okay to put this into the same PR as it's just one line, but I can seperate the fix if you want.

I named the option `titleKey` for now, but `titleProperty` would also be a valid alternative.