### PR TITLE
fix: update link to hosting page

### DIFF
--- a/docs/plugins/CNAME.md
+++ b/docs/plugins/CNAME.md
@@ -8,7 +8,7 @@ This plugin emits a `CNAME` record that points your subdomain to the default dom
 
 If you want to use a custom domain name like `quartz.example.com` for the site, then this is needed.
 
-See [[hosting]] for more information.
+See [[hosting|Hosting]] for more information.
 
 > [!note]
 > For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.

--- a/docs/plugins/CNAME.md
+++ b/docs/plugins/CNAME.md
@@ -8,7 +8,7 @@ This plugin emits a `CNAME` record that points your subdomain to the default dom
 
 If you want to use a custom domain name like `quartz.example.com` for the site, then this is needed.
 
-See [[Hosting]] for more information.
+See [[hosting]] for more information.
 
 > [!note]
 > For information on how to add, remove or configure plugins, see the [[configuration#Plugins|Configuration]] page.


### PR DESCRIPTION
**PR Summary**:
PR fixes the broken link found [CNAME page](https://quartz.jzhao.xyz/plugins/CNAME). Instead of "Hosting" it should be "hosting" (case-sensitive) because it points to [hosting.md](https://github.com/jackyzha0/quartz/blob/v4/docs/hosting.md).