### PR TITLE
fix(style): LaTex/KaTeX overflow

### DIFF
--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -517,9 +517,10 @@ ol.overflow {
 .katex-display {
   overflow-x: auto;
   overflow-y: visible;
-}
-
-.katex .base,
-.katex .strut {
-  display: inline !important;
+  .katex .katex-html {
+    .base,
+    .strut {
+      display: inline;
+    }
+  }
 }

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -517,7 +517,7 @@ ol.overflow {
 .katex-display {
   overflow-x: auto;
   overflow-y: visible;
-  .katex .katex-html {
+  & > .katex .katex-html {
     .base,
     .strut {
       display: inline;

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -513,3 +513,11 @@ ol.overflow {
     padding-left: 1rem;
   }
 }
+
+.katex-display {
+  overflow-x: auto;
+}
+
+.katex .base, .katex .strut {
+  display: inline;
+}

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -516,6 +516,7 @@ ol.overflow {
 
 .katex-display {
   overflow-x: auto;
+  overflow-y: visible;
 }
 
 .katex .base,

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -520,5 +520,5 @@ ol.overflow {
 
 .katex .base,
 .katex .strut {
-  display: inline;
+  display: inline !important;
 }

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -518,6 +518,7 @@ ol.overflow {
   overflow-x: auto;
 }
 
-.katex .base, .katex .strut {
+.katex .base,
+.katex .strut {
   display: inline;
 }

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -517,6 +517,7 @@ ol.overflow {
 .katex-display {
   overflow-x: auto;
   overflow-y: visible;
+
   & > .katex .katex-html {
     .base,
     .strut {


### PR DESCRIPTION
Closes https://github.com/jackyzha0/quartz/issues/1018

The following allows the content to scroll horizontally if it exceeds the available page width:

```scss
.katex-display {
  overflow-x: auto;
}
```

The following ensures the KaTeX does not create a (vertical) scrollbar with minimal or no scroll. (By default, the KaTeX takes as much vertical space as it needs.)

```scss
.katex .base, .katex .strut {
  // was display: inline-block;
  display: inline;
}
```

@migueltorrescosta can you check if these changes fix your overflow issues without affecting the KaTeX to display incorrectly? As far as I can tell, the KaTeX displays correctly, but I am not too familiar with it.