### PR TITLE
Fix links case sensitivity in path.ts

### DIFF
--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -214,11 +214,12 @@ export function transformLink(src: FullSlug, target: string, opts: TransformOpti
     let [targetCanonical, targetAnchor] = splitAnchor(canonicalSlug)
 
     if (opts.strategy === "shortest") {
+      const lowerCaseTargetCanonical = targetCanonical.toLowerCase();
       // if the file name is unique, then it's just the filename
       const matchingFileNames = opts.allSlugs.filter((slug) => {
         const parts = slug.split("/")
         const fileName = parts.at(-1)
-        return targetCanonical === fileName
+        return lowerCaseTargetCanonical === fileName.toLowerCase();
       })
 
       // only match, just use it

--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -214,12 +214,12 @@ export function transformLink(src: FullSlug, target: string, opts: TransformOpti
     let [targetCanonical, targetAnchor] = splitAnchor(canonicalSlug)
 
     if (opts.strategy === "shortest") {
-      const lowerCaseTargetCanonical = targetCanonical.toLowerCase();
+      const lowerCaseTargetCanonical = targetCanonical.toLowerCase()
       // if the file name is unique, then it's just the filename
       const matchingFileNames = opts.allSlugs.filter((slug) => {
         const parts = slug.split("/")
         const fileName = parts.at(-1)
-        return lowerCaseTargetCanonical === fileName.toLowerCase();
+        return lowerCaseTargetCanonical === fileName?.toLowerCase() ?? ""
       })
 
       // only match, just use it


### PR DESCRIPTION
This is a fix that I created for a bug below. It makes Quartz to have case insensitive links, the same as we have in Obsidian.
It has minimal impact. 

https://github.com/jackyzha0/quartz/issues/1122