### PR TITLE
fix(docs): correct ExplicitPublish as filters instead of transformers

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,10 +73,10 @@ You can customize the behaviour of Quartz by adding, removing and reordering plu
 > [!note]
 > Each node is modified by every transformer _in order_. Some transformers are position sensitive, so you may need to pay particular attention to whether they need to come before or after certain other plugins.
 
-You should take care to add the plugin to the right entry corresponding to its plugin type. For example, to add the [[ExplicitPublish]] plugin (a [[tags/plugin/transformer|Transformer]], you would add the following line:
+You should take care to add the plugin to the right entry corresponding to its plugin type. For example, to add the [[ExplicitPublish]] plugin (a [[tags/plugin/filter|Filter]]), you would add the following line:
 
 ```ts title="quartz.config.ts"
-transformers: [
+filters: [
   ...
   Plugin.ExplicitPublish(),
   ...

--- a/docs/plugins/ExplicitPublish.md
+++ b/docs/plugins/ExplicitPublish.md
@@ -13,6 +13,6 @@ This plugin has no configuration options.
 
 ## API
 
-- Category: Emitter
+- Category: Filter
 - Function name: `Plugin.ExplicitPublish()`.
 - Source: [`quartz/plugins/filters/explicit.ts`](https://github.com/jackyzha0/quartz/blob/v4/quartz/plugins/filters/explicit.ts).


### PR DESCRIPTION
### Description

The docs refer to `ExplicitPublish` as a filter, emitter, and transformer. Updated all references to the plugin to refer to it as a filter — this was my best guess as to the current plugin type, as it's in `plugins/filters/`.
