### PR TITLE
.callout-content support

### DIFF
--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -425,7 +425,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
               const [firstLine, ...remainingLines] = text.split("\n")
               const remainingText = remainingLines.join("\n")
 
-              const calloutContent = node.children.length > 1 ? node.children[1] : undefined
+              const [_, calloutContent] = node.children.length
 
               const match = firstLine.match(calloutRegex)
               if (match && match.input) {

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -492,6 +492,22 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
                     "data-callout-metadata": calloutMetaData,
                   },
                 }
+
+                // Add callout-content class to callout body if it has one.
+                if (node.children.length > 1) {
+                  const contentData = node.children[1]
+                  node.children[1] = {
+                    data: {
+                      hProperties: {
+                        ...(contentData.data?.hProperties ?? {}),
+                        className: "callout-content",
+                      },
+                      hName: "div",
+                    },
+                    type: "blockquote",
+                    children: [contentData],
+                  }
+                }
               }
             })
           }

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -494,7 +494,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
                 }
 
                 // Add callout-content class to callout body if it has one.
-                if (calloutContent) {
+                if (calloutContent.length > 0) {
                   const contentData: BlockContent | DefinitionContent = {
                     data: {
                       hProperties: {

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -415,7 +415,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
               }
 
               // find first line and callout content
-              const [firstChild, calloutContent] = node.children
+              const [firstChild, ...calloutContent] = node.children
               if (firstChild.type !== "paragraph" || firstChild.children[0]?.type !== "text") {
                 return
               }
@@ -498,15 +498,14 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
                   const contentData: BlockContent | DefinitionContent = {
                     data: {
                       hProperties: {
-                        ...(calloutContent.data?.hProperties ?? {}),
                         className: "callout-content",
                       },
                       hName: "div",
                     },
                     type: "blockquote",
-                    children: [calloutContent],
+                    children: [...calloutContent],
                   }
-                  node.children.splice(1, 1, ...[contentData])
+                  node.children.splice(1, Infinity, ...[contentData])
                 }
               }
             })

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -505,7 +505,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
                     type: "blockquote",
                     children: [...calloutContent],
                   }
-                  node.children.splice(1, Infinity, ...[contentData])
+                  node.children = [node.children[0], contentData]
                 }
               }
             })

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -425,6 +425,8 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
               const [firstLine, ...remainingLines] = text.split("\n")
               const remainingText = remainingLines.join("\n")
 
+              const calloutContent = node.children.length > 1 ? node.children[1] : undefined
+
               const match = firstLine.match(calloutRegex)
               if (match && match.input) {
                 const [calloutDirective, typeString, calloutMetaData, collapseChar] = match
@@ -494,19 +496,14 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
                 }
 
                 // Add callout-content class to callout body if it has one.
-                if (node.children.length > 1) {
-                  const contentData = node.children[1]
-                  node.children[1] = {
-                    data: {
-                      hProperties: {
-                        ...(contentData.data?.hProperties ?? {}),
-                        className: "callout-content",
-                      },
-                      hName: "div",
-                    },
-                    type: "blockquote",
-                    children: [contentData],
+                if (calloutContent !== undefined) {
+                  const calloutContentWrapped: BlockContent | DefinitionContent = {
+                    type: "html",
+                    value: `<div class="callout-content">
+                      ${toHtml(toHast(calloutContent, { allowDangerousHtml: true }), { allowDangerousHtml: true })}
+                    </div>`,
                   }
+                  node.children.splice(1, 1, ...[calloutContentWrapped])
                 }
               }
             })

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -414,8 +414,8 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
                 return
               }
 
-              // find first line
-              const firstChild = node.children[0]
+              // find first line and callout content
+              const [firstChild, calloutContent] = node.children
               if (firstChild.type !== "paragraph" || firstChild.children[0]?.type !== "text") {
                 return
               }
@@ -424,8 +424,6 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
               const restOfTitle = firstChild.children.slice(1)
               const [firstLine, ...remainingLines] = text.split("\n")
               const remainingText = remainingLines.join("\n")
-
-              const [_, calloutContent] = node.children
 
               const match = firstLine.match(calloutRegex)
               if (match && match.input) {

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -425,7 +425,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
               const [firstLine, ...remainingLines] = text.split("\n")
               const remainingText = remainingLines.join("\n")
 
-              const calloutContent = node.children.length > 1 ? node.children[1] : undefined
+              const [_, calloutContent] = node.children
 
               const match = firstLine.match(calloutRegex)
               if (match && match.input) {
@@ -496,14 +496,19 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
                 }
 
                 // Add callout-content class to callout body if it has one.
-                if (calloutContent !== undefined) {
-                  const calloutContentWrapped: BlockContent | DefinitionContent = {
-                    type: "html",
-                    value: `<div class="callout-content">
-                      ${toHtml(toHast(calloutContent, { allowDangerousHtml: true }), { allowDangerousHtml: true })}
-                    </div>`,
+                if (calloutContent) {
+                  const contentData: BlockContent | DefinitionContent = {
+                    data: {
+                      hProperties: {
+                        ...(calloutContent.data?.hProperties ?? {}),
+                        className: "callout-content",
+                      },
+                      hName: "div",
+                    },
+                    type: "blockquote",
+                    children: [calloutContent],
                   }
-                  node.children.splice(1, 1, ...[calloutContentWrapped])
+                  node.children.splice(1, 1, ...[contentData])
                 }
               }
             })

--- a/quartz/styles/callouts.scss
+++ b/quartz/styles/callouts.scss
@@ -10,7 +10,7 @@
   transition: max-height 0.3s ease;
   box-sizing: border-box;
 
-  & > *:nth-child(2) {
+  & > .callout-content > :first-child {
     margin-top: 0;
   }
 


### PR DESCRIPTION
Closes https://github.com/jackyzha0/quartz/issues/1180

### Markdown:

```markdown
> [!info] hello
>
> - test
> - two
```

### Before:

```html
<blockquote class="callout info" data-callout="info">
  <div class="callout-title">
    <div class="callout-icon"></div>
    <div class="callout-title-inner">
      <p>hello </p>
    </div>

  </div>
  <ul>
    <li>test</li>
    <li>two</li>
  </ul>
</blockquote>
```

### After:

```html
<blockquote class="callout info" data-callout="info">
  <div class="callout-title">
    <div class="callout-icon"></div>
    <div class="callout-title-inner">
      <p>hello </p>
    </div>

  </div>
  <div class="callout-content">
    <ul>
      <li>test</li>
      <li>two</li>
    </ul>
  </div>
</blockquote>
```