### PR TITLE
Fix: Table `overflow-wrap: anywhere` breaks words on mobile

### DIFF
--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -43,8 +43,20 @@ ul,
 .math {
   color: var(--darkgray);
   fill: var(--darkgray);
-  overflow-wrap: anywhere;
   hyphens: auto;
+}
+
+p,
+ul,
+text,
+a,
+li,
+ol,
+ul,
+.katex,
+.math {
+  overflow-wrap: anywhere;
+  /* tr and td removed from list of selectors for overflow-wrap, allowing them to use default 'normal' property value */
 }
 
 .math {


### PR DESCRIPTION
Set `tr` and `td` overflow-wrap to 'normal'
Closes #1258 