### PR TITLE
fix(toc): correct type for minEntries param

### DIFF
--- a/quartz/plugins/transformers/toc.ts
+++ b/quartz/plugins/transformers/toc.ts
@@ -6,7 +6,7 @@ import Slugger from "github-slugger"
 
 export interface Options {
   maxDepth: 1 | 2 | 3 | 4 | 5 | 6
-  minEntries: 1
+  minEntries: number
   showByDefault: boolean
   collapseByDefault: boolean
 }
@@ -52,7 +52,7 @@ export const TableOfContents: QuartzTransformerPlugin<Partial<Options> | undefin
                 }
               })
 
-              if (toc.length > opts.minEntries) {
+              if (toc.length > 0 && toc.length > opts.minEntries) {
                 file.data.toc = toc.map((entry) => ({
                   ...entry,
                   depth: entry.depth - highestDepth,


### PR DESCRIPTION
Fixes this typing problem by setting the type to `number`. Also makes sure that a user input of `0` is handled gracefully.

![image](https://github.com/jackyzha0/quartz/assets/1475672/09d5bfbf-d85d-49b3-8383-0eef27fb1ba1)
