### PR TITLE
Check link isExternal before adding target="_blank"

### DIFF
--- a/quartz/plugins/transformers/links.ts
+++ b/quartz/plugins/transformers/links.ts
@@ -93,7 +93,7 @@ export const CrawlLinks: QuartzTransformerPlugin<Partial<Options> | undefined> =
                 }
                 node.properties.className = classes
 
-                if (opts.openLinksInNewTab) {
+                if (isExternal && opts.openLinksInNewTab) {
                   node.properties.target = "_blank"
                 }
 


### PR DESCRIPTION
Fixes #1186 openLinksInNewTab opens ALL links in new tabs. Fixed to reflect documented behavior here: https://quartz.jzhao.xyz/plugins/CrawlLinks