### PR TITLE
docs: Clarifications in the Explorer Docs

### DIFF
--- a/docs/features/explorer.md
+++ b/docs/features/explorer.md
@@ -61,7 +61,7 @@ export class FileNode {
   children: FileNode[]  // children of current node
   name: string  // last part of slug
   displayName: string // what actually should be displayed in the explorer
-  file: QuartzPluginData | null // set if node is a file, see `QuartzPluginData` for more detail
+  file: QuartzPluginData | null // if node is a file, this is the file's metadata. See `QuartzPluginData` for more detail
   depth: number // depth of current node
 
   ... // rest of implementation
@@ -166,6 +166,19 @@ Component.Explorer({
 ```
 
 You can customize this by changing the entries of the `omit` set. Simply add all folder or file names you want to remove.
+
+### Remove files by tag
+
+You can access the frontmatter of a file by `node.file?.frontmatter?`. This allows you to filter out files based on their frontmatter, for example by their tags.
+
+```ts title="quartz.layout.ts"
+Component.Explorer({
+  filterFn: (node) => {
+    // exclude files with the tag "explorerexclude"
+    return node.file?.frontmatter?.tags?.includes("explorerexclude") !== true
+  },
+})
+```
 
 ### Show every element in explorer
 


### PR DESCRIPTION
This is PR closes issue #932 and enhances the [Explorer Documentation](https://github.com/jackyzha0/quartz/blob/v4/docs/features/explorer.md)
### Summary
- The PR clarifies that the `file` property of `FileNode` contains metadata about that file. The previous phrasing "set if node is a file" could suggest that it is a boolean.
- Furthermore the PR adds an example of how to use that metadata to filter out notes by their tag. I think that this might be a common enough use case to justify its own example. What is more: this example doesn't only showcase how to access the tags of a file, but how to access the complete frontmatter which is useful for a lot more use cases.

As discussed in #932, the docs should not become to convoluted. In my opinion, the first change is an important clarification. The second change is more debatable, but IMHO is a more useful example the [existing filter example](https://github.com/jackyzha0/quartz/blob/v4/docs/features/explorer.md#remove-list-of-elements-filter)