### PR TITLE
fix: resolve relative paths for clickable folders (fixes #1055)

### DIFF
--- a/quartz/components/ExplorerNode.tsx
+++ b/quartz/components/ExplorerNode.tsx
@@ -206,7 +206,7 @@ export function ExplorerNode({ node, opts, fullPath, fileData }: ExplorerNodePro
               <div key={node.name} data-folderpath={folderPath}>
                 {folderBehavior === "link" ? (
                   <a
-                    href={resolveRelative(fileData.slug!, folderPath as SimpleSlug)}
+                    href={resolveRelative(fileData.slug!, folderPath as SimpleSlug, true)}
                     data-for={node.name}
                     class="folder-title"
                   >

--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -161,8 +161,15 @@ export function pathToRoot(slug: FullSlug): RelativeURL {
   return rootPath as RelativeURL
 }
 
-export function resolveRelative(current: FullSlug, target: FullSlug | SimpleSlug): RelativeURL {
-  const res = joinSegments(pathToRoot(current), simplifySlug(target as FullSlug)) as RelativeURL
+export function resolveRelative(
+  current: FullSlug,
+  target: FullSlug | SimpleSlug,
+  isFolder = false,
+): RelativeURL {
+  let res = joinSegments(pathToRoot(current), simplifySlug(target as FullSlug)) as RelativeURL
+  if (isFolder && !endsWith(res, "/")) {
+    res = (res + "/") as RelativeURL
+  }
   return res
 }
 


### PR DESCRIPTION
PR fixes #1055 relative path resolution on clickable folders within explorers