### PR TITLE
fix(callouts): properly transclude blockRefs inside callouts

### DIFF
--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -52,6 +52,26 @@ export function pageResources(
   }
 }
 
+// TODO: proper typings
+// TODO: move to a utils file?
+function hasPropertyValue(obj: any, property: any, value: string) {
+  for (const key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      if (typeof obj[key] === "object") {
+        if (obj[key].id === value) {
+          return true
+        }
+        if (hasPropertyValue(obj[key], property, value)) {
+          return true
+        }
+      } else if (key === property && obj[key].id === value) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
 export function renderPage(
   cfg: GlobalConfiguration,
   slug: FullSlug,
@@ -75,13 +95,35 @@ export function renderPage(
           return
         }
 
+        // callouts in transcluded pages
+        // blockRefs in callouts should transclude the entire callout
+        const transclusionCallouts = page.htmlAst?.children.filter(
+          (f) =>
+            f.type === "element" &&
+            f.tagName === "blockquote" &&
+            ((f.properties.className ?? []) as string[]).includes("callout"),
+        )
+
         let blockRef = node.properties.dataBlock as string | undefined
         if (blockRef?.startsWith("#^")) {
-          // block transclude
           blockRef = blockRef.slice("#^".length)
           let blockNode = page.blocks?.[blockRef]
           if (blockNode) {
-            if (blockNode.tagName === "li") {
+            if (
+              transclusionCallouts !== undefined &&
+              transclusionCallouts.length > 0 &&
+              transclusionCallouts.find(
+                (f) =>
+                  hasPropertyValue(f, blockNode!.properties, blockNode!.properties.id as string) ===
+                  true,
+              )
+            ) {
+              blockNode = transclusionCallouts.find(
+                (f) =>
+                  hasPropertyValue(f, blockNode!.properties, blockNode!.properties.id as string) ===
+                  true,
+              ) as Element
+            } else if (blockNode.tagName === "li") {
               blockNode = {
                 type: "element",
                 tagName: "ul",

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -52,20 +52,14 @@ export function pageResources(
   }
 }
 
-// TODO: proper typings
-// TODO: move to a utils file?
+// Check if an element has a property with a specific value
 function hasPropertyValue(obj: any, property: any, value: string) {
   for (const key in obj) {
     if (obj.hasOwnProperty(key)) {
       if (typeof obj[key] === "object") {
-        if (obj[key].id === value) {
+        if (obj[key].id === value || hasPropertyValue(obj[key], property, value)) {
           return true
         }
-        if (hasPropertyValue(obj[key], property, value)) {
-          return true
-        }
-      } else if (key === property && obj[key].id === value) {
-        return true
       }
     }
   }

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -106,6 +106,7 @@ export function renderPage(
 
         let blockRef = node.properties.dataBlock as string | undefined
         if (blockRef?.startsWith("#^")) {
+          // block transclude
           blockRef = blockRef.slice("#^".length)
           let blockNode = page.blocks?.[blockRef]
           if (blockNode) {


### PR DESCRIPTION
closes https://github.com/jackyzha0/quartz/issues/967

## Proposal:

When transcluding a blockref (`![[somePage#^123456]]`), check for callouts inside the transcluded file. If the transcluded file contains callouts, check every callout for a `blockRef` matching the current `blockRef`.
 - if a match is found => transclude the entire callout.
 - if there is no match => use previous behavior.

@jackyzha0 can you give me some feedback on the direction of the implementation?