### PR TITLE
feat(graph): obsidianLikeFocusOnHover

### DIFF
--- a/quartz/components/Graph.tsx
+++ b/quartz/components/Graph.tsx
@@ -18,6 +18,7 @@ export interface D3Config {
   removeTags: string[]
   showTags: boolean
   focusOnHover?: boolean
+  obsidianLikeFocusOnHover?: boolean
 }
 
 interface GraphOptions {

--- a/quartz/components/Graph.tsx
+++ b/quartz/components/Graph.tsx
@@ -18,7 +18,6 @@ export interface D3Config {
   removeTags: string[]
   showTags: boolean
   focusOnHover?: boolean
-  obsidianLikeFocusOnHover?: boolean
 }
 
 interface GraphOptions {

--- a/quartz/components/scripts/graph.inline.ts
+++ b/quartz/components/scripts/graph.inline.ts
@@ -45,7 +45,6 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
     removeTags,
     showTags,
     focusOnHover,
-    obsidianLikeFocusOnHover,
   } = JSON.parse(graph.dataset["cfg"]!)
 
   const data: Map<SimpleSlug, ContentDetails> = new Map(
@@ -225,19 +224,17 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
           .duration(200)
           .style("opacity", 0.2)
 
-        if (obsidianLikeFocusOnHover) {
-          d3.selectAll<HTMLElement, NodeData>(".node")
-            .filter((d) => !connectedNodes.includes(d.id))
-            .nodes()
-            .map((it) => d3.select(it.parentNode as HTMLElement).select("text"))
-            .forEach((it) =>
-              it
-                .transition()
-                .duration(200)
-                .attr("opacityOld", it.style("opacity"))
-                .style("opacity", 0.2),
-            )
-        }
+        d3.selectAll<HTMLElement, NodeData>(".node")
+          .filter((d) => !connectedNodes.includes(d.id))
+          .nodes()
+          .map((it) => d3.select(it.parentNode as HTMLElement).select("text"))
+          .forEach((it) =>
+            it
+              .transition()
+              .duration(200)
+              .attr("opacityOld", it.style("opacity"))
+              .style("opacity", 0.2),
+          )
       }
 
       // highlight links
@@ -261,13 +258,11 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
         d3.selectAll<HTMLElement, NodeData>(".link").transition().duration(200).style("opacity", 1)
         d3.selectAll<HTMLElement, NodeData>(".node").transition().duration(200).style("opacity", 1)
 
-        if (obsidianLikeFocusOnHover) {
-          d3.selectAll<HTMLElement, NodeData>(".node")
-            .filter((d) => !connectedNodes.includes(d.id))
-            .nodes()
-            .map((it) => d3.select(it.parentNode as HTMLElement).select("text"))
-            .forEach((it) => it.transition().duration(200).style("opacity", it.attr("opacityOld")))
-        }
+        d3.selectAll<HTMLElement, NodeData>(".node")
+          .filter((d) => !connectedNodes.includes(d.id))
+          .nodes()
+          .map((it) => d3.select(it.parentNode as HTMLElement).select("text"))
+          .forEach((it) => it.transition().duration(200).style("opacity", it.attr("opacityOld")))
       }
       const currentId = d.id
       const linkNodes = d3

--- a/quartz/components/scripts/graph.inline.ts
+++ b/quartz/components/scripts/graph.inline.ts
@@ -224,13 +224,19 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
           .transition()
           .duration(200)
           .style("opacity", 0.2)
-        
+
         if (obsidianLikeFocusOnHover) {
           d3.selectAll<HTMLElement, NodeData>(".node")
             .filter((d) => !connectedNodes.includes(d.id))
             .nodes()
-            .map(it => d3.select(it.parentNode as HTMLElement).select("text"))
-            .forEach(it => it.transition().duration(200).attr("opacityOld", it.style("opacity")).style("opacity", 0.2))
+            .map((it) => d3.select(it.parentNode as HTMLElement).select("text"))
+            .forEach((it) =>
+              it
+                .transition()
+                .duration(200)
+                .attr("opacityOld", it.style("opacity"))
+                .style("opacity", 0.2),
+            )
         }
       }
 
@@ -259,8 +265,8 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
           d3.selectAll<HTMLElement, NodeData>(".node")
             .filter((d) => !connectedNodes.includes(d.id))
             .nodes()
-            .map(it => d3.select(it.parentNode as HTMLElement).select("text"))
-            .forEach(it => it.transition().duration(200).style("opacity", it.attr("opacityOld")))
+            .map((it) => d3.select(it.parentNode as HTMLElement).select("text"))
+            .forEach((it) => it.transition().duration(200).style("opacity", it.attr("opacityOld")))
         }
       }
       const currentId = d.id

--- a/quartz/components/scripts/graph.inline.ts
+++ b/quartz/components/scripts/graph.inline.ts
@@ -228,13 +228,14 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
           .filter((d) => !connectedNodes.includes(d.id))
           .nodes()
           .map((it) => d3.select(it.parentNode as HTMLElement).select("text"))
-          .forEach((it) =>
+          .forEach((it) => {
+            let opacity = parseFloat(it.style("opacity"))
             it
               .transition()
               .duration(200)
-              .attr("opacityOld", it.style("opacity"))
-              .style("opacity", 0.2),
-          )
+              .attr("opacityOld", opacity)
+              .style("opacity", Math.min(opacity, 0.2))
+          })
       }
 
       // highlight links

--- a/quartz/components/scripts/graph.inline.ts
+++ b/quartz/components/scripts/graph.inline.ts
@@ -230,8 +230,7 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
           .map((it) => d3.select(it.parentNode as HTMLElement).select("text"))
           .forEach((it) => {
             let opacity = parseFloat(it.style("opacity"))
-            it
-              .transition()
+            it.transition()
               .duration(200)
               .attr("opacityOld", opacity)
               .style("opacity", Math.min(opacity, 0.2))

--- a/quartz/components/scripts/graph.inline.ts
+++ b/quartz/components/scripts/graph.inline.ts
@@ -45,6 +45,7 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
     removeTags,
     showTags,
     focusOnHover,
+    obsidianLikeFocusOnHover,
   } = JSON.parse(graph.dataset["cfg"]!)
 
   const data: Map<SimpleSlug, ContentDetails> = new Map(
@@ -223,6 +224,14 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
           .transition()
           .duration(200)
           .style("opacity", 0.2)
+        
+        if (obsidianLikeFocusOnHover) {
+          d3.selectAll<HTMLElement, NodeData>(".node")
+            .filter((d) => !connectedNodes.includes(d.id))
+            .nodes()
+            .map(it => d3.select(it.parentNode as HTMLElement).select("text"))
+            .forEach(it => it.transition().duration(200).attr("opacityOld", it.style("opacity")).style("opacity", 0.2))
+        }
       }
 
       // highlight links
@@ -245,6 +254,14 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
       if (focusOnHover) {
         d3.selectAll<HTMLElement, NodeData>(".link").transition().duration(200).style("opacity", 1)
         d3.selectAll<HTMLElement, NodeData>(".node").transition().duration(200).style("opacity", 1)
+
+        if (obsidianLikeFocusOnHover) {
+          d3.selectAll<HTMLElement, NodeData>(".node")
+            .filter((d) => !connectedNodes.includes(d.id))
+            .nodes()
+            .map(it => d3.select(it.parentNode as HTMLElement).select("text"))
+            .forEach(it => it.transition().duration(200).style("opacity", it.attr("opacityOld")))
+        }
       }
       const currentId = d.id
       const linkNodes = d3


### PR DESCRIPTION
Adds an option that allows the users to set `opacityScale: 4.75,` (to use `opacity: 1` for labels) and which would fade the text out when focusing on certain nodes:

![Untitled video - Made with Clipchamp](https://github.com/jackyzha0/quartz/assets/39565527/c4b458bd-fc42-4020-add8-1226ccf09505)
