### PR TITLE
feat: depend on self

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@clack/prompts": "^0.7.0",
         "@floating-ui/dom": "^1.6.3",
+        "@jackyzha0/quartz": "file:./",
         "@napi-rs/simple-git": "0.1.16",
         "async-mutex": "^0.5.0",
         "chalk": "^5.3.0",
@@ -591,6 +592,10 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@jackyzha0/quartz": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/@napi-rs/simple-git": {
       "version": "0.1.16",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@clack/prompts": "^0.7.0",
     "@floating-ui/dom": "^1.6.3",
+    "@jackyzha0/quartz": "file:./",
     "@napi-rs/simple-git": "0.1.16",
     "async-mutex": "^0.5.0",
     "chalk": "^5.3.0",


### PR DESCRIPTION
Now that I can confirm this is working, here's my change that enables proper dependency resolution with community plugins as dependencies via NPM, which depend on a quartz-api package, which depends on quartz. The way my current quartz-api package uses this change is necessarily much more complex than the change itself, because dependency resolution is not fun. 

Part of: #1062 

Edit: I didn't touch the file that's failing style checks, weird