### PR TITLE
idea: Tags appear as hollow circles on the graph

### DIFF
--- a/quartz/components/scripts/graph.inline.ts
+++ b/quartz/components/scripts/graph.inline.ts
@@ -265,7 +265,8 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
     .call(drag(simulation))
 
   // make tags hollow circles
-  node.filter((d) => d.id.startsWith("tags/"))
+  node
+    .filter((d) => d.id.startsWith("tags/"))
     .attr("stroke", color)
     .attr("stroke-width", 2)
     .attr("fill", "var(--light)")

--- a/quartz/components/scripts/graph.inline.ts
+++ b/quartz/components/scripts/graph.inline.ts
@@ -264,6 +264,12 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
     // @ts-ignore
     .call(drag(simulation))
 
+  // make tags hollow circles
+  node.filter((d) => d.id.startsWith("tags/"))
+    .attr("stroke", color)
+    .attr("stroke-width", 2)
+    .attr("fill", "var(--light)")
+
   // draw labels
   const labels = graphNode
     .append("text")


### PR DESCRIPTION
A simple idea:

Tags are nice.
Obsidian by default colours the tags in green on the graph, to visually quickly separate them from other notes (should the user wish to see them at all)

While tags are coloured by default in Quartz (in the _colour_ function), they become visually identical to visited pages when the user has browsed the digital garden quite a lot.
The idea is to draw them as hollow circles on the graph, for a fast visual separation which doesn't break the visual too much (e.g. squares would look bad imho). This way, one can quickly see tags on the graph, making sure that the additional node is not another idea, but a tag used for classification.

A simple example of how it looks:
<img width="462" alt="Screenshot" src="https://github.com/jackyzha0/quartz/assets/22347352/1acf8ff6-4b7d-4056-9379-c584c72d41e4">


(in my personal implementation, I also removed the element in the _color_ function that always shows the tags as coloured, as this is not necessary anymore to visually distinguish them.)