### PR TITLE
fix(description): make sure description counts characters instead of words

### DIFF
--- a/quartz/plugins/transformers/description.ts
+++ b/quartz/plugins/transformers/description.ts
@@ -42,21 +42,26 @@ export const Description: QuartzTransformerPlugin<Partial<Options> | undefined> 
             const finalDesc: string[] = []
             const len = opts.descriptionLength
             let sentenceIdx = 0
+            let currentDescriptionLength = 0
 
             if (sentences[0] !== undefined && sentences[0].length >= len) {
               const firstSentence = sentences[0].split(" ")
-              while (finalDesc.length < len) {
+              while (currentDescriptionLength < len) {
                 const sentence = firstSentence[sentenceIdx]
                 if (!sentence) break
                 finalDesc.push(sentence)
+                currentDescriptionLength += sentence.length
                 sentenceIdx++
               }
               finalDesc.push("...")
             } else {
-              while (finalDesc.length < len) {
+              while (currentDescriptionLength < len) {
                 const sentence = sentences[sentenceIdx]
                 if (!sentence) break
                 finalDesc.push(sentence.endsWith(".") ? sentence : sentence + ".")
+                currentDescriptionLength += sentence.endsWith(".")
+                  ? sentence.length
+                  : sentence.length + 1
                 sentenceIdx++
               }
             }

--- a/quartz/plugins/transformers/description.ts
+++ b/quartz/plugins/transformers/description.ts
@@ -58,11 +58,9 @@ export const Description: QuartzTransformerPlugin<Partial<Options> | undefined> 
               while (currentDescriptionLength < len) {
                 const sentence = sentences[sentenceIdx]
                 if (!sentence) break
-                finalDesc.push(sentence.endsWith(".") ? sentence : sentence + ".")
-                currentDescriptionLength += sentence.endsWith(".")
-                  ? sentence.length
-                  : sentence.length + 1
-                sentenceIdx++
+                const currentSentence = sentence.endsWith(".") ? sentence : sentence + "."
+                finalDesc.push(currentSentence)
+                currentDescriptionLength += currentSentence.length
               }
             }
 


### PR DESCRIPTION
https://github.com/jackyzha0/quartz/commit/141dd3b51f59aabc8ef3506d040f7360a86f26d0 changed the construction of the meta:description to use an array instead of a string.

This pull request restores the previous behavior of using the length of the final description string instead of the number of words.

Example for https://github.com/jackyzha0/quartz/blob/v4/docs/showcase.md:

Currently after running `npx quartz build`:

```html
<!--689 characters-->
<meta property="og:description"
    content="Want to see what Quartz can do? Here are some cool community gardens: Quartz Documentation (this site!) Jacky Zhao’s Garden Socratica Toolbox oldwinter の数字花园 Aaron Pham’s Garden The Quantum Garden Abhijeet’s Math Wiki Matt Dunn’s Second Brain Pelayo Arbues’ Notes Vince Imbat’s Talahardin 🧠🌳 Chad’s Mind Garden Pedro MC Fernandes’s Topo da Mente Mau Camargo’s Notkesto Caicai’s Novels 🌊 Collapsed Wave Sideny’s 3D Artist’s Handbook Mike’s AI Garden 🤖🪴 Brandon Boswell’s Garden Scaling Synthesis - A hypertext research notebook Data Dictionary 🧠 sspaeti.com’s Second Brain 🪴Aster’s notebook If you want to see your own on here, submit a Pull Request adding yourself to this file! ..." />
```

Using the branch of this pull request:

```html
<!--181 characters-->
<meta property="og:description"
    content="Want to see what Quartz can do? Here are some cool community gardens: Quartz Documentation (this site!) Jacky Zhao’s Garden Socratica Toolbox oldwinter の数字花园 Aaron Pham’s Garden ..." />
```