### PR TITLE
feat(explorer): filenode tree populated with index files 

### DIFF
--- a/docs/features/explorer.md
+++ b/docs/features/explorer.md
@@ -56,13 +56,14 @@ Want to customize it even more?
 This component allows you to fully customize all of its behavior. You can pass a custom `sort`, `filter` and `map` function.
 All functions you can pass work with the `FileNode` class, which has the following properties:
 
-```ts title="quartz/components/ExplorerNode.tsx" {2-5}
+```ts title="quartz/components/ExplorerNode.tsx" {2-7}
 export class FileNode {
   children: FileNode[]  // children of current node
   name: string  // last part of slug
   displayName: string // what actually should be displayed in the explorer
   file: QuartzPluginData | null // if node is a file, this is the file's metadata. See `QuartzPluginData` for more detail
   depth: number // depth of current node
+  hidden: boolean // if the node is shown in the file tree
 
   ... // rest of implementation
 }
@@ -180,6 +181,38 @@ Component.Explorer({
 })
 ```
 
+### Remove folders by tag
+
+To hide some folders, you can create an `index.md` at its root, and add a tag in it, as a [[Frontmatter]] attribute:
+
+```md title="my-folder-to-hide/index.md"
+---
+tags:
+	- excluded
+---
+
+> You can't see me (in the explorer), my time is now
+```
+
+Now you can filter this folder having the `excluded` tag, with the following `filterFn` function
+
+```ts title="quartz.layout.ts"
+Component.Explorer({
+  filterFn: (node) => {
+    if (!node.file) {
+      // the current node is a folder
+      let indexFile = node.children.find((node) => node.name === "index")
+	  if (indexFile) {
+	    // a child node named index exists
+	    return indexFile?.file?.frontmatter?.tags?.includes("excluded") !== true
+      }
+    }
+    
+    return true
+  },	
+})
+```
+
 ### Show every element in explorer
 
 To override the default filter function that removes the `tags` folder from the explorer, you can set the filter function to `undefined`.
@@ -189,6 +222,8 @@ Component.Explorer({
   filterFn: undefined, // apply no filter function, every file and folder will visible
 })
 ```
+
+
 
 ## Advanced examples
 

--- a/docs/features/explorer.md
+++ b/docs/features/explorer.md
@@ -202,14 +202,14 @@ Component.Explorer({
     if (!node.file) {
       // the current node is a folder
       let indexFile = node.children.find((node) => node.name === "index")
-	  if (indexFile) {
-	    // a child node named index exists
-	    return indexFile?.file?.frontmatter?.tags?.includes("excluded") !== true
+      if (indexFile) {
+        // a child node named index exists
+        return indexFile?.file?.frontmatter?.tags?.includes("excluded") !== true
       }
     }
-    
+
     return true
-  },	
+  },
 })
 ```
 
@@ -222,8 +222,6 @@ Component.Explorer({
   filterFn: undefined, // apply no filter function, every file and folder will visible
 })
 ```
-
-
 
 ## Advanced examples
 

--- a/quartz/components/ExplorerNode.tsx
+++ b/quartz/components/ExplorerNode.tsx
@@ -47,13 +47,15 @@ export class FileNode {
   displayName: string
   file: QuartzPluginData | null
   depth: number
+  hidden: boolean
 
-  constructor(slugSegment: string, displayName?: string, file?: QuartzPluginData, depth?: number) {
+  constructor(slugSegment: string, displayName?: string, file?: QuartzPluginData, depth?: number, hidden?: boolean) {
     this.children = []
     this.name = slugSegment
     this.displayName = displayName ?? file?.frontmatter?.title ?? slugSegment
     this.file = file ? clone(file) : null
     this.depth = depth ?? 0
+    this.hidden = hidden ?? false
   }
 
   private insert(fileData: DataWrapper) {
@@ -71,6 +73,7 @@ export class FileNode {
         if (title && title !== "index") {
           this.displayName = title
         }
+        this.children.push(new FileNode("index", undefined, fileData.file, this.depth + 1, true))
       } else {
         // direct child
         this.children.push(new FileNode(nextSegment, undefined, fileData.file, this.depth + 1))
@@ -163,6 +166,9 @@ type ExplorerNodeProps = {
 }
 
 export function ExplorerNode({ node, opts, fullPath, fileData }: ExplorerNodeProps) {
+  if (node.hidden) {
+    return <></>
+  }  
   // Get options
   const folderBehavior = opts.folderClickBehavior
   const isDefaultOpen = opts.folderDefaultState === "open"

--- a/quartz/components/ExplorerNode.tsx
+++ b/quartz/components/ExplorerNode.tsx
@@ -49,7 +49,13 @@ export class FileNode {
   depth: number
   hidden: boolean
 
-  constructor(slugSegment: string, displayName?: string, file?: QuartzPluginData, depth?: number, hidden?: boolean) {
+  constructor(
+    slugSegment: string,
+    displayName?: string,
+    file?: QuartzPluginData,
+    depth?: number,
+    hidden?: boolean,
+  ) {
     this.children = []
     this.name = slugSegment
     this.displayName = displayName ?? file?.frontmatter?.title ?? slugSegment
@@ -168,7 +174,7 @@ type ExplorerNodeProps = {
 export function ExplorerNode({ node, opts, fullPath, fileData }: ExplorerNodeProps) {
   if (node.hidden) {
     return <></>
-  }  
+  }
   // Get options
   const folderBehavior = opts.folderClickBehavior
   const isDefaultOpen = opts.folderDefaultState === "open"


### PR DESCRIPTION
this pull request aims to fix #1140

i implemented the least impacting method to populate the filenode tree with the folder index files, by adding another attribute: `hidden`.

people will still rely on `node.file === null` to know if the node is a folder, the only difference is that `index`files are now "hidden", and the explorer list does not render "hidden" nodes.