### PR TITLE
feat: support youtube playlist iframe

### DIFF
--- a/docs/plugins/ObsidianFlavoredMarkdown.md
+++ b/docs/plugins/ObsidianFlavoredMarkdown.md
@@ -20,7 +20,7 @@ This plugin accepts the following configuration options:
 - `parseArrows`: If `true` (default), transforms arrow symbols into their HTML character equivalents.
 - `parseBlockReferences`: If `true` (default), handles block references, linking to specific content blocks.
 - `enableInHtmlEmbed`: If `true`, allows embedding of content directly within HTML. Defaults to `false`.
-- `enableYouTubeEmbed`: If `true` (default), enables the embedding of YouTube videos using external image Markdown syntax.
+- `enableYouTubeEmbed`: If `true` (default), enables the embedding of YouTube videos and playlists using external image Markdown syntax.
 - `enableVideoEmbed`: If `true` (default), enables the embedding of video files.
 - `enableCheckbox`: If `true`, adds support for interactive checkboxes in content. Defaults to `false`.
 


### PR DESCRIPTION
Closes https://github.com/jackyzha0/quartz/issues/926

Tested with the following markdown:

```markdown
## Playlist only

![[https://www.youtube.com/playlist?list=PL7oLu8NfQd84_gsyqBVSVgUmCCgcvSZMx]]

## Video with playlist

![[https://www.youtube.com/watch?v=Z8WIALfgaA4&list=PL7oLu8NfQd84_gsyqBVSVgUmCCgcvSZMx]]

## Video only (no playlist)

![[https://www.youtube.com/watch?v=Byy-QNgtHIg]]
```