### PR TITLE
fix: do not render <p> inside FolderContent article

### DIFF
--- a/quartz/components/pages/FolderContent.tsx
+++ b/quartz/components/pages/FolderContent.tsx
@@ -47,9 +47,7 @@ export default ((opts?: Partial<FolderContentOptions>) => {
 
     return (
       <div class={classes}>
-        <article>
-          <p>{content}</p>
-        </article>
+        <article>{content}</article>
         <div class="page-listing">
           {options.showFolderCount && (
             <p>


### PR DESCRIPTION
it can lead to nested `<p>`'s which is actually [invalid html](https://www.w3.org/TR/html401/struct/text.html#h-9.3.1:~:text=The%20P%20element%20represents%20a%20paragraph.%20It%20cannot%20contain%20block%2Dlevel%20elements%20(including%20P%20itself).)