### PR TITLE
feat(robots): Enable robots.txt support

### DIFF
--- a/docs/plugins/ContentIndex.md
+++ b/docs/plugins/ContentIndex.md
@@ -4,7 +4,7 @@ tags:
   - plugin/emitter
 ---
 
-This plugin emits both RSS and an XML sitemap for your site. The [[RSS Feed]] allows users to subscribe to content on your site and the sitemap allows search engines to better index your site. The plugin also emits a `contentIndex.json` file which is used by dynamic frontend components like search and graph.
+This plugin emits both RSS and an XML sitemap for your site. The [[RSS Feed]] allows users to subscribe to content on your site and the sitemap allows search engines to better index your site. The plugin also emits a `contentIndex.json` file which is used by dynamic frontend components like search and graph. This plugin also emits the Robots file for managing webcrawlers.
 
 This plugin emits a comprehensive index of the site's content, generating additional resources such as a sitemap, an RSS feed, and a
 
@@ -15,6 +15,7 @@ This plugin accepts the following configuration options:
 
 - `enableSiteMap`: If `true` (default), generates a sitemap XML file (`sitemap.xml`) listing all site URLs for search engines in content discovery.
 - `enableRSS`: If `true` (default), produces an RSS feed (`index.xml`) with recent content updates.
+- `enableRobots`: If `true` (default), produces a Robots file (`robots.txt`) for webcrawlers.
 - `rssLimit`: Defines the maximum number of entries to include in the RSS feed, helping to focus on the most recent or relevant content. Defaults to `10`.
 - `rssFullHtml`: If `true`, the RSS feed includes full HTML content. Otherwise it includes just summaries.
 - `includeEmptyFiles`: If `true` (default), content files with no body text are included in the generated index and resources.

--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -80,6 +80,7 @@ const config: QuartzConfig = {
       Plugin.ContentIndex({
         enableSiteMap: true,
         enableRSS: true,
+        enableRobots: true,
       }),
       Plugin.Assets(),
       Plugin.Static(),


### PR DESCRIPTION
Closes https://github.com/jackyzha0/quartz/issues/1042

@jackyzha0 A few questions for this one:

 - Do we want `robots.txt` as a separate file, or in code? (currently in code)
 - Do we want to enable or disable `robots.txt` by default? (currently enabled by default)
 - Any feedback on the default content? Currently it is set to the following:

```txt
User-agent: *
Allow: /
Sitemap: https://quartz.jzhao.xyz/sitemap.xml
```

The `Sitemap:` url depends on the `baseUrl` value in `quartz.config.ts`.