### PR TITLE
Feat: extend Docker Support

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -1,0 +1,71 @@
+name: Build and Push
+
+on:
+  push:
+    tags:
+      - v4.*
+  workflow_dispatch:
+
+jobs:
+  build-push:
+    name: Build/Push image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    steps:
+      -
+        name: Checkout repository
+        uses: actions/checkout@v4
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          context: git
+          images: |
+            name=ghcr.io/${{ github.repository_owner }}/quartz,enable=true
+            # name=docker.io/${{ github.repository_owner }}/quartz,enable=false
+          labels: |
+            org.opencontainers.image.title=quartz
+            org.opencontainers.image.vendor=Quartz Community
+            org.opencontainers.image.description=A container image for Quartz
+            org.opencontainers.image.licenses=CC0
+
+          tags: |
+            type=semver,pattern={{ version }}
+            type=semver,pattern={{ major }}.{{ minor }}
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            {{ sha }}
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # -
+      #   name: Login to Docker Hub
+      #   uses: docker/login-action@v3
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Login to GitHub Packages Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      -
+        name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          platforms: linux/amd64
+          tags:      ${{ steps.meta.outputs.tags }}
+          labels:    ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -15,11 +15,9 @@ jobs:
       id-token: write
       packages: write
     steps:
-      -
-        name: Checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v4
-      -
-        name: Docker meta
+      - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -40,11 +38,9 @@ jobs:
             type=ref,event=tag
             type=ref,event=pr
             {{ sha }}
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       # -
@@ -53,19 +49,17 @@ jobs:
       #   with:
       #     username: ${{ secrets.DOCKERHUB_USERNAME }}
       #     password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Login to GitHub Packages Registry
+      - name: Login to GitHub Packages Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      -
-        name: Build and push
+      - name: Build and push
         uses: docker/build-push-action@v5
         with:
           push: true
           platforms: linux/amd64
-          tags:      ${{ steps.meta.outputs.tags }}
-          labels:    ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,6 @@ RUN apt update ; \
 WORKDIR /usr/src/app
 COPY --from=builder /usr/src/app/ /usr/src/app/
 COPY . .
-CMD ["npx", "quartz", "build", "--serve"]
+
+ENTRYPOINT ["npx", "quartz" ]
+CMD ["build", "--serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ COPY package-lock.json* .
 RUN npm ci
 
 FROM node:20-slim
+
+RUN apt update ; \
+    apt install --no-install-recommends -y git; \
+    rm -rf /var/cache/apt/*
 WORKDIR /usr/src/app
 COPY --from=builder /usr/src/app/ /usr/src/app/
 COPY . .

--- a/docs/features/Docker Support.md
+++ b/docs/features/Docker Support.md
@@ -1,7 +1,33 @@
 Quartz comes shipped with a Docker image that will allow you to preview your Quartz locally without installing Node.
 
-You can run the below one-liner to run Quartz in Docker.
+You can run Quartz in Docker. A container image is available at:
+
+- `ghcr.io/jackyzha0/quartz`
+
+You can create a local build with:
 
 ```sh
-docker run --rm -itp 8080:8080 $(docker build -q .)
+docker build --load -t ghcr.io/jackyzha0/quartz .
 ```
+
+This example expects a `content/` directory with the `quartz.*.ts` configuration files and a (empty) `public/` directory to be present in the preesent working directory.
+
+```sh
+mkdir -p content/ public/
+```
+
+Build the site with running a local development web server for preview:
+
+```sh
+docker run --rm -it -p 8080:8080 -v ${PWD}/content:/usr/src/app/content -v ${PWD}/public:/usr/src/app/public --entrypoint sh ghcr.io/jackyzha0/quartz -c "cp content/quartz.*.ts .; npx quartz build --serve"
+```
+
+You can now access your dynamically built page at http://localhost:8080
+
+Build the site for deployment
+
+```sh
+docker run --rm -it -p 8080:8080 -v ${PWD}/content:/usr/src/app/content -v ${PWD}/public:/usr/src/app/public --entrypoint sh ghcr.io/jackyzha0/quartz -c "cp content/quartz.*.ts .; npx quartz build; rm public/quartz.*.ts"
+```
+
+This procedure from building a Quartz page from a content repository without a custom fork of the application could be enhanced by providing a custom entrypoint script.

--- a/docs/features/Docker Support.md
+++ b/docs/features/Docker Support.md
@@ -1,16 +1,57 @@
+# Docker Support
+
 Quartz comes shipped with a Docker image that will allow you to preview your Quartz locally without installing Node.
 
 You can run Quartz in Docker. A container image is available at:
 
 - `ghcr.io/jackyzha0/quartz`
 
-You can create a local build with:
+## Building
+
+You can create a local build with this command issued from the root of the repository:
 
 ```sh
 docker build --load -t ghcr.io/jackyzha0/quartz .
 ```
 
-This example expects a `content/` directory with the `quartz.*.ts` configuration files and a (empty) `public/` directory to be present in the preesent working directory.
+## Usage
+
+The way how the container is built expects your content present in the directory structure of the application.
+
+You can use the image to build a fork of Quartz that includes your changes.
+
+From within the root of your local clone of your Quartz fork, run this to build the site and to launch a preview webserver:
+
+```sh
+docker run --rm -it -p 8080:8080 -v ${PWD}:/usr/src/app ghcr.io/jackyzha0/quartz
+```
+
+Given you have just built your Quartz image from this repository, which deviates from the convention to hold content in a directory called `content/` and instead uses `docs/`, you could use this command to preview the Quartz documentation:
+
+```sh
+docker run --rm -it -p 8080:8080 -v ${PWD}:/usr/src/app ghcr.io/jackyzha0/quartz build --serve -d docs
+```
+
+Open http://localhost:8080 to show the locally built site.
+
+## Advanced usage
+
+This image can also act on repositories which only contain a `content/` directory, next to an optional `.quartz` directory for files overlayed on top of the Quartz application packaged in the image.
+
+The expected file system layout of such a repository is as follows:
+
+```console
+.
+├── .quartz
+│   ├── quartz # optional
+│   │   └── …
+│   ├── quartz.config.ts
+│   └── quartz.layout.ts
+└── content
+    └── index.md
+```
+
+This example expects a `content/` directory with the content and a `.quart/` directory with `quartz.*.ts` configuration files and other overlays to be present in the working directory.
 
 ```sh
 mkdir -p content/ public/
@@ -19,7 +60,7 @@ mkdir -p content/ public/
 Build the site with running a local development web server for preview:
 
 ```sh
-docker run --rm -it -p 8080:8080 -v ${PWD}/content:/usr/src/app/content -v ${PWD}/public:/usr/src/app/public --entrypoint sh ghcr.io/jackyzha0/quartz -c "cp content/quartz.*.ts .; npx quartz build --serve"
+docker run --rm -it -p 8080:8080 -v ${PWD}/.quartz:/usr/src/app/.quartz -v ${PWD}/content:/usr/src/app/content -v ${PWD}/public:/usr/src/app/public --entrypoint sh ghcr.io/jackyzha0/quartz -c "cp -R .quartz/* /usr/src/app/; npx quartz build --serve"
 ```
 
 You can now access your dynamically built page at http://localhost:8080
@@ -27,7 +68,44 @@ You can now access your dynamically built page at http://localhost:8080
 Build the site for deployment
 
 ```sh
-docker run --rm -it -v ${PWD}/content:/usr/src/app/content -v ${PWD}/public:/usr/src/app/public --entrypoint sh ghcr.io/jackyzha0/quartz -c "cp content/quartz.*.ts .; npx quartz build; rm public/quartz.*.ts"
+docker run --rm -it -p 8080:8080 -v ${PWD}/.quartz:/usr/src/app/.quartz -v ${PWD}/content:/usr/src/app/content -v ${PWD}/public:/usr/src/app/public --entrypoint sh ghcr.io/jackyzha0/quartz -c "cp -R .quartz/* /usr/src/app/; npx quartz build"
 ```
 
-This procedure from building a Quartz page from a content repository without a custom fork of the application could be enhanced by providing a custom entrypoint script.
+This procedure from building a Quartz page from a content repository without a custom fork of the application
+
+- lacks permission handling. The output in the `public/` directory is owned by root, when run with rootful Docker. It is advised to use rootless (Docker/Podman) containers with subuid mapping.
+- could be improved by
+  - providing a custom entrypoint script.
+  - publishing Quartz as an independent Node package to NPM to install it from a release version.
+
+## CI Usage
+
+The Quartz container image can also be used in CI.
+
+This pipeline example works for building a Quartz site from a content repository with `.quartz` and `content/` overlays with GitLab CI and pushing to GitLab Pages:
+
+```yaml
+image:
+  name: ghcr.io/jackyzha0/quartz:v4
+  entrypoint: [""]
+
+pages:
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+  stage: deploy
+  environment: live
+
+  before_script:
+    - cd /usr/src/app
+    - mkdir -p public
+
+  script:
+    - cp -R $CI_PROJECT_DIR/.quartz/* .
+    - npx quartz build -d $CI_PROJECT_DIR/content
+    - mv public $CI_PROJECT_DIR
+
+  artifacts:
+    paths:
+      - public
+```

--- a/docs/features/Docker Support.md
+++ b/docs/features/Docker Support.md
@@ -27,7 +27,7 @@ You can now access your dynamically built page at http://localhost:8080
 Build the site for deployment
 
 ```sh
-docker run --rm -it -p 8080:8080 -v ${PWD}/content:/usr/src/app/content -v ${PWD}/public:/usr/src/app/public --entrypoint sh ghcr.io/jackyzha0/quartz -c "cp content/quartz.*.ts .; npx quartz build; rm public/quartz.*.ts"
+docker run --rm -it -v ${PWD}/content:/usr/src/app/content -v ${PWD}/public:/usr/src/app/public --entrypoint sh ghcr.io/jackyzha0/quartz -c "cp content/quartz.*.ts .; npx quartz build; rm public/quartz.*.ts"
 ```
 
 This procedure from building a Quartz page from a content repository without a custom fork of the application could be enhanced by providing a custom entrypoint script.


### PR DESCRIPTION
These commits package Quartz as a container here at the GitHub container registry when a new tag is pushed:

- [Package quartz](https://github.com/jackyzha0/quartz/pkgs/container/quartz)

The CI workflow is prepared to also push to Docker Hub. There is also a workflow dispatch trigger to create manual builds. The configuration could be parametrised more in the future.

The Dockerfile has been minimally modified to conform to the OCI standard with regards to the entrypoint and its command, plus has been extended with the missing `git` dependency to be able to use the `build` command.

The documentation has been extended with some examples on how to use the image.

The documentation expects the image to be pushed to `ghcr.io/jackyzha0/quartz`.