### PR TITLE
fix(type): coerce correct LinkData for graph

### DIFF
--- a/quartz/components/scripts/graph.inline.ts
+++ b/quartz/components/scripts/graph.inline.ts
@@ -12,7 +12,7 @@ type NodeData = {
 type LinkData = {
   source: SimpleSlug
   target: SimpleSlug
-}
+} & d3.SimulationNodeDatum
 
 const localStorageKey = "graph-visited"
 function getVisited(): Set<SimpleSlug> {


### PR DESCRIPTION
An example link object

```prolog
{
    "source": {
        "id": "/",
        "text": "Aaron's notes",
        "tags": [
            "evergreen",
            "fruit"
        ],
        "index": 22,
        "x": -50.025577042980444,
        "y": -27.05089761524019,
        "vy": 0.00018630272746150963,
        "vx": 0.0029189953805208936
    },
    "target": {
        "id": "thoughts/writing",
        "text": "Writing",
        "tags": [
            "sapling",
            "evergreen"
        ],
        "index": 15,
        "x": -74.28009506153397,
        "y": -41.16782288566355,
        "vy": 0.00017464123708282747,
        "vx": 0.002824068624643071
    },
    "index": 0
}
```


Not entirely sure where does SimulationNodeDatum comes from links here, since link.source and link.target should just be simpleSlug?