### PR TITLE
feat: disable popovers for page with frontmatter disablePopovers: true

### DIFF
--- a/quartz/plugins/transformers/frontmatter.ts
+++ b/quartz/plugins/transformers/frontmatter.ts
@@ -92,6 +92,7 @@ declare module "vfile" {
         draft: boolean
         enableToc: string
         cssclasses: string[]
+        disablePopovers: boolean
       }>
   }
 }

--- a/quartz/plugins/transformers/links.ts
+++ b/quartz/plugins/transformers/links.ts
@@ -50,6 +50,11 @@ export const CrawlLinks: QuartzTransformerPlugin<Partial<Options> | undefined> =
             }
 
             visit(tree, "element", (node, _index, _parent) => {
+              // disable popovers if specified in frontmatter
+              if (file.data.frontmatter?.disablePopovers) {
+                node.properties["data-no-popover"] = true
+              }
+
               // rewrite all links
               if (
                 node.tagName === "a" &&


### PR DESCRIPTION
As quick fix for #890 I'd like to add the option to disable popovers for page with frontmatter `disablePopovers: true`
Maybe some users will also find this feature useful.