### PR TITLE
fix: spelling error

### DIFF
--- a/quartz/i18n/locales/fr-FR.ts
+++ b/quartz/i18n/locales/fr-FR.ts
@@ -63,7 +63,7 @@ export default {
       lastFewNotes: ({ count }) => `Les dernières ${count} notes`,
     },
     error: {
-      title: "Pas trouvé",
+      title: "Introuvable",
       notFound: "Cette page est soit privée, soit elle n'existe pas.",
     },
     folderContent: {


### PR DESCRIPTION
I really don't know why I translated this like that into "pas trouvé", and it bugged me a lot. I finally fixed it…