### PR TITLE
fix(description): first sentence no longer repeats until max length

### DIFF
--- a/quartz/plugins/transformers/description.ts
+++ b/quartz/plugins/transformers/description.ts
@@ -61,6 +61,7 @@ export const Description: QuartzTransformerPlugin<Partial<Options> | undefined> 
                 const currentSentence = sentence.endsWith(".") ? sentence : sentence + "."
                 finalDesc.push(currentSentence)
                 currentDescriptionLength += currentSentence.length
+                sentenceIdx++
               }
             }
 


### PR DESCRIPTION
Closes https://github.com/jackyzha0/quartz/issues/980

The index of the sentence was not being incremented, causing the description to keep repeating the first sentence until the configured description length was reached.