### PR TITLE
fix: correctly parse falsy js as title

### DIFF
--- a/quartz/plugins/transformers/frontmatter.ts
+++ b/quartz/plugins/transformers/frontmatter.ts
@@ -57,9 +57,9 @@ export const FrontMatter: QuartzTransformerPlugin<Partial<Options> | undefined> 
               },
             })
 
-            if (data.title) {
+            if (data.title != null && data.title.toString() !== "") {
               data.title = data.title.toString()
-            } else if (data.title === null || data.title === undefined) {
+            } else {
               data.title = file.stem ?? i18n(cfg.configuration.locale).propertyDefaults.title
             }
 


### PR DESCRIPTION
See #894, this is only the fix without new functionality. I added a check for an empty string after conversion to string so it it guaranteed there is always a title.