### PR TITLE
fix(tag): move hash to sass styling only

### DIFF
--- a/quartz/components/PageList.tsx
+++ b/quartz/components/PageList.tsx
@@ -63,7 +63,7 @@ export const PageList: QuartzComponent = ({ cfg, fileData, allFiles, limit }: Pr
                       class="internal tag-link"
                       href={resolveRelative(fileData.slug!, `tags/${tag}` as FullSlug)}
                     >
-                      #{tag}
+                      {tag}
                     </a>
                   </li>
                 ))}

--- a/quartz/components/RecentNotes.tsx
+++ b/quartz/components/RecentNotes.tsx
@@ -63,7 +63,7 @@ export default ((userOpts?: Partial<Options>) => {
                           class="internal tag-link"
                           href={resolveRelative(fileData.slug!, `tags/${tag}` as FullSlug)}
                         >
-                          #{tag}
+                          {tag}
                         </a>
                       </li>
                     ))}

--- a/quartz/components/TagList.tsx
+++ b/quartz/components/TagList.tsx
@@ -9,12 +9,11 @@ const TagList: QuartzComponent = ({ fileData, displayClass }: QuartzComponentPro
     return (
       <ul class={classNames(displayClass, "tags")}>
         {tags.map((tag) => {
-          const display = `#${tag}`
           const linkDest = baseDir + `/tags/${slugTag(tag)}`
           return (
             <li>
               <a href={linkDest} class="internal tag-link">
-                {display}
+                {tag}
               </a>
             </li>
           )

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -328,7 +328,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
                   children: [
                     {
                       type: "text",
-                      value: `#${tag}`,
+                      value: tag,
                     },
                   ],
                 }

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -79,6 +79,11 @@ a {
       border-radius: 0;
       padding: 0;
     }
+    &.tag-link {
+      &::before {
+        content: "#";
+      }
+    }
   }
 
   &.external .external-icon {


### PR DESCRIPTION
This is a small change to wrap the `#` (which is added to every tag) in a `<span>` element. This allows css to target the hash 
<img width="128" alt="image" src="https://github.com/jackyzha0/quartz/assets/4028391/d898e75f-6c5e-4ccc-be30-f1842e982e8d">
