### PR TITLE
chore: passing additional buildCtx to componentData

### DIFF
--- a/quartz/components/types.ts
+++ b/quartz/components/types.ts
@@ -3,8 +3,10 @@ import { StaticResources } from "../util/resources"
 import { QuartzPluginData } from "../plugins/vfile"
 import { GlobalConfiguration } from "../cfg"
 import { Node } from "hast"
+import { BuildCtx } from "../util/ctx"
 
 export type QuartzComponentProps = {
+  ctx: BuildCtx
   externalResources: StaticResources
   fileData: QuartzPluginData
   cfg: GlobalConfiguration

--- a/quartz/plugins/emitters/404.tsx
+++ b/quartz/plugins/emitters/404.tsx
@@ -46,6 +46,7 @@ export const NotFoundPage: QuartzEmitterPlugin = () => {
         frontmatter: { title: notFound, tags: [] },
       })
       const componentData: QuartzComponentProps = {
+        ctx,
         fileData: vfile.data,
         externalResources,
         cfg,

--- a/quartz/plugins/emitters/contentPage.tsx
+++ b/quartz/plugins/emitters/contentPage.tsx
@@ -97,6 +97,7 @@ export const ContentPage: QuartzEmitterPlugin<Partial<FullPageLayout>> = (userOp
 
         const externalResources = pageResources(pathToRoot(slug), resources)
         const componentData: QuartzComponentProps = {
+          ctx,
           fileData: file.data,
           externalResources,
           cfg,

--- a/quartz/plugins/emitters/folderPage.tsx
+++ b/quartz/plugins/emitters/folderPage.tsx
@@ -95,6 +95,7 @@ export const FolderPage: QuartzEmitterPlugin<Partial<FullPageLayout>> = (userOpt
         const externalResources = pageResources(pathToRoot(slug), resources)
         const [tree, file] = folderDescriptions[folder]
         const componentData: QuartzComponentProps = {
+          ctx,
           fileData: file.data,
           externalResources,
           cfg,

--- a/quartz/plugins/emitters/tagPage.tsx
+++ b/quartz/plugins/emitters/tagPage.tsx
@@ -99,6 +99,7 @@ export const TagPage: QuartzEmitterPlugin<Partial<FullPageLayout>> = (userOpts) 
         const externalResources = pageResources(pathToRoot(slug), resources)
         const [tree, file] = tagDescriptions[tag]
         const componentData: QuartzComponentProps = {
+          ctx,
           fileData: file.data,
           externalResources,
           cfg,


### PR DESCRIPTION
this would help #740 to have access to argv and other build time argument.

Probably still useful since we need to pass back the map for slug, URL back to component somehow.