### PR TITLE
feat: add plugin to remove first h1 header

### DIFF
--- a/quartz/plugins/transformers/heading.ts
+++ b/quartz/plugins/transformers/heading.ts
@@ -1,8 +1,8 @@
 import { QuartzTransformerPlugin } from "../types"
-import { visit } from 'unist-util-visit';
+import { visit } from "unist-util-visit"
 
 export interface Options {
-  startOnly: boolean,
+  startOnly: boolean
 }
 
 const defaultOptions: Options = {
@@ -11,30 +11,32 @@ const defaultOptions: Options = {
 
 function removeFirstH1({ startOnly }: Options) {
   return (tree: any) => {
-    visit(tree, 'heading', (node: any, index: number | undefined, parent: any) => {
-      const hasFrontmatter = parent.children.some((child: { type: string }) => child.type === 'yaml');
-      const isFirstRelevantNode = index === (hasFrontmatter ? 1 : 0);
+    visit(tree, "heading", (node: any, index: number | undefined, parent: any) => {
+      const hasFrontmatter = parent.children.some(
+        (child: { type: string }) => child.type === "yaml",
+      )
+      const isFirstRelevantNode = index === (hasFrontmatter ? 1 : 0)
 
       if (startOnly && !isFirstRelevantNode) {
-        return;
+        return
       }
 
       if (node.depth === 1) {
-        parent.children.splice(index!, 1);
-        return;
+        parent.children.splice(index!, 1)
+        return
       }
-    });
-  };
+    })
+  }
 }
 
-export const RemoveFirstHeading: QuartzTransformerPlugin<Partial<Options> | undefined> = (userOpts) => {
+export const RemoveFirstHeading: QuartzTransformerPlugin<Partial<Options> | undefined> = (
+  userOpts,
+) => {
   const opts = { ...defaultOptions, ...userOpts }
   return {
     name: "RemoveFirstHeading",
     markdownPlugins() {
-      return [
-        [removeFirstH1, {startOnly: opts.startOnly}]
-      ]
+      return [[removeFirstH1, { startOnly: opts.startOnly }]]
     },
   }
 }

--- a/quartz/plugins/transformers/heading.ts
+++ b/quartz/plugins/transformers/heading.ts
@@ -1,0 +1,40 @@
+import { QuartzTransformerPlugin } from "../types"
+import { visit } from 'unist-util-visit';
+
+export interface Options {
+  startOnly: boolean,
+}
+
+const defaultOptions: Options = {
+  startOnly: true,
+}
+
+function removeFirstH1({ startOnly }: Options) {
+  return (tree: any) => {
+    visit(tree, 'heading', (node: any, index: number | undefined, parent: any) => {
+      const hasFrontmatter = parent.children.some((child: { type: string }) => child.type === 'yaml');
+      const isFirstRelevantNode = index === (hasFrontmatter ? 1 : 0);
+
+      if (startOnly && !isFirstRelevantNode) {
+        return;
+      }
+
+      if (node.depth === 1) {
+        parent.children.splice(index!, 1);
+        return;
+      }
+    });
+  };
+}
+
+export const RemoveFirstHeading: QuartzTransformerPlugin<Partial<Options> | undefined> = (userOpts) => {
+  const opts = { ...defaultOptions, ...userOpts }
+  return {
+    name: "RemoveFirstHeading",
+    markdownPlugins() {
+      return [
+        [removeFirstH1, {startOnly: opts.startOnly}]
+      ]
+    },
+  }
+}

--- a/quartz/plugins/transformers/index.ts
+++ b/quartz/plugins/transformers/index.ts
@@ -9,4 +9,4 @@ export { OxHugoFlavouredMarkdown } from "./oxhugofm"
 export { SyntaxHighlighting } from "./syntax"
 export { TableOfContents } from "./toc"
 export { HardLineBreaks } from "./linebreaks"
-export { RemoveFirstHeading } from './heading'
+export { RemoveFirstHeading } from "./heading"

--- a/quartz/plugins/transformers/index.ts
+++ b/quartz/plugins/transformers/index.ts
@@ -9,3 +9,4 @@ export { OxHugoFlavouredMarkdown } from "./oxhugofm"
 export { SyntaxHighlighting } from "./syntax"
 export { TableOfContents } from "./toc"
 export { HardLineBreaks } from "./linebreaks"
+export { RemoveFirstHeading } from './heading'


### PR DESCRIPTION
When writing markdown, it's customary to have a H1 header at the top of the file, e.g.

```
---
title: Page Title
tags: ["test", "custom", "title"]
---

# Page Title

Some text

## H2 Title

More text
```

This can for example be enforced by the great [Obsidian Linter](https://github.com/platers/obsidian-linter) extension.

Since Quartz uses the frontmatter title (or filename as a fallback) to display the page header, the result is that there are two headers:

![image](https://github.com/jackyzha0/quartz/assets/1475672/1bd4ac1a-f77e-45f2-afda-cee3e7ba1527)

This plugin removes the additional Markdown title:

![image](https://github.com/jackyzha0/quartz/assets/1475672/f4094d2c-0e17-4fd2-b3c1-3a08606bdc38)
