### PR TITLE
fix(fast rebuild): handle added an deleted markdown correctly

### DIFF
--- a/quartz/build.ts
+++ b/quartz/build.ts
@@ -188,7 +188,7 @@ async function partialRebuildFromEntrypoint(
         if (emitterGraph) {
           const existingGraph = dependencies[emitter.name]
           if (existingGraph !== null) {
-            existingGraph.addGraph(emitterGraph)
+            existingGraph.mergeGraph(emitterGraph)
           } else {
             // might be the first time we're adding a mardown file
             dependencies[emitter.name] = emitterGraph

--- a/quartz/build.ts
+++ b/quartz/build.ts
@@ -185,9 +185,14 @@ async function partialRebuildFromEntrypoint(
         const emitterGraph =
           (await emitter.getDependencyGraph?.(ctx, processedFiles, staticResources)) ?? null
 
-        // emmiter may not define a dependency graph. nothing to update if so
         if (emitterGraph) {
-          dependencies[emitter.name]?.updateIncomingEdgesForNode(emitterGraph, fp)
+          const existingGraph = dependencies[emitter.name]
+          if (existingGraph !== null) {
+            existingGraph.addGraph(emitterGraph)
+          } else {
+            // might be the first time we're adding a mardown file
+            dependencies[emitter.name] = emitterGraph
+          }
         }
       }
       break

--- a/quartz/build.ts
+++ b/quartz/build.ts
@@ -229,7 +229,6 @@ async function partialRebuildFromEntrypoint(
   // EMIT
   perf.addEvent("rebuild")
   let emittedFiles = 0
-  const destinationsToDelete = new Set<FilePath>()
 
   for (const emitter of cfg.plugins.emitters) {
     const depGraph = dependencies[emitter.name]
@@ -269,11 +268,6 @@ async function partialRebuildFromEntrypoint(
       // and supply [a.md, b.md] to the emitter
       const upstreams = [...depGraph.getLeafNodeAncestors(fp)] as FilePath[]
 
-      if (action === "delete" && upstreams.length === 1) {
-        // if there's only one upstream, the destination is solely dependent on this file
-        destinationsToDelete.add(upstreams[0])
-      }
-
       const upstreamContent = upstreams
         // filter out non-markdown files
         .filter((file) => contentMap.has(file))
@@ -296,14 +290,24 @@ async function partialRebuildFromEntrypoint(
   console.log(`Emitted ${emittedFiles} files to \`${argv.output}\` in ${perf.timeSince("rebuild")}`)
 
   // CLEANUP
-  // delete files that are solely dependent on this file
-  await rimraf([...destinationsToDelete])
+  const destinationsToDelete = new Set<FilePath>()
   for (const file of toRemove) {
     // remove from cache
     contentMap.delete(file)
-    // remove the node from dependency graphs
-    Object.values(dependencies).forEach((depGraph) => depGraph?.removeNode(file))
+    Object.values(dependencies).forEach((depGraph) => {
+      // remove the node from dependency graphs
+      depGraph?.removeNode(file)
+      // remove any orphan nodes. eg if a.md is deleted, a.html is orphaned and should be removed
+      const orphanNodes = depGraph?.removeOrphanNodes()
+      orphanNodes?.forEach((node) => {
+        // only delete files that are in the output directory
+        if (node.startsWith(argv.output)) {
+          destinationsToDelete.add(node)
+        }
+      })
+    })
   }
+  await rimraf([...destinationsToDelete])
 
   toRemove.clear()
   release()

--- a/quartz/depgraph.test.ts
+++ b/quartz/depgraph.test.ts
@@ -39,6 +39,28 @@ describe("DepGraph", () => {
     })
   })
 
+  describe("addGraph", () => {
+    test("merges two graphs", () => {
+      const graph = new DepGraph<string>()
+      graph.addEdge("A.md", "A.html")
+
+      const other = new DepGraph<string>()
+      other.addEdge("B.md", "B.html")
+
+      graph.addGraph(other)
+
+      const expected = {
+        nodes: ["A.md", "A.html", "B.md", "B.html"],
+        edges: [
+          ["A.md", "A.html"],
+          ["B.md", "B.html"],
+        ],
+      }
+
+      assert.deepStrictEqual(graph.export(), expected)
+    })
+  })
+
   describe("updateIncomingEdgesForNode", () => {
     test("merges when node exists", () => {
       // A.md -> B.md -> B.html

--- a/quartz/depgraph.test.ts
+++ b/quartz/depgraph.test.ts
@@ -39,7 +39,7 @@ describe("DepGraph", () => {
     })
   })
 
-  describe("addGraph", () => {
+  describe("mergeGraph", () => {
     test("merges two graphs", () => {
       const graph = new DepGraph<string>()
       graph.addEdge("A.md", "A.html")
@@ -47,7 +47,7 @@ describe("DepGraph", () => {
       const other = new DepGraph<string>()
       other.addEdge("B.md", "B.html")
 
-      graph.addGraph(other)
+      graph.mergeGraph(other)
 
       const expected = {
         nodes: ["A.md", "A.html", "B.md", "B.html"],

--- a/quartz/depgraph.ts
+++ b/quartz/depgraph.ts
@@ -39,9 +39,23 @@ export default class DepGraph<T> {
     }
   }
 
+  // Remove node and all edges connected to it
   removeNode(node: T): void {
     if (this._graph.has(node)) {
+      // first remove all edges so other nodes don't have references to this node
+      for (const target of this._graph.get(node)!.outgoing) {
+        this.removeEdge(node, target)
+      }
+      for (const source of this._graph.get(node)!.incoming) {
+        this.removeEdge(source, node)
+      }
       this._graph.delete(node)
+    }
+  }
+
+  forEachNode(callback: (node: T) => void): void {
+    for (const node of this._graph.keys()) {
+      callback(node)
     }
   }
 
@@ -119,6 +133,24 @@ export default class DepGraph<T> {
         this.removeEdge(source, target)
       }
     })
+  }
+
+  // Remove all nodes that do not have any incoming or outgoing edges
+  // A node may be orphaned if the only node pointing to it was removed
+  removeOrphanNodes(): Set<T> {
+    let orphanNodes = new Set<T>()
+
+    this.forEachNode((node) => {
+      if (this.inDegree(node) === 0 && this.outDegree(node) === 0) {
+        orphanNodes.add(node)
+      }
+    })
+
+    orphanNodes.forEach((node) => {
+      this.removeNode(node)
+    })
+
+    return orphanNodes
   }
 
   // Get all leaf nodes (i.e. destination paths) reachable from the node provided

--- a/quartz/depgraph.ts
+++ b/quartz/depgraph.ts
@@ -92,6 +92,15 @@ export default class DepGraph<T> {
 
   // DEPENDENCY ALGORITHMS
 
+  // Add all nodes and edges from other graph to this graph
+  addGraph(other: DepGraph<T>): void {
+    other.forEachEdge(([source, target]) => {
+      this.addNode(source)
+      this.addNode(target)
+      this.addEdge(source, target)
+    })
+  }
+
   // For the node provided:
   // If node does not exist, add it
   // If an incoming edge was added in other, it is added in this graph

--- a/quartz/depgraph.ts
+++ b/quartz/depgraph.ts
@@ -107,7 +107,7 @@ export default class DepGraph<T> {
   // DEPENDENCY ALGORITHMS
 
   // Add all nodes and edges from other graph to this graph
-  addGraph(other: DepGraph<T>): void {
+  mergeGraph(other: DepGraph<T>): void {
     other.forEachEdge(([source, target]) => {
       this.addNode(source)
       this.addNode(target)


### PR DESCRIPTION
This PR fixes some incorrect behaviour:
- When `new.md` was added, the dependency graph didn't track it
- When `content/a.md` was deleted, `public/a.html` wasn't deleted

After this PR, I think fast rebuilds are ready for default use. It would be great if beta testers could verify it operates correctly for their workflows. @aarnphm @jackyzha0 