### PR TITLE
feat(frontmatter): configure max length for description

### DIFF
--- a/docs/plugins/Description.md
+++ b/docs/plugins/Description.md
@@ -14,7 +14,7 @@ If the frontmatter contains a `description` property, it is used (see [[authorin
 This plugin accepts the following configuration options:
 
 - `descriptionLength`: the maximum length of the generated description. Default is 150 characters. The cut off happens after the first _sentence_ that ends after the given length.
-- `replaceExternalLinks`: If `true` (default), replace external links with their domain in the description (e.g. `https://domain.tld/` is replaced with `domain`).
+- `replaceExternalLinks`: If `true` (default), replace external links with their domain and path in the description (e.g. `https://domain.tld/some_page/another_page?query=hello&target=world` is replaced with `domain.tld/some_page/another_page`).
 
 ## API
 

--- a/docs/plugins/Description.md
+++ b/docs/plugins/Description.md
@@ -14,6 +14,7 @@ If the frontmatter contains a `description` property, it is used (see [[authorin
 This plugin accepts the following configuration options:
 
 - `descriptionLength`: the maximum length of the generated description. Default is 150 characters. The cut off happens after the first _sentence_ that ends after the given length.
+- `replaceExternalLinks`: If `true` (default), replace external links with their domain in the description (e.g. `https://domain.tld/` is replaced with `domain`).
 
 ## API
 

--- a/quartz/plugins/transformers/description.ts
+++ b/quartz/plugins/transformers/description.ts
@@ -14,7 +14,7 @@ const defaultOptions: Options = {
 }
 
 const urlRegex = new RegExp(
-  /(https?:\/\/)?(?<domain>[\da-z\.-]+)\.([a-z\.]{2,6})(:\d+)?([\/\w\.-]*)/,
+  /(https?:\/\/)?(?<domain>([\da-z\.-]+)\.([a-z\.]{2,6})(:\d+)?)(?<path>[\/\w\.-]*)(\?[\/\w\.=&;-]*)?/,
   "g",
 )
 
@@ -30,8 +30,8 @@ export const Description: QuartzTransformerPlugin<Partial<Options> | undefined> 
             let text = escapeHTML(toString(tree))
 
             if (opts.replaceExternalLinks) {
-              frontMatterDescription = frontMatterDescription?.replace(urlRegex, "$<domain>")
-              text = text.replace(urlRegex, "$<domain>")
+              frontMatterDescription = frontMatterDescription?.replace(urlRegex, "$<domain>" + "$<path>")
+              text = text.replace(urlRegex, "$<domain>" + "$<path>")
             }
 
             const desc = frontMatterDescription ?? text

--- a/quartz/plugins/transformers/description.ts
+++ b/quartz/plugins/transformers/description.ts
@@ -13,6 +13,11 @@ const defaultOptions: Options = {
   replaceExternalLinks: true,
 }
 
+const urlRegex = new RegExp(
+  /(https?:\/\/)?(?<domain>[\da-z\.-]+)\.([a-z\.]{2,6})(:\d+)?([\/\w\.-]*)/,
+  "g",
+)
+
 export const Description: QuartzTransformerPlugin<Partial<Options> | undefined> = (userOpts) => {
   const opts = { ...defaultOptions, ...userOpts }
   return {
@@ -25,14 +30,8 @@ export const Description: QuartzTransformerPlugin<Partial<Options> | undefined> 
             let text = escapeHTML(toString(tree))
 
             if (opts.replaceExternalLinks) {
-              frontMatterDescription = frontMatterDescription?.replace(
-                /(https?:\/\/)?(?<domain>[\da-z\.-]+)\.([a-z\.]{2,6})(:\d+)?([\/\w\.-]*)/g,
-                "$<domain>",
-              )
-              text = text.replace(
-                /(https?:\/\/)?(?<domain>[\da-z\.-]+)\.([a-z\.]{2,6})(:\d+)?([\/\w\.-]*)/g,
-                "$<domain>",
-              )
+              frontMatterDescription = frontMatterDescription?.replace(urlRegex, "$<domain>")
+              text = text.replace(urlRegex, "$<domain>")
             }
 
             const desc = frontMatterDescription ?? text

--- a/quartz/plugins/transformers/description.ts
+++ b/quartz/plugins/transformers/description.ts
@@ -23,15 +23,27 @@ export const Description: QuartzTransformerPlugin<Partial<Options> | undefined> 
             const text = escapeHTML(toString(tree))
 
             const desc = frontMatterDescription ?? text
-            const sentences = desc.replace(/\s+/g, " ").split(".")
+            const sentences = desc.replace(/\s+/g, " ").split(/\.\s/)
             let finalDesc = ""
             let sentenceIdx = 0
             const len = opts.descriptionLength
-            while (finalDesc.length < len) {
-              const sentence = sentences[sentenceIdx]
-              if (!sentence) break
-              finalDesc += sentence + "."
-              sentenceIdx++
+
+            if (sentences[0].length >= len) {
+              const firstSentence = sentences[0].split(" ")
+              while (finalDesc.length < len) {
+                const sentence = firstSentence[sentenceIdx]
+                if (!sentence) break
+                finalDesc += sentence + " "
+                sentenceIdx++
+              }
+              finalDesc = finalDesc.trimEnd() + "..."
+            } else {
+              while (finalDesc.length < len) {
+                const sentence = sentences[sentenceIdx]
+                if (!sentence) break
+                finalDesc += sentence + "."
+                sentenceIdx++
+              }
             }
 
             file.data.description = finalDesc

--- a/quartz/plugins/transformers/description.ts
+++ b/quartz/plugins/transformers/description.ts
@@ -21,17 +21,17 @@ export const Description: QuartzTransformerPlugin<Partial<Options> | undefined> 
       return [
         () => {
           return async (tree: HTMLRoot, file) => {
-            const frontMatterDescription = file.data.frontmatter?.description
-            const text = escapeHTML(toString(tree))
+            let frontMatterDescription = file.data.frontmatter?.description
+            let text = escapeHTML(toString(tree))
 
             if (opts.replaceExternalLinks) {
-              frontMatterDescription?.replace(
-                /(?:https?:\/\/)?([\da-z\.-]+)\.(?:[a-z\.]{2,6})(?::\d+)?(?:[\/\w\.-]*)/g,
-                "$1",
+              frontMatterDescription = frontMatterDescription?.replace(
+                /(https?:\/\/)?(?<domain>[\da-z\.-]+)\.([a-z\.]{2,6})(:\d+)?([\/\w\.-]*)/g,
+                "$<domain>",
               )
-              text.replace(
-                /(?:https?:\/\/)?([\da-z\.-]+)\.(?:[a-z\.]{2,6})(?::\d+)?(?:[\/\w\.-]*)/g,
-                "$1",
+              text = text.replace(
+                /(https?:\/\/)?(?<domain>[\da-z\.-]+)\.([a-z\.]{2,6})(:\d+)?([\/\w\.-]*)/g,
+                "$<domain>",
               )
             }
 
@@ -54,7 +54,7 @@ export const Description: QuartzTransformerPlugin<Partial<Options> | undefined> 
               while (finalDesc.length < len) {
                 const sentence = sentences[sentenceIdx]
                 if (!sentence) break
-                finalDesc += sentence + "."
+                finalDesc += sentence.endsWith(".") ? sentence : sentence + "."
                 sentenceIdx++
               }
             }

--- a/quartz/plugins/transformers/description.ts
+++ b/quartz/plugins/transformers/description.ts
@@ -5,12 +5,12 @@ import { escapeHTML } from "../../util/escape"
 
 export interface Options {
   descriptionLength: number
-  removeExternalLinks: boolean
+  replaceExternalLinks: boolean
 }
 
 const defaultOptions: Options = {
   descriptionLength: 150,
-  removeExternalLinks: true,
+  replaceExternalLinks: true,
 }
 
 export const Description: QuartzTransformerPlugin<Partial<Options> | undefined> = (userOpts) => {
@@ -24,7 +24,7 @@ export const Description: QuartzTransformerPlugin<Partial<Options> | undefined> 
             const frontMatterDescription = file.data.frontmatter?.description
             const text = escapeHTML(toString(tree))
 
-            if (opts.removeExternalLinks) {
+            if (opts.replaceExternalLinks) {
               frontMatterDescription?.replace(
                 /(?:https?:\/\/)?([\da-z\.-]+)\.(?:[a-z\.]{2,6})(?::\d+)?(?:[\/\w\.-]*)/g,
                 "$1",

--- a/quartz/plugins/transformers/description.ts
+++ b/quartz/plugins/transformers/description.ts
@@ -5,10 +5,12 @@ import { escapeHTML } from "../../util/escape"
 
 export interface Options {
   descriptionLength: number
+  removeExternalLinks: boolean
 }
 
 const defaultOptions: Options = {
   descriptionLength: 150,
+  removeExternalLinks: true,
 }
 
 export const Description: QuartzTransformerPlugin<Partial<Options> | undefined> = (userOpts) => {
@@ -21,6 +23,17 @@ export const Description: QuartzTransformerPlugin<Partial<Options> | undefined> 
           return async (tree: HTMLRoot, file) => {
             const frontMatterDescription = file.data.frontmatter?.description
             const text = escapeHTML(toString(tree))
+
+            if (opts.removeExternalLinks) {
+              frontMatterDescription?.replace(
+                /(?:https?:\/\/)?([\da-z\.-]+)\.(?:[a-z\.]{2,6})(?::\d+)?(?:[\/\w\.-]*)/g,
+                "$1",
+              )
+              text.replace(
+                /(?:https?:\/\/)?([\da-z\.-]+)\.(?:[a-z\.]{2,6})(?::\d+)?(?:[\/\w\.-]*)/g,
+                "$1",
+              )
+            }
 
             const desc = frontMatterDescription ?? text
             const sentences = desc.replace(/\s+/g, " ").split(/\.\s/)

--- a/quartz/plugins/transformers/description.ts
+++ b/quartz/plugins/transformers/description.ts
@@ -30,7 +30,10 @@ export const Description: QuartzTransformerPlugin<Partial<Options> | undefined> 
             let text = escapeHTML(toString(tree))
 
             if (opts.replaceExternalLinks) {
-              frontMatterDescription = frontMatterDescription?.replace(urlRegex, "$<domain>" + "$<path>")
+              frontMatterDescription = frontMatterDescription?.replace(
+                urlRegex,
+                "$<domain>" + "$<path>",
+              )
               text = text.replace(urlRegex, "$<domain>" + "$<path>")
             }
 

--- a/quartz/plugins/transformers/description.ts
+++ b/quartz/plugins/transformers/description.ts
@@ -40,7 +40,7 @@ export const Description: QuartzTransformerPlugin<Partial<Options> | undefined> 
             let sentenceIdx = 0
             const len = opts.descriptionLength
 
-            if (sentences[0].length >= len) {
+            if (sentences[0] !== undefined && sentences[0].length >= len) {
               const firstSentence = sentences[0].split(" ")
               while (finalDesc.length < len) {
                 const sentence = firstSentence[sentenceIdx]


### PR DESCRIPTION
Fixes #901 Descriptions sometimes are much longer than the configured max

Proposal:

 - For descriptions with sentence(s) shorter than configured maximum => no change.
 - For descriptions with sentence(s) longer than configured maximum => break sentence after first word over the limit and add "..." (e.g. `a very long sentence that is not stopping anytime soon.` => `a very long sentence...`)
 - For descriptions containing an **external** link => replace link with domain. (e.g. `https://domain.tld/` is replaced with `domain`)
     - Internal links are already handled properly.