### PR TITLE
docs: replace .gitlab-ci.yml example with more reliable and faster ci job

### DIFF
--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -182,35 +182,31 @@ Using `docs.example.com` is an example of a subdomain. They're a simple way of c
 
 ## GitLab Pages
 
-In your local Quartz, create a new file `.gitlab-ci.yaml`.
+In your local Quartz, create a new file `.gitlab-ci.yml`.
 
-```yaml title=".gitlab-ci.yaml"
+```yaml title=".gitlab-ci.yml"
 stages:
   - build
   - deploy
 
-variables:
-  NODE_VERSION: "18.14"
+image: node:18
+cache:  # Cache modules in between jobs
+  key: $CI_COMMIT_REF_SLUG
+  paths:
+    - .npm/
 
 build:
   stage: build
   rules:
     - if: '$CI_COMMIT_REF_NAME == "v4"'
   before_script:
-    - apt-get update -q && apt-get install -y nodejs npm
-    - npm install -g n
-    - n $NODE_VERSION
     - hash -r
-    - npm ci
+    - npm ci --cache .npm --prefer-offline
   script:
     - npx quartz build
   artifacts:
     paths:
       - public
-  cache:
-    paths:
-      - ~/.npm/
-    key: "${CI_COMMIT_REF_SLUG}-node-${CI_COMMIT_REF_NAME}"
   tags:
     - docker
 

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -190,7 +190,7 @@ stages:
   - deploy
 
 image: node:18
-cache:  # Cache modules in between jobs
+cache: # Cache modules in between jobs
   key: $CI_COMMIT_REF_SLUG
   paths:
     - .npm/


### PR DESCRIPTION
Rework gitlab-ci pipeline to be faster and more reliable by not relying on the default image being debian based, instead getting an image that already has node 18 installed, also fixing the `.npm` folder caching to work with modern versions on gitlab.  

ps: i hate prettier, might want to like, not have it check the docs.