### PR TITLE
feat(i18n): homepage link for 404 pages

### DIFF
--- a/quartz/components/pages/404.tsx
+++ b/quartz/components/pages/404.tsx
@@ -3,9 +3,8 @@ import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } fro
 
 const NotFound: QuartzComponent = ({ cfg }: QuartzComponentProps) => {
   // If baseUrl contains a pathname after the domain, use this as the home link
-  const baseDirFull = cfg.baseUrl ? cfg.baseUrl : "/"
-  const pathLoc = baseDirFull.indexOf("/")
-  const baseDir = pathLoc === -1 ? "/" : baseDirFull.substring(pathLoc)
+  const url = new URL(`https://${cfg.baseUrl ?? "example.com"}`)
+  const baseDir = url.pathname
 
   return (
     <article class="popover-hint">

--- a/quartz/components/pages/404.tsx
+++ b/quartz/components/pages/404.tsx
@@ -1,9 +1,12 @@
 import { i18n } from "../../i18n"
-import { pathToRoot } from "../../util/path"
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "../types"
 
-const NotFound: QuartzComponent = ({ fileData, cfg }: QuartzComponentProps) => {
-  const baseDir = pathToRoot(fileData.slug!)
+const NotFound: QuartzComponent = ({ cfg }: QuartzComponentProps) => {
+  // If baseUrl contains a pathname after the domain, use this as the home link
+  const baseDirFull = cfg.baseUrl ? cfg.baseUrl : "/"
+  const pathLoc = baseDirFull.indexOf("/")
+  const baseDir = pathLoc === -1 ? "/" : baseDirFull.substring(pathLoc)
+
   return (
     <article class="popover-hint">
       <h1>404</h1>

--- a/quartz/components/pages/404.tsx
+++ b/quartz/components/pages/404.tsx
@@ -1,11 +1,14 @@
 import { i18n } from "../../i18n"
+import { pathToRoot } from "../../util/path"
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "../types"
 
-const NotFound: QuartzComponent = ({ cfg }: QuartzComponentProps) => {
+const NotFound: QuartzComponent = ({ fileData, cfg }: QuartzComponentProps) => {
+  const baseDir = pathToRoot(fileData.slug!)
   return (
     <article class="popover-hint">
       <h1>404</h1>
       <p>{i18n(cfg.locale).pages.error.notFound}</p>
+      <a href={baseDir}>{i18n(cfg.locale).pages.error.home}</a>
     </article>
   )
 }

--- a/quartz/i18n/index.ts
+++ b/quartz/i18n/index.ts
@@ -16,6 +16,7 @@ import vi from "./locales/vi-VN"
 import pt from "./locales/pt-BR"
 import hu from "./locales/hu-HU"
 import fa from "./locales/fa-IR"
+import pl from "./locales/pl-PL"
 
 export const TRANSLATIONS = {
   "en-US": en,
@@ -56,6 +57,7 @@ export const TRANSLATIONS = {
   "pt-BR": pt,
   "hu-HU": hu,
   "fa-IR": fa,
+  "pl-PL": pl,
 } as const
 
 export const defaultTranslation = "en-US"

--- a/quartz/i18n/index.ts
+++ b/quartz/i18n/index.ts
@@ -16,7 +16,6 @@ import vi from "./locales/vi-VN"
 import pt from "./locales/pt-BR"
 import hu from "./locales/hu-HU"
 import fa from "./locales/fa-IR"
-import pl from "./locales/pl-PL"
 
 export const TRANSLATIONS = {
   "en-US": en,
@@ -57,7 +56,6 @@ export const TRANSLATIONS = {
   "pt-BR": pt,
   "hu-HU": hu,
   "fa-IR": fa,
-  "pl-PL": pl,
 } as const
 
 export const defaultTranslation = "en-US"

--- a/quartz/i18n/locales/ar-SA.ts
+++ b/quartz/i18n/locales/ar-SA.ts
@@ -70,6 +70,7 @@ export default {
     error: {
       title: "غير موجود",
       notFound: "إما أن هذه الصفحة خاصة أو غير موجودة.",
+      home: "العوده للصفحة الرئيسية",
     },
     folderContent: {
       folder: "مجلد",

--- a/quartz/i18n/locales/de-DE.ts
+++ b/quartz/i18n/locales/de-DE.ts
@@ -65,6 +65,7 @@ export default {
     error: {
       title: "Nicht gefunden",
       notFound: "Diese Seite ist entweder nicht öffentlich oder existiert nicht.",
+      home: "Return to Homepage",
     },
     folderContent: {
       folder: "Ordner",

--- a/quartz/i18n/locales/definition.ts
+++ b/quartz/i18n/locales/definition.ts
@@ -67,6 +67,7 @@ export interface Translation {
     error: {
       title: string
       notFound: string
+      home: string
     }
     folderContent: {
       folder: string

--- a/quartz/i18n/locales/en-US.ts
+++ b/quartz/i18n/locales/en-US.ts
@@ -65,6 +65,7 @@ export default {
     error: {
       title: "Not Found",
       notFound: "Either this page is private or doesn't exist.",
+      home: "Return to Homepage",
     },
     folderContent: {
       folder: "Folder",

--- a/quartz/i18n/locales/es-ES.ts
+++ b/quartz/i18n/locales/es-ES.ts
@@ -65,6 +65,7 @@ export default {
     error: {
       title: "No se encontró.",
       notFound: "Esta página es privada o no existe.",
+      home: "Regresar a la página principal",
     },
     folderContent: {
       folder: "Carpeta",

--- a/quartz/i18n/locales/fa-IR.ts
+++ b/quartz/i18n/locales/fa-IR.ts
@@ -65,6 +65,7 @@ export default {
     error: {
       title: "یافت نشد",
       notFound: "این صفحه یا خصوصی است یا وجود ندارد",
+      home: "بازگشت به صفحه اصلی",
     },
     folderContent: {
       folder: "پوشه",

--- a/quartz/i18n/locales/fr-FR.ts
+++ b/quartz/i18n/locales/fr-FR.ts
@@ -65,6 +65,7 @@ export default {
     error: {
       title: "Introuvable",
       notFound: "Cette page est soit privée, soit elle n'existe pas.",
+      home: "Retour à la page d'accueil",
     },
     folderContent: {
       folder: "Dossier",

--- a/quartz/i18n/locales/hu-HU.ts
+++ b/quartz/i18n/locales/hu-HU.ts
@@ -65,6 +65,7 @@ export default {
     error: {
       title: "Nem található",
       notFound: "Ez a lap vagy privát vagy nem létezik.",
+      home: "Vissza a kezdőlapra",
     },
     folderContent: {
       folder: "Mappa",

--- a/quartz/i18n/locales/it-IT.ts
+++ b/quartz/i18n/locales/it-IT.ts
@@ -65,6 +65,7 @@ export default {
     error: {
       title: "Non trovato",
       notFound: "Questa pagina è privata o non esiste.",
+      home: "Ritorna alla home page",
     },
     folderContent: {
       folder: "Cartella",

--- a/quartz/i18n/locales/ja-JP.ts
+++ b/quartz/i18n/locales/ja-JP.ts
@@ -65,6 +65,7 @@ export default {
     error: {
       title: "Not Found",
       notFound: "ページが存在しないか、非公開設定になっています。",
+      home: "ホームページに戻る",
     },
     folderContent: {
       folder: "フォルダ",

--- a/quartz/i18n/locales/ko-KR.ts
+++ b/quartz/i18n/locales/ko-KR.ts
@@ -65,6 +65,7 @@ export default {
     error: {
       title: "Not Found",
       notFound: "페이지가 존재하지 않거나 비공개 설정이 되어 있습니다.",
+      home: "홈페이지로 돌아가기",
     },
     folderContent: {
       folder: "폴더",

--- a/quartz/i18n/locales/nl-NL.ts
+++ b/quartz/i18n/locales/nl-NL.ts
@@ -66,6 +66,7 @@ export default {
     error: {
       title: "Niet gevonden",
       notFound: "Deze pagina is niet zichtbaar of bestaat niet.",
+      home: "Keer terug naar de start pagina",
     },
     folderContent: {
       folder: "Map",

--- a/quartz/i18n/locales/pl-PL.ts
+++ b/quartz/i18n/locales/pl-PL.ts
@@ -65,6 +65,7 @@ export default {
     error: {
       title: "Nie znaleziono",
       notFound: "Ta strona jest prywatna lub nie istnieje.",
+      home: "Powrót do strony głównej",
     },
     folderContent: {
       folder: "Folder",

--- a/quartz/i18n/locales/pt-BR.ts
+++ b/quartz/i18n/locales/pt-BR.ts
@@ -65,6 +65,7 @@ export default {
     error: {
       title: "Não encontrado",
       notFound: "Esta página é privada ou não existe.",
+      home: "Retornar a página inicial",
     },
     folderContent: {
       folder: "Arquivo",

--- a/quartz/i18n/locales/ro-RO.ts
+++ b/quartz/i18n/locales/ro-RO.ts
@@ -66,6 +66,7 @@ export default {
     error: {
       title: "Pagina nu a fost găsită",
       notFound: "Fie această pagină este privată, fie nu există.",
+      home: "Reveniți la pagina de pornire",
     },
     folderContent: {
       folder: "Dosar",

--- a/quartz/i18n/locales/ru-RU.ts
+++ b/quartz/i18n/locales/ru-RU.ts
@@ -67,6 +67,7 @@ export default {
     error: {
       title: "Страница не найдена",
       notFound: "Эта страница приватная или не существует",
+      home: "Вернуться на главную страницу",
     },
     folderContent: {
       folder: "Папка",

--- a/quartz/i18n/locales/uk-UA.ts
+++ b/quartz/i18n/locales/uk-UA.ts
@@ -65,6 +65,7 @@ export default {
     error: {
       title: "Не знайдено",
       notFound: "Ця сторінка або приватна, або не існує.",
+      home: "Повернутися на головну сторінку",
     },
     folderContent: {
       folder: "Папка",

--- a/quartz/i18n/locales/vi-VN.ts
+++ b/quartz/i18n/locales/vi-VN.ts
@@ -65,6 +65,7 @@ export default {
     error: {
       title: "Không Tìm Thấy",
       notFound: "Trang này được bảo mật hoặc không tồn tại.",
+      home: "Trở về trang chủ",
     },
     folderContent: {
       folder: "Thư Mục",

--- a/quartz/i18n/locales/zh-CN.ts
+++ b/quartz/i18n/locales/zh-CN.ts
@@ -65,6 +65,7 @@ export default {
     error: {
       title: "无法找到",
       notFound: "私有笔记或笔记不存在。",
+      home: "返回首页",
     },
     folderContent: {
       folder: "文件夹",


### PR DESCRIPTION
Hello,

This is hopefully a small non-breaking change.

This PR adds a homepage link to the 404 page.
This makes it easier to navigate to the correct page when following a dead link, particularly on mobile pages where the explorer tree is hidden.

The translations are based on Google Translate + asking some bilingual friends. Apologies if the direct translation doesn't make sense!
