### PR TITLE
fix: fix explorer view gradient positioning on mobile (fixes #906)

### DIFF
--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -485,6 +485,7 @@ ul.overflow,
 ol.overflow {
   max-height: 400;
   overflow-y: auto;
+  position: relative;
 
   // clearfix
   content: "";


### PR DESCRIPTION
## This PR

Fixes #906 

## The :bug: 
- Using `position: absolute` and `bottom: 0` on an element without setting `position: relative` in its parent causes that element to be positioned at the bottom of the viewport instead of the bottom of the containing element
- The `overflow` class applied to `ul`/`ol` does not specify `position: relative`, but its `::after` child does specify `position: absolute` and `bottom: 0`
- On mobile, this causes the gradient styling from the `::after` pseudo-element to be positioned at the bottom of the screen
- This PR simply adds the `position: relative` property to the containing element

## Notes
- All other instances of children specifying `position: absolute` also have a parent that specifies `position: relative`