### PR TITLE
feat: ability to hide tags in the recent notes component

### DIFF
--- a/docs/features/recent notes.md
+++ b/docs/features/recent notes.md
@@ -7,18 +7,11 @@ Quartz can generate a list of recent notes based on some filtering and sorting c
 
 ## Customization
 
-### Parameters
-
-| Parameter Name | Description                                                                                                                                                                                                                                                                                            | Default value                                  |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
-| `title`        | the displayed title of the component                                                                                                                                                                                                                                                                   | the [[i18n]] value                             |
-| `limit`        | the number of recent notes                                                                                                                                                                                                                                                                             | `3`                                            |
-| `showTags`     | if the note's tags are displayed                                                                                                                                                                                                                                                                       | `true`                                         |
-| `linkToMore`   | show a 'see more' link. this field should be a full slug to a page that exists (e.g. "tags/components")                                                                                                                                                                                                | `false`                                        |
-| `filter`       | custom filter function that has the signature `(f: QuartzPluginData) => boolean`                                                                                                                                                                                                                       | `() => true`                                   |
-| `sort`         | custom sort function. By default, Quartz will sort by date and then tie break lexographically. The sort function should be a function that has the signature `(f1: QuartzPluginData, f2: QuartzPluginData) => number`. See `byDateAndAlphabetical` in `quartz/components/PageList.tsx` for an example. | `byDateAndAlphabetical( GlobalConfiguration )` |
-
-### Relevant files
-
+- Changing the title from "Recent notes": pass in an additional parameter to `Component.RecentNotes({ title: "Recent writing" })`
+- Changing the number of recent notes: pass in an additional parameter to `Component.RecentNotes({ limit: 5 })`
+- Display the note's tags (defaults to true): `Component.RecentNotes({showTags: false})`
+- Show a 'see more' link: pass in an additional parameter to `Component.RecentNotes({ linkToMore: "tags/components" })`. This field should be a full slug to a page that exists.
+- Customize filtering: pass in an additional parameter to `Component.RecentNotes({ filter: someFilterFunction })`. The filter function should be a function that has the signature `(f: QuartzPluginData) => boolean`.
+- Customize sorting: pass in an additional parameter to `Component.RecentNotes({ sort: someSortFunction })`. By default, Quartz will sort by date and then tie break lexographically. The sort function should be a function that has the signature `(f1: QuartzPluginData, f2: QuartzPluginData) => number`. See `byDateAndAlphabetical` in `quartz/components/PageList.tsx` for an example.
 - Component: `quartz/components/RecentNotes.tsx`
 - Style: `quartz/components/styles/recentNotes.scss`

--- a/docs/features/recent notes.md
+++ b/docs/features/recent notes.md
@@ -9,7 +9,7 @@ Quartz can generate a list of recent notes based on some filtering and sorting c
 
 - Changing the title from "Recent notes": pass in an additional parameter to `Component.RecentNotes({ title: "Recent writing" })`
 - Changing the number of recent notes: pass in an additional parameter to `Component.RecentNotes({ limit: 5 })`
-- Display the note's tags (defaults to true): `Component.RecentNotes({showTags: false})`
+- Display the note's tags (defaults to true): `Component.RecentNotes({ showTags: false })`
 - Show a 'see more' link: pass in an additional parameter to `Component.RecentNotes({ linkToMore: "tags/components" })`. This field should be a full slug to a page that exists.
 - Customize filtering: pass in an additional parameter to `Component.RecentNotes({ filter: someFilterFunction })`. The filter function should be a function that has the signature `(f: QuartzPluginData) => boolean`.
 - Customize sorting: pass in an additional parameter to `Component.RecentNotes({ sort: someSortFunction })`. By default, Quartz will sort by date and then tie break lexographically. The sort function should be a function that has the signature `(f1: QuartzPluginData, f2: QuartzPluginData) => number`. See `byDateAndAlphabetical` in `quartz/components/PageList.tsx` for an example.

--- a/docs/features/recent notes.md
+++ b/docs/features/recent notes.md
@@ -9,6 +9,7 @@ Quartz can generate a list of recent notes based on some filtering and sorting c
 
 - Changing the title from "Recent notes": pass in an additional parameter to `Component.RecentNotes({ title: "Recent writing" })`
 - Changing the number of recent notes: pass in an additional parameter to `Component.RecentNotes({ limit: 5 })`
+- Display the note's tags (defaults to true): `Component.RecentNotes({showTags: false})`
 - Show a 'see more' link: pass in an additional parameter to `Component.RecentNotes({ linkToMore: "tags/components" })`. This field should be a full slug to a page that exists.
 - Customize filtering: pass in an additional parameter to `Component.RecentNotes({ filter: someFilterFunction })`. The filter function should be a function that has the signature `(f: QuartzPluginData) => boolean`.
 - Customize sorting: pass in an additional parameter to `Component.RecentNotes({ sort: someSortFunction })`. By default, Quartz will sort by date and then tie break lexographically. The sort function should be a function that has the signature `(f1: QuartzPluginData, f2: QuartzPluginData) => number`. See `byDateAndAlphabetical` in `quartz/components/PageList.tsx` for an example.

--- a/docs/features/recent notes.md
+++ b/docs/features/recent notes.md
@@ -7,11 +7,18 @@ Quartz can generate a list of recent notes based on some filtering and sorting c
 
 ## Customization
 
-- Changing the title from "Recent notes": pass in an additional parameter to `Component.RecentNotes({ title: "Recent writing" })`
-- Changing the number of recent notes: pass in an additional parameter to `Component.RecentNotes({ limit: 5 })`
-- Display the note's tags (defaults to true): `Component.RecentNotes({showTags: false})`
-- Show a 'see more' link: pass in an additional parameter to `Component.RecentNotes({ linkToMore: "tags/components" })`. This field should be a full slug to a page that exists.
-- Customize filtering: pass in an additional parameter to `Component.RecentNotes({ filter: someFilterFunction })`. The filter function should be a function that has the signature `(f: QuartzPluginData) => boolean`.
-- Customize sorting: pass in an additional parameter to `Component.RecentNotes({ sort: someSortFunction })`. By default, Quartz will sort by date and then tie break lexographically. The sort function should be a function that has the signature `(f1: QuartzPluginData, f2: QuartzPluginData) => number`. See `byDateAndAlphabetical` in `quartz/components/PageList.tsx` for an example.
+### Parameters
+
+| Parameter Name | Description                                                                                                                                                                                                                                                                                            | Default value                                  |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
+| `title`        | the displayed title of the component                                                                                                                                                                                                                                                                   | the [[i18n]] value                             |
+| `limit`        | the number of recent notes                                                                                                                                                                                                                                                                             | `3`                                            |
+| `showTags`     | if the note's tags are displayed                                                                                                                                                                                                                                                                       | `true`                                         |
+| `linkToMore`   | show a 'see more' link. this field should be a full slug to a page that exists (e.g. "tags/components")                                                                                                                                                                                                | `false`                                        |
+| `filter`       | custom filter function that has the signature `(f: QuartzPluginData) => boolean`                                                                                                                                                                                                                       | `() => true`                                   |
+| `sort`         | custom sort function. By default, Quartz will sort by date and then tie break lexographically. The sort function should be a function that has the signature `(f1: QuartzPluginData, f2: QuartzPluginData) => number`. See `byDateAndAlphabetical` in `quartz/components/PageList.tsx` for an example. | `byDateAndAlphabetical( GlobalConfiguration )` |
+
+### Relevant files
+
 - Component: `quartz/components/RecentNotes.tsx`
 - Style: `quartz/components/styles/recentNotes.scss`

--- a/quartz/components/RecentNotes.tsx
+++ b/quartz/components/RecentNotes.tsx
@@ -12,6 +12,7 @@ interface Options {
   title?: string
   limit: number
   linkToMore: SimpleSlug | false
+  showTags: boolean
   filter: (f: QuartzPluginData) => boolean
   sort: (f1: QuartzPluginData, f2: QuartzPluginData) => number
 }
@@ -19,6 +20,7 @@ interface Options {
 const defaultOptions = (cfg: GlobalConfiguration): Options => ({
   limit: 3,
   linkToMore: false,
+  showTags: true,
   filter: () => true,
   sort: byDateAndAlphabetical(cfg),
 })
@@ -56,7 +58,8 @@ export default ((userOpts?: Partial<Options>) => {
                       <Date date={getDate(cfg, page)!} locale={cfg.locale} />
                     </p>
                   )}
-                  <ul class="tags">
+                  {opts.showTags && (
+                    <ul class="tags">
                     {tags.map((tag) => (
                       <li>
                         <a
@@ -68,6 +71,7 @@ export default ((userOpts?: Partial<Options>) => {
                       </li>
                     ))}
                   </ul>
+                  )}
                 </div>
               </li>
             )

--- a/quartz/components/RecentNotes.tsx
+++ b/quartz/components/RecentNotes.tsx
@@ -60,17 +60,17 @@ export default ((userOpts?: Partial<Options>) => {
                   )}
                   {opts.showTags && (
                     <ul class="tags">
-                    {tags.map((tag) => (
-                      <li>
-                        <a
-                          class="internal tag-link"
-                          href={resolveRelative(fileData.slug!, `tags/${tag}` as FullSlug)}
-                        >
-                          {tag}
-                        </a>
-                      </li>
-                    ))}
-                  </ul>
+                      {tags.map((tag) => (
+                        <li>
+                          <a
+                            class="internal tag-link"
+                            href={resolveRelative(fileData.slug!, `tags/${tag}` as FullSlug)}
+                          >
+                            {tag}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
                   )}
                 </div>
               </li>

--- a/quartz/components/RecentNotes.tsx
+++ b/quartz/components/RecentNotes.tsx
@@ -60,17 +60,17 @@ export default ((userOpts?: Partial<Options>) => {
                   )}
                   {opts.showTags && (
                     <ul class="tags">
-                      {tags.map((tag) => (
-                        <li>
-                          <a
-                            class="internal tag-link"
-                            href={resolveRelative(fileData.slug!, `tags/${tag}` as FullSlug)}
-                          >
-                            {tag}
-                          </a>
-                        </li>
-                      ))}
-                    </ul>
+                    {tags.map((tag) => (
+                      <li>
+                        <a
+                          class="internal tag-link"
+                          href={resolveRelative(fileData.slug!, `tags/${tag}` as FullSlug)}
+                        >
+                          {tag}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
                   )}
                 </div>
               </li>


### PR DESCRIPTION
fixes #1068 by adding a simple `showTags` option to the Recent Notes component which defaults to true

here is how tags look with tags enabled
<img width="247" alt="image" src="https://github.com/jackyzha0/quartz/assets/5795145/8cdada99-3f52-4854-96d0-f418e81d615b">

And here with the `showTags: false` option
<img width="201" alt="image" src="https://github.com/jackyzha0/quartz/assets/5795145/8b27895a-3a02-49fa-a770-5582c8252e60">

