### PR TITLE
fix: add space and missing dot for listing pages

### DIFF
--- a/quartz/components/pages/TagContent.tsx
+++ b/quartz/components/pages/TagContent.tsx
@@ -66,9 +66,12 @@ function TagContent(props: QuartzComponentProps) {
                   <p>
                     {i18n(cfg.locale).pages.tagContent.itemsUnderTag({ count: pages.length })}
                     {pages.length > numPages && (
-                      <span>
-                        {i18n(cfg.locale).pages.tagContent.showingFirst({ count: numPages })}
-                      </span>
+                      <>
+                        {" "}
+                        <span>
+                          {i18n(cfg.locale).pages.tagContent.showingFirst({ count: numPages })}
+                        </span>
+                      </>
                     )}
                   </p>
                   <PageList limit={numPages} {...listProps} />

--- a/quartz/i18n/locales/de-DE.ts
+++ b/quartz/i18n/locales/de-DE.ts
@@ -69,13 +69,13 @@ export default {
     folderContent: {
       folder: "Ordner",
       itemsUnderFolder: ({ count }) =>
-        count === 1 ? "1 Datei in diesem Ordner" : `${count} Dateien in diesem Ordner.`,
+        count === 1 ? "1 Datei in diesem Ordner." : `${count} Dateien in diesem Ordner.`,
     },
     tagContent: {
       tag: "Tag",
       tagIndex: "Tag-Übersicht",
       itemsUnderTag: ({ count }) =>
-        count === 1 ? "1 Datei mit diesem Tag" : `${count} Dateien mit diesem Tag.`,
+        count === 1 ? "1 Datei mit diesem Tag." : `${count} Dateien mit diesem Tag.`,
       showingFirst: ({ count }) => `Die ersten ${count} Tags werden angezeigt.`,
       totalTags: ({ count }) => `${count} Tags insgesamt.`,
     },

--- a/quartz/i18n/locales/en-US.ts
+++ b/quartz/i18n/locales/en-US.ts
@@ -69,13 +69,13 @@ export default {
     folderContent: {
       folder: "Folder",
       itemsUnderFolder: ({ count }) =>
-        count === 1 ? "1 item under this folder" : `${count} items under this folder.`,
+        count === 1 ? "1 item under this folder." : `${count} items under this folder.`,
     },
     tagContent: {
       tag: "Tag",
       tagIndex: "Tag Index",
       itemsUnderTag: ({ count }) =>
-        count === 1 ? "1 item with this tag" : `${count} items with this tag.`,
+        count === 1 ? "1 item with this tag." : `${count} items with this tag.`,
       showingFirst: ({ count }) => `Showing first ${count} tags.`,
       totalTags: ({ count }) => `Found ${count} total tags.`,
     },

--- a/quartz/i18n/locales/es-ES.ts
+++ b/quartz/i18n/locales/es-ES.ts
@@ -69,13 +69,13 @@ export default {
     folderContent: {
       folder: "Carpeta",
       itemsUnderFolder: ({ count }) =>
-        count === 1 ? "1 artículo en esta carpeta" : `${count} artículos en esta carpeta.`,
+        count === 1 ? "1 artículo en esta carpeta." : `${count} artículos en esta carpeta.`,
     },
     tagContent: {
       tag: "Etiqueta",
       tagIndex: "Índice de Etiquetas",
       itemsUnderTag: ({ count }) =>
-        count === 1 ? "1 artículo con esta etiqueta" : `${count} artículos con esta etiqueta.`,
+        count === 1 ? "1 artículo con esta etiqueta." : `${count} artículos con esta etiqueta.`,
       showingFirst: ({ count }) => `Mostrando las primeras ${count} etiquetas.`,
       totalTags: ({ count }) => `Se encontraron ${count} etiquetas en total.`,
     },

--- a/quartz/i18n/locales/fr-FR.ts
+++ b/quartz/i18n/locales/fr-FR.ts
@@ -69,13 +69,13 @@ export default {
     folderContent: {
       folder: "Dossier",
       itemsUnderFolder: ({ count }) =>
-        count === 1 ? "1 élément sous ce dossier" : `${count} éléments sous ce dossier.`,
+        count === 1 ? "1 élément sous ce dossier." : `${count} éléments sous ce dossier.`,
     },
     tagContent: {
       tag: "Étiquette",
       tagIndex: "Index des étiquettes",
       itemsUnderTag: ({ count }) =>
-        count === 1 ? "1 élément avec cette étiquette" : `${count} éléments avec cette étiquette.`,
+        count === 1 ? "1 élément avec cette étiquette." : `${count} éléments avec cette étiquette.`,
       showingFirst: ({ count }) => `Affichage des premières ${count} étiquettes.`,
       totalTags: ({ count }) => `Trouvé ${count} étiquettes au total.`,
     },

--- a/quartz/i18n/locales/it-IT.ts
+++ b/quartz/i18n/locales/it-IT.ts
@@ -69,13 +69,13 @@ export default {
     folderContent: {
       folder: "Cartella",
       itemsUnderFolder: ({ count }) =>
-        count === 1 ? "1 oggetto in questa cartella" : `${count} oggetti in questa cartella.`,
+        count === 1 ? "1 oggetto in questa cartella." : `${count} oggetti in questa cartella.`,
     },
     tagContent: {
       tag: "Etichetta",
       tagIndex: "Indice etichette",
       itemsUnderTag: ({ count }) =>
-        count === 1 ? "1 oggetto con questa etichetta" : `${count} oggetti con questa etichetta.`,
+        count === 1 ? "1 oggetto con questa etichetta." : `${count} oggetti con questa etichetta.`,
       showingFirst: ({ count }) => `Prime ${count} etichette.`,
       totalTags: ({ count }) => `Trovate ${count} etichette totali.`,
     },

--- a/quartz/i18n/locales/nl-NL.ts
+++ b/quartz/i18n/locales/nl-NL.ts
@@ -70,7 +70,7 @@ export default {
     folderContent: {
       folder: "Map",
       itemsUnderFolder: ({ count }) =>
-        count === 1 ? "1 item in deze map" : `${count} items in deze map.`,
+        count === 1 ? "1 item in deze map." : `${count} items in deze map.`,
     },
     tagContent: {
       tag: "Label",

--- a/quartz/i18n/locales/uk-UA.ts
+++ b/quartz/i18n/locales/uk-UA.ts
@@ -69,13 +69,13 @@ export default {
     folderContent: {
       folder: "Папка",
       itemsUnderFolder: ({ count }) =>
-        count === 1 ? "У цій папці 1 елемент" : `Елементів у цій папці: ${count}.`,
+        count === 1 ? "У цій папці 1 елемент." : `Елементів у цій папці: ${count}.`,
     },
     tagContent: {
       tag: "Тег",
       tagIndex: "Індекс тегу",
       itemsUnderTag: ({ count }) =>
-        count === 1 ? "1 елемент з цим тегом" : `Елементів з цим тегом: ${count}.`,
+        count === 1 ? "1 елемент з цим тегом." : `Елементів з цим тегом: ${count}.`,
       showingFirst: ({ count }) => `Показ перших ${count} тегів.`,
       totalTags: ({ count }) => `Всього знайдено тегів: ${count}.`,
     },


### PR DESCRIPTION
New day, new PR ;-)

This one adds the missing space here and unifies the usage of the dot at the end. The singular had a dot in some languages, the plural in all languages. Now the dot is always there.

Before:

![image](https://github.com/jackyzha0/quartz/assets/1475672/42e6db38-3ab1-4189-9990-ca5667f3dd1a)
![image](https://github.com/jackyzha0/quartz/assets/1475672/9197bc73-43c1-4d5c-9803-30be1ee9b4b1)
![image](https://github.com/jackyzha0/quartz/assets/1475672/3c971452-e25b-4f30-86a3-d9231f85753d)


After:

![image](https://github.com/jackyzha0/quartz/assets/1475672/c5ee5b58-7ce0-4d4c-a35a-ff2f254d9f7b)
![image](https://github.com/jackyzha0/quartz/assets/1475672/2721c196-18ec-4fb9-9b8e-06ca7d21ebaf)
