### PR TITLE
feat(search): add search by title/content index and tag at the same time

### DIFF
--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -414,8 +414,8 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
         const query = currentSearchTerm.substring(separatorIndex + 1).trim()
         searchResults = await index.searchAsync({
           query: query,
-          // return at least 100 documents, so it is enough to filter them by tag (implemented in flexsearch)
-          limit: Math.max(numSearchResults, 100),
+          // return at least 10000 documents, so it is enough to filter them by tag (implemented in flexsearch)
+          limit: Math.max(numSearchResults, 10000),
           index: ["title", "content"],
           tag: tag,
         })

--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -406,7 +406,7 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
 
     let searchResults: FlexSearch.SimpleDocumentSearchResultSetUnit[]
     if (searchType === "tags") {
-      currentSearchTerm = currentSearchTerm.substring(1)
+      currentSearchTerm = currentSearchTerm.substring(1).trim()
       const separatorIndex = currentSearchTerm.indexOf(" ")
       if (separatorIndex != -1) {
         // search by title and content index and then filter by tag (implemented in flexsearch)

--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -421,6 +421,9 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
         for (let searchResult of searchResults) {
           searchResult.result = searchResult.result.slice(0, numSearchResults)
         }
+        // set search type to basic and remove tag from term for proper highlightning and scroll
+        searchType = "basic"
+        currentSearchTerm = query
       } else {
         // default search by tags index
         searchResults = await index.searchAsync({

--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -406,14 +406,15 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
 
     let searchResults: FlexSearch.SimpleDocumentSearchResultSetUnit[]
     if (searchType === "tags") {
-      let [tag, ...queries] = currentSearchTerm.substring(1).split(" ")
-      const query = queries.join(" ").trim()
-
-      if (query !== "") {
+      currentSearchTerm = currentSearchTerm.substring(1)
+      const separatorIndex = currentSearchTerm.indexOf(" ")
+      if (separatorIndex != -1) {
         // search by title and content index and then filter by tag (implemented in flexsearch)
+        const tag = currentSearchTerm.substring(0, separatorIndex)
+        const query = currentSearchTerm.substring(separatorIndex + 1).trim()
         searchResults = await index.searchAsync({
           query: query,
-          // search at least 100 documents, so it is enough to filter them by tag (not tags index)
+          // return at least 100 documents, so it is enough to filter them by tag (implemented in flexsearch)
           limit: Math.max(numSearchResults, 100),
           index: ["title", "content"],
           tag: tag,
@@ -427,7 +428,7 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
       } else {
         // default search by tags index
         searchResults = await index.searchAsync({
-          query: tag,
+          query: currentSearchTerm,
           limit: numSearchResults,
           index: ["tags"],
         })


### PR DESCRIPTION
I think I managed to do a title/content and tag search at the same time(Closes #948). The basic search functionality has not changed and works as before.

If you type `#abc xyz` into the search, you will find documents with `abc` tag and `xyz` in the title/content of the document.

Due to implementation details within `flexsearch`, the title/content index is searched first and only then the found documents are filtered by tag. As a result, it is possible that the first `numSearchResults` of documents do not contain the specified tag and nothing will be returned as a result. To get around this, I have set the search limit to a minimum of 100 documents to increase the chances of finding documents with the desired tag. This is especially noticeable when there are not enough letters for a more accurate full text search (e.g. we typed `#abc x`, `x` occurs in a large number of documents and there is no guarantee that the first `numSearchResults` documents contain the tag).

Maybe we should increase this number from 100 to 500 or 1000 (but maybe the search will become slower, we need to find a balance).

I also noticed one thing about `numSearchResults`. This is not the total number of documents that will be displayed to the user, but the number of documents that each index will return. In a `basic` search there are two indexes: title and content, so it is possible that the user may see `2 * numSearchResults` (`numSearchResults` from the title index and the same number from content).
If this is the intended behavior, it's probably worth writing about it in the documentation.
For now, for consistency when searching by title/content and tags at the same time, I slice first `numSearchResults` from each index (because a search can return up to 100 documents).

I do not know how to test that the search highlighting is not broken (at first glance everything looks ok). Do we have tests for search and highlighting matches?

If there are any questions or unclear details, I will be glad to help. 
