### PR TITLE
feat: allow the user to specify the frontmatter property names

### DIFF
--- a/docs/plugins/CreatedModifiedDate.md
+++ b/docs/plugins/CreatedModifiedDate.md
@@ -12,6 +12,7 @@ This plugin determines the created, modified, and published dates for a document
 This plugin accepts the following configuration options:
 
 - `priority`: The data sources to consult for date information. Highest priority first. Possible values are `"frontmatter"`, `"git"`, and `"filesystem"`. Defaults to `"frontmatter", "git", "filesystem"]`.
+- `properties`: An object specifying the frontmatter property names for `created`, `updated`, and `published` dates. Defaults to `{created: ["date"], updated: ["lastmod", "updated", "last-modified"], published: ["publishDate"],}`
 
 > [!warning]
 > If you rely on `git` for dates, make sure `defaultDateType` is set to `modified` in `quartz.config.ts`.

--- a/quartz/plugins/transformers/lastmod.ts
+++ b/quartz/plugins/transformers/lastmod.ts
@@ -6,11 +6,11 @@ import chalk from "chalk"
 
 export interface Options {
   priority: ("frontmatter" | "git" | "filesystem")[]
-  properties?: {
+  properties: Partial<{
     created: string[]
     modified: string[]
     published: string[]
-  }
+  }>
 }
 
 const defaultOptions: Options = {
@@ -40,7 +40,14 @@ type MaybeDate = undefined | string | number
 export const CreatedModifiedDate: QuartzTransformerPlugin<Partial<Options> | undefined> = (
   userOpts,
 ) => {
-  const opts = { ...defaultOptions, ...userOpts }
+  const opts = {
+    ...defaultOptions,
+    ...userOpts,
+    properties: {
+      ...defaultOptions.properties,
+      ...userOpts?.properties,
+    },
+  }
   return {
     name: "CreatedModifiedDate",
     markdownPlugins() {
@@ -60,14 +67,20 @@ export const CreatedModifiedDate: QuartzTransformerPlugin<Partial<Options> | und
                 created ||= st.birthtimeMs
                 modified ||= st.mtimeMs
               } else if (source === "frontmatter" && opts.properties && file.data.frontmatter) {
-                for (const createdProperty of opts.properties.created!) {
-                  created ||= file.data.frontmatter[createdProperty] as MaybeDate
+                if (opts.properties.created) {
+                  for (const createdProperty of opts.properties.created) {
+                    created ||= file.data.frontmatter[createdProperty] as MaybeDate
+                  }
                 }
-                for (const modifiedProperty of opts.properties.modified!) {
-                  modified ||= file.data.frontmatter[modifiedProperty] as MaybeDate
+                if (opts.properties.modified) {
+                  for (const modifiedProperty of opts.properties.modified) {
+                    modified ||= file.data.frontmatter[modifiedProperty] as MaybeDate
+                  }
                 }
-                for (const publishedProperty of opts.properties.published!) {
-                  published ||= file.data.frontmatter[publishedProperty] as MaybeDate
+                if (opts.properties.published) {
+                  for (const publishedProperty of opts.properties.published) {
+                    published ||= file.data.frontmatter[publishedProperty] as MaybeDate
+                  }
                 }
               } else if (source === "git") {
                 if (!repo) {


### PR DESCRIPTION
Hello, new to the project here, so please forgive if there is an existing contributing workflow I'm unaware of.

My frontmatter has different property names than `lastmod.ts` expected, so I updated the options and parsing code to allow for custom property names.

Originally, I had the three properties as `string` instead of `string[]`, however, that might have been a breaking change. Specifically, the `modified` property had three options available, which necessitated needing `string[]`, which keeps existing functionality

```typescript
Plugin.CreatedModifiedDate({
  priority: ["frontmatter"],
  properties: {
    created: ["created"],
    modified: ["updated"],
    published: ["publishDate"],
  },
}),
```

Thanks!