### PR TITLE
fix: Popover z-index issue on left sidebar

### DIFF
--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -161,6 +161,7 @@ a {
       box-sizing: border-box;
       padding: 0 4rem;
       position: fixed;
+      z-index: 1;
       @media all and (max-width: $fullPageWidth) {
         position: initial;
         flex-direction: row;


### PR DESCRIPTION
## Issue:
 Popovers in the left sidebar were displaying underneath certain elements, such as the footer and code blocks. (See #1217 point 2)

## Solution:
 Set the `z-index: 1;` for both the left and right sidebars to ensure that popovers are displayed above all other elements.
