### PR TITLE
feat: add alias/metadata to transclude tag

### DIFF
--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -276,7 +276,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
                     return {
                       type: "html",
                       data: { hProperties: { transclude: true } },
-                      value: `<blockquote class="transclude" data-url="${url}" data-block="${block}"><a href="${
+                      value: `<blockquote class="transclude" data-url="${url}" data-block="${block}" data-embed-alias="${alias}"><a href="${
                         url + anchor
                       }" class="transclude-inner">Transclude of ${url}${block}</a></blockquote>`,
                     }


### PR DESCRIPTION
Simple feature that adds a transcluded link's alias to the html tag under `data-embed-alias`. 

This aligns with the Obsidian method of adding the link alias to transcluded notes. Obsidian renders the transclusions as a `<div>` and uses the `alt` attribute, but as I don't believe `alt` is valid for `<blockquote>` I elected to go with `data-embed-alias`.

I'm not 100% on the name it should have, maybe it should just be `data-alias` or `data-metadata`.