### PR TITLE
fix(description): make sure to we join space correctly

### DIFF
--- a/quartz/plugins/transformers/description.ts
+++ b/quartz/plugins/transformers/description.ts
@@ -39,29 +39,29 @@ export const Description: QuartzTransformerPlugin<Partial<Options> | undefined> 
 
             const desc = frontMatterDescription ?? text
             const sentences = desc.replace(/\s+/g, " ").split(/\.\s/)
-            let finalDesc = ""
-            let sentenceIdx = 0
+            const finalDesc: string[] = []
             const len = opts.descriptionLength
+            let sentenceIdx = 0
 
             if (sentences[0] !== undefined && sentences[0].length >= len) {
               const firstSentence = sentences[0].split(" ")
               while (finalDesc.length < len) {
                 const sentence = firstSentence[sentenceIdx]
                 if (!sentence) break
-                finalDesc += sentence + " "
+                finalDesc.push(sentence)
                 sentenceIdx++
               }
-              finalDesc = finalDesc.trimEnd() + "..."
+              finalDesc.push("...")
             } else {
               while (finalDesc.length < len) {
                 const sentence = sentences[sentenceIdx]
                 if (!sentence) break
-                finalDesc += sentence.endsWith(".") ? sentence : sentence + "."
+                finalDesc.push(sentence.endsWith(".") ? sentence : sentence + ".")
                 sentenceIdx++
               }
             }
 
-            file.data.description = finalDesc
+            file.data.description = finalDesc.join(" ")
             file.data.text = text
           }
         },


### PR DESCRIPTION
<img width="188" alt="Screenshot 2024-03-06 at 22 25 52" src="https://github.com/jackyzha0/quartz/assets/29749331/2b7b7b86-3c82-458f-ac24-1ba2efc0b827">

Fixes the space when joining sentences.

Probably make it less brittle.

<img width="700" alt="Screenshot 2024-03-06 at 22 42 28" src="https://github.com/jackyzha0/quartz/assets/29749331/7a54a623-ac1c-4ce2-b23a-344285c416dc">
