### PR TITLE
fix: unnecessery 'm' letter removed in pt-BR

### DIFF
--- a/quartz/i18n/locales/pt-BR.ts
+++ b/quartz/i18n/locales/pt-BR.ts
@@ -69,7 +69,7 @@ export default {
     folderContent: {
       folder: "Arquivo",
       itemsUnderFolder: ({ count }) =>
-        count === 1 ? "1 item mneste arquivo." : `${count} items neste arquivo.`,
+        count === 1 ? "1 item neste arquivo." : `${count} items neste arquivo.`,
     },
     tagContent: {
       tag: "Tag",


### PR DESCRIPTION
**Description:**

This pull request addresses a grammatical error in the pt-BR language translation of Quartz. 

**Changes:**

- Corrected the grammatical error by replacing the incorrect word "mneste" with the correct word "neste" in the pt-BR translation.
- Updated the relevant code or translation files to ensure consistency.

**Screenshots:**

Before:

![Incorrect Translation](https://github.com/jackyzha0/quartz/assets/93885104/cba5bf39-c15a-473e-a3c8-a84e8d46f191)

After:

![Corrected Translation](https://github.com/jackyzha0/quartz/assets/93885104/1aea17f2-fb62-4e71-a150-386d23ef6011)

**Additional Notes:**

This change ensures that the language translation in Quartz is accurate and free from grammatical errors, providing a better user experience for Portuguese speakers.