### PR TITLE
Fix Non-English Anchor Popover Positioning Issue and Update Type Hint

### DIFF
--- a/quartz/components/scripts/popover.inline.ts
+++ b/quartz/components/scripts/popover.inline.ts
@@ -3,7 +3,7 @@ import { normalizeRelativeURLs } from "../../util/path"
 
 const p = new DOMParser()
 async function mouseEnterHandler(
-  this: HTMLLinkElement,
+  this: HTMLAnchorElement,
   { clientX, clientY }: { clientX: number; clientY: number },
 ) {
   const link = this
@@ -33,7 +33,7 @@ async function mouseEnterHandler(
   thisUrl.hash = ""
   thisUrl.search = ""
   const targetUrl = new URL(link.href)
-  const hash = targetUrl.hash
+  const hash = decodeURIComponent(targetUrl.hash)
   targetUrl.hash = ""
   targetUrl.search = ""
 
@@ -100,7 +100,7 @@ async function mouseEnterHandler(
 }
 
 document.addEventListener("nav", () => {
-  const links = [...document.getElementsByClassName("internal")] as HTMLLinkElement[]
+  const links = [...document.getElementsByClassName("internal")] as HTMLAnchorElement[]
   for (const link of links) {
     link.addEventListener("mouseenter", mouseEnterHandler)
     window.addCleanup(() => link.removeEventListener("mouseenter", mouseEnterHandler))


### PR DESCRIPTION
This PR addresses two issues:
1. Corrects the non-English anchor popover positioning problem by changing the `hash` passed to `querySelector` to `decodeURIComponent(hash)`. This ensures that the popover correctly scroll its content to the corresponding title for non-English anchors. (fix #409)
2. Updates the type hint of `mouseEnterHandler` from `HTMLLinkElement` to `HTMLAnchorElement` as the passed element is an `<a>` element, not a `<link>` element. Reference: [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLinkElement).