### PR TITLE
fix(resources): Use full path to font when cdnCache is false

### DIFF
--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -228,7 +228,7 @@ export const ComponentResources: QuartzEmitterPlugin<Options> = (opts?: Partial<
 
             googleFontsStyleSheet = googleFontsStyleSheet.replace(
               url,
-              `/static/fonts/${filename}.ttf`,
+              `https://${cfg.baseUrl}/static/fonts/${filename}.ttf`,
             )
 
             promises.push(


### PR DESCRIPTION
Closes https://github.com/jackyzha0/quartz/issues/974