### PR TITLE
fix: broken doc links on /plugins/*

### DIFF
--- a/docs/plugins/AliasRedirects.md
+++ b/docs/plugins/AliasRedirects.md
@@ -26,7 +26,7 @@ The emitter supports the following aliases:
 - `alias`
 
 > [!note]
-> For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.
+> For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.
 
 This plugin has no configuration options.
 

--- a/docs/plugins/Assets.md
+++ b/docs/plugins/Assets.md
@@ -9,7 +9,7 @@ This plugin emits all non-Markdown static assets in your content folder (like im
 Note that all static assets will then be accessible through its path on your generated site, i.e: `host.me/path/to/static.pdf`
 
 > [!note]
-> For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.
+> For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.
 
 This plugin has no configuration options.
 

--- a/docs/plugins/CNAME.md
+++ b/docs/plugins/CNAME.md
@@ -11,7 +11,7 @@ If you want to use a custom domain name like `quartz.example.com` for the site, 
 See [[Hosting]] for more information.
 
 > [!note]
-> For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.
+> For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.
 
 This plugin has no configuration options.
 

--- a/docs/plugins/ComponentResources.md
+++ b/docs/plugins/ComponentResources.md
@@ -7,7 +7,7 @@ tags:
 This plugin manages and emits the static resources required for the Quartz framework. This includes CSS stylesheets and JavaScript scripts that enhance the functionality and aesthetics of the generated site. See also the `cdnCaching` option in the `theme` section of the [[configuration]].
 
 > [!note]
-> For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.
+> For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.
 
 This plugin has no configuration options.
 

--- a/docs/plugins/ContentIndex.md
+++ b/docs/plugins/ContentIndex.md
@@ -9,7 +9,7 @@ This plugin emits both RSS and an XML sitemap for your site. The [[RSS Feed]] al
 This plugin emits a comprehensive index of the site's content, generating additional resources such as a sitemap, an RSS feed, and a
 
 > [!note]
-> For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.
+> For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.
 
 This plugin accepts the following configuration options:
 

--- a/docs/plugins/ContentPage.md
+++ b/docs/plugins/ContentPage.md
@@ -7,7 +7,7 @@ tags:
 This plugin is a core component of the Quartz framework. It generates the HTML pages for each piece of Markdown content. It emits the full-page [[layout]], including headers, footers, and body content, among others.
 
 > [!note]
-> For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.
+> For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.
 
 This plugin has no configuration options.
 

--- a/docs/plugins/CrawlLinks.md
+++ b/docs/plugins/CrawlLinks.md
@@ -7,7 +7,7 @@ tags:
 This plugin parses links and processes them to point to the right places. It is also needed for embedded links (like images). See [[Obsidian compatibility]] for more information.
 
 > [!note]
-> For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.
+> For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.
 
 This plugin accepts the following configuration options:
 

--- a/docs/plugins/CreatedModifiedDate.md
+++ b/docs/plugins/CreatedModifiedDate.md
@@ -7,7 +7,7 @@ tags:
 This plugin determines the created, modified, and published dates for a document using three potential data sources: frontmatter metadata, Git history, and the filesystem. See [[authoring content#Syntax]] for more information.
 
 > [!note]
-> For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.
+> For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.
 
 This plugin accepts the following configuration options:
 

--- a/docs/plugins/Description.md
+++ b/docs/plugins/Description.md
@@ -9,7 +9,7 @@ This plugin generates descriptions that are used as metadata for the HTML `head`
 If the frontmatter contains a `description` property, it is used (see [[authoring content#Syntax]]). Otherwise, the plugin will do its best to use the first few sentences of the content to reach the target description length.
 
 > [!note]
-> For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.
+> For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.
 
 This plugin accepts the following configuration options:
 

--- a/docs/plugins/ExplicitPublish.md
+++ b/docs/plugins/ExplicitPublish.md
@@ -7,7 +7,7 @@ tags:
 This plugin filters content based on an explicit `publish` flag in the frontmatter, allowing only content that is explicitly marked for publication to pass through. It's the opt-in version of [[RemoveDrafts]]. See [[private pages]] for more information.
 
 > [!note]
-> For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.
+> For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.
 
 This plugin has no configuration options.
 

--- a/docs/plugins/FolderPage.md
+++ b/docs/plugins/FolderPage.md
@@ -9,7 +9,7 @@ This plugin generates index pages for folders, creating a listing page for each 
 Example: [[advanced/|Advanced]]
 
 > [!note]
-> For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.
+> For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.
 
 This plugin has no configuration options.
 

--- a/docs/plugins/Frontmatter.md
+++ b/docs/plugins/Frontmatter.md
@@ -7,7 +7,7 @@ tags:
 This plugin parses the frontmatter of the page using the [gray-matter](https://github.com/jonschlinkert/gray-matter) library. See [[authoring content#Syntax]], [[Obsidian compatibility]] and [[OxHugo compatibility]] for more information.
 
 > [!note]
-> For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.
+> For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.
 
 This plugin accepts the following configuration options:
 

--- a/docs/plugins/GitHubFlavoredMarkdown.md
+++ b/docs/plugins/GitHubFlavoredMarkdown.md
@@ -9,7 +9,7 @@ This plugin enhances Markdown processing to support GitHub Flavored Markdown (GF
 In addition, this plugin adds optional features for typographic refinement (such as converting straight quotes to curly quotes, dashes to en-dashes/em-dashes, and ellipses) and automatic heading links as a symbol that appears next to the heading on hover.
 
 > [!note]
-> For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.
+> For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.
 
 This plugin accepts the following configuration options:
 

--- a/docs/plugins/HardLineBreaks.md
+++ b/docs/plugins/HardLineBreaks.md
@@ -7,7 +7,7 @@ tags:
 This plugin automatically converts single line breaks in Markdown text into hard line breaks in the HTML output. This plugin is not enabled by default as this doesn't follow the semantics of actual Markdown but you may enable it if you'd like parity with [[Obsidian compatibility|Obsidian]].
 
 > [!note]
-> For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.
+> For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.
 
 This plugin has no configuration options.
 

--- a/docs/plugins/Latex.md
+++ b/docs/plugins/Latex.md
@@ -7,7 +7,7 @@ tags:
 This plugin adds LaTeX support to Quartz. See [[features/Latex|Latex]] for more information.
 
 > [!note]
-> For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.
+> For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.
 
 This plugin accepts the following configuration options:
 

--- a/docs/plugins/NotFoundPage.md
+++ b/docs/plugins/NotFoundPage.md
@@ -7,7 +7,7 @@ tags:
 This plugin emits a 404 (Not Found) page for broken or non-existent URLs.
 
 > [!note]
-> For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.
+> For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.
 
 This plugin has no configuration options.
 

--- a/docs/plugins/ObsidianFlavoredMarkdown.md
+++ b/docs/plugins/ObsidianFlavoredMarkdown.md
@@ -7,7 +7,7 @@ tags:
 This plugin provides support for [[Obsidian compatibility]].
 
 > [!note]
-> For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.
+> For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.
 
 This plugin accepts the following configuration options:
 

--- a/docs/plugins/OxHugoFlavoredMarkdown.md
+++ b/docs/plugins/OxHugoFlavoredMarkdown.md
@@ -7,7 +7,7 @@ tags:
 This plugin provides support for [ox-hugo](https://github.com/kaushalmodi/ox-hugo) compatibility. See [[OxHugo compatibility]] for more information.
 
 > [!note]
-> For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.
+> For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.
 
 This plugin accepts the following configuration options:
 

--- a/docs/plugins/RemoveDrafts.md
+++ b/docs/plugins/RemoveDrafts.md
@@ -7,7 +7,7 @@ tags:
 This plugin filters out content from your vault, so that only finalized content is made available. This prevents [[private pages]] from being published. By default, it filters out all pages with `draft: true` in the frontmatter and leaves all other pages intact.
 
 > [!note]
-> For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.
+> For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.
 
 This plugin has no configuration options.
 

--- a/docs/plugins/Static.md
+++ b/docs/plugins/Static.md
@@ -10,7 +10,7 @@ This plugin emits all static resources needed by Quartz. This is used, for examp
 > This is different from [[Assets]]. The resources from the [[Static]] plugin are located under `quartz/static`, whereas [[Assets]] renders all static resources under `content` and is used for images, videos, audio, etc. that are directly referenced by your markdown content.
 
 > [!note]
-> For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.
+> For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.
 
 This plugin has no configuration options.
 

--- a/docs/plugins/SyntaxHighlighting.md
+++ b/docs/plugins/SyntaxHighlighting.md
@@ -7,7 +7,7 @@ tags:
 This plugin is used to add syntax highlighting to code blocks in Quartz. See [[syntax highlighting]] for more information.
 
 > [!note]
-> For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.
+> For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.
 
 This plugin accepts the following configuration options:
 

--- a/docs/plugins/TableOfContents.md
+++ b/docs/plugins/TableOfContents.md
@@ -7,7 +7,7 @@ tags:
 This plugin generates a table of contents (TOC) for Markdown documents. See [[table of contents]] for more information.
 
 > [!note]
-> For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.
+> For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.
 
 This plugin accepts the following configuration options:
 

--- a/docs/plugins/TagPage.md
+++ b/docs/plugins/TagPage.md
@@ -7,7 +7,7 @@ tags:
 This plugin emits dedicated pages for each tag used in the content. See [[folder and tag listings]] for more information.
 
 > [!note]
-> For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.
+> For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.
 
 This plugin has no configuration options.
 


### PR DESCRIPTION
Resolves #1052 by changing a typo in the link, see diff
