### PR TITLE
fix(wikilinks): proper escaping of pipe character in wikilinks inside tables

### DIFF
--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -188,7 +188,8 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
             const [raw]: (string | undefined)[] = capture
             let escaped = raw ?? ""
             escaped = escaped.replace("#", "\\#")
-            escaped = escaped.replace("|", "\\|")
+            // escape pipe characters if they are not already escaped
+            escaped = escaped.replace(/((^|[^\\])(\\\\)*)\|/g, "$1\\|")
 
             return escaped
           })


### PR DESCRIPTION
Closes https://github.com/jackyzha0/quartz/issues/1038

## Root cause

Pipe characters in wikilinks with alias inside tables were assumed to not be escaped. Quartz inserted an backslash to escape them, even if the pipe character was already escaped.

Obsidian automatically escapes the the pipe character inside tables.

## Test cases

### Input

```markdown
---
title: table test
---

| Testing Tables | w |
| --- | --- |
| [[index#Test-Header|Test-Header]] | w |
| [[index#Test-Header\|Test-Header]] | w |
| [[#Test-Header|Test-Header]] | w |
| [[#Test-Header\|Test-Header]] | w |
| [[#Test-Header]] | w |

## Test-Header

text
```

### Output

```html
<article class="popover-hint">
  <div class="table-container">
    <table>
      <thead>
        <tr>
          <th>Testing Tables</th>
          <th>w</th>
        </tr>
      </thead>
      <tbody>
        <tr>
          <td><a href="./#test-header" class="internal alias" data-slug="index">Test-Header</a></td>
          <td>w</td>
        </tr>
        <tr>
          <td><a href="./#test-header" class="internal alias" data-slug="index">Test-Header</a></td>
          <td>w</td>
        </tr>
        <tr>
          <td><a href="#Test-Header" class="internal alias">Test-Header</a></td>
          <td>w</td>
        </tr>
        <tr>
          <td><a href="#Test-Header" class="internal alias">Test-Header</a></td>
          <td>w</td>
        </tr>
        <tr>
          <td><a href="#Test-Header" class="internal alias"></a></td>
          <td>w</td>
        </tr>
      </tbody>
    </table>
  </div>
  <h2 id="test-header">Test-Header<a role="anchor" aria-hidden="true" tabindex="-1" data-no-popover="true"
      href="#test-header" class="internal"><svg width="18" height="18" viewBox="0 0 24 24" fill="none"
        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
        <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
        <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path>
      </svg></a></h2>
  <p>text</p>
</article>
```