### PR TITLE
fix(transclusion): prevent duplicate transclusion if multiple transclusions are present.

### DIFF
--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -118,11 +118,12 @@ export function renderPage(
               // skip until we find the blockref that matches
               if (el.properties?.id === blockRef) {
                 startIdx = i
-                startDepth = Number(el.tagName.substring(1))
+                startDepth = depth
               }
             } else if (depth <= startDepth) {
               // looking for new header that is same level or higher
               endIdx = i
+              break
             }
           }
 


### PR DESCRIPTION
Closes https://github.com/jackyzha0/quartz/issues/979

Root cause: having multiple transclusions to different parts of another page in a single page caused the every transclusion to have all previous transclusions too.

Example:

```markdown
![[page1#header1]]

![[page1#header2]]
```

would result in something like this:

```html
<!--
![[page1#header1]]
-->
<h1>header1</h1>
<p>text.</p>
<!--
![[page1#header2]]
-->
<h1>header1</h1> <!-- Should not be here -->
<p>text.</p> <!-- Should not be here -->
<h1>header2</h1>
<p>more text.</p>
```

By adding a `break` after finding the `endIdx`, the transcluded content will no longer include other parts outside the transcluded header (and it's content and child nodes).