### PR TITLE
fix(assets): pdf page linking support.

### DIFF
--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -168,8 +168,10 @@ export function resolveRelative(current: FullSlug, target: FullSlug | SimpleSlug
 
 export function splitAnchor(link: string): [string, string] {
   let [fp, anchor] = link.split("#", 2)
-  anchor =
-    anchor === undefined ? "" : anchor.match(/page=\d+/) ? "#" + anchor : "#" + slugAnchor(anchor)
+  if (fp.endsWith(".pdf")) {
+    return [fp, "#" + anchor]
+  }
+  anchor = anchor === undefined ? "" : "#" + slugAnchor(anchor)
   return [fp, anchor]
 }
 

--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -169,7 +169,8 @@ export function resolveRelative(current: FullSlug, target: FullSlug | SimpleSlug
 export function splitAnchor(link: string): [string, string] {
   let [fp, anchor] = link.split("#", 2)
   if (fp.endsWith(".pdf")) {
-    return [fp, "#" + anchor]
+    anchor = anchor === undefined ? "" : "#" + anchor
+    return [fp, anchor]
   }
   anchor = anchor === undefined ? "" : "#" + slugAnchor(anchor)
   return [fp, anchor]

--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -168,7 +168,8 @@ export function resolveRelative(current: FullSlug, target: FullSlug | SimpleSlug
 
 export function splitAnchor(link: string): [string, string] {
   let [fp, anchor] = link.split("#", 2)
-  anchor = anchor === undefined ? "" : "#" + slugAnchor(anchor)
+  anchor =
+    anchor === undefined ? "" : anchor.match(/page=\d+/) ? "#" + anchor : "#" + slugAnchor(anchor)
   return [fp, anchor]
 }
 

--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -169,8 +169,7 @@ export function resolveRelative(current: FullSlug, target: FullSlug | SimpleSlug
 export function splitAnchor(link: string): [string, string] {
   let [fp, anchor] = link.split("#", 2)
   if (fp.endsWith(".pdf")) {
-    anchor = anchor === undefined ? "" : "#" + anchor
-    return [fp, anchor]
+    return [fp, anchor === undefined ? "" : `#${anchor}`]
   }
   anchor = anchor === undefined ? "" : "#" + slugAnchor(anchor)
   return [fp, anchor]


### PR DESCRIPTION
Closes https://github.com/jackyzha0/quartz/issues/1022

This implementation has two caveats:
 1. The PDF link expects an exact match, like `link.pdf#page=123`. Something like `link.pdf#page=123&someotheroption=true` won't match. I could easily expand the match to accept more, but I am unsure of potential edge cases that are relevant, if any.
 2. The workaround makes an exception on the `slugAnchor` function. This function is from the `github-slugger` library. This library aims to match GitHub's way of generating slugs from headings. (see [the source repository here](https://github.com/Flet/github-slugger?tab=readme-ov-file#github-slugger)). Arguably this case is not a slug, as it is not referring to a heading.

@jackyzha0 what is your opinion on this workaround and above caveats? Should we implement it here or should I look into making a separate parsing step somewhere for cases like this? (meaning, links with options instead of headers, so like `link#option=value`)