### PR TITLE
Permit Manual (and Scripted) Trigger of CI Job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - v4
+  workflow_dispatch:
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Adding this stamp allows two things. 

First, it enables this button so that a user can manually trigger their build/test CI script.
![image](https://github.com/jackyzha0/quartz/assets/9065495/eb45dd0f-13ea-4201-b691-b1da5cf94d2d)

Second, more importantly, allows other CI scripts in the repo to trigger this workflow.

Use case, I want a CI job that procedurally checks the status of a google drive folder and commits any changes to my quartz /content directory. 
After that sync job runs, I want the site to rebuild and publish.

This requires the workflow_dispatch be enabled for the job that needs to be triggered.

Docs: https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_dispatch

Example use: https://github.com/smissingham/blog/blob/15537d51a389b37df1347c9fe7b473b184b388f6/.github/workflows/drive-sync.yml#L66
