### PR TITLE
Add Options to display Custom Frontmatter Fields

### DIFF
--- a/quartz/components/ContentMeta.tsx
+++ b/quartz/components/ContentMeta.tsx
@@ -12,6 +12,10 @@ interface ContentMetaOptions {
    */
   showReadingTime: boolean
   showComma: boolean
+  frontmatter?: {
+    fieldName: string,
+    fieldPrefix?: string,
+  }[]
 }
 
 const defaultOptions: ContentMetaOptions = {
@@ -40,6 +44,20 @@ export default ((opts?: Partial<ContentMetaOptions>) => {
           minutes: Math.ceil(minutes),
         })
         segments.push(displayedTime)
+      }
+
+      if (options.frontmatter && fileData.frontmatter) {
+        options.frontmatter.forEach((field) => {
+          if (fileData.frontmatter && field.fieldName in fileData.frontmatter && fileData.frontmatter[field.fieldName] !== null) {
+            const value = fileData.frontmatter[field.fieldName]
+            const prefix = field.fieldPrefix ? `${field.fieldPrefix}` : ""
+            if (prefix) {
+              segments.push(`${prefix} ${value}`)
+            } else {
+              segments.push(`${value}`)
+            }
+          }
+        })
       }
 
       const segmentsElements = segments.map((segment) => <span>{segment}</span>)


### PR DESCRIPTION
I added an option to display custom Frontmatter Field for each Page. 
When calling `Component.ContentMeta()` you can now add frontmatter options like so. These Options will be displayed after the date Meta.

```tsx
Component.ContentMeta({
      frontmatter: [{
        fieldName: "test",
      }, {
        fieldName: "nr",
        fieldPrefix: "nr",
      }
      ]
    }),
```
