### PR TITLE
homepage coloured as visited in the Graph

### DIFF
--- a/quartz/components/scripts/graph.inline.ts
+++ b/quartz/components/scripts/graph.inline.ts
@@ -336,7 +336,7 @@ function renderGlobalGraph() {
 
 document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
   const slug = e.detail.url
-  addToVisited(slug)
+  addToVisited(simplifySlug(slug))
   await renderGraph("graph-container", slug)
 
   const containerIcon = document.getElementById("global-graph-icon")


### PR DESCRIPTION
The homepage's full slug is "index".
When the graph is rendered, the _color_ method identifies is a node should be colored as visited or not.
In the case of the homepage, SimpleSlug "/" is different from the FullSlug stored in _visited_ (i.e. in browser's memory), which is why the homepage is never coloured as a visited page in the graph.

By making sure to store the SimpleSlug in _addToVisited()_ function via the _simplifySlug()_ function, the pages "index", "folder/index", "tags/tag/index" are stored as "/", "folder/", "tags/tag/" in the browser's memory. While folder and parent tags pages ain't shown on the graph (so we don't care), this makes sure that the homepage ("index") is coloured as a visited page in the _color_ function.

(... unless it should always remain shown as not visited by design)