### PR TITLE
fix(translusion): block reference not being recognized.

### DIFF
--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -195,7 +195,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options> 
           const [rawFp, rawHeader, rawAlias]: (string | undefined)[] = capture
 
           const [fp, anchor] = splitAnchor(`${rawFp ?? ""}${rawHeader ?? ""}`)
-          const blockRef = Boolean(anchor?.startsWith("^")) ? "^" : ""
+          const blockRef = Boolean(rawHeader?.match(/^#?\^/)) ? "^" : ""
           const displayAnchor = anchor ? `#${blockRef}${anchor.trim().replace(/^#+/, "")}` : ""
           const displayAlias = rawAlias ?? rawHeader?.replace("#", "|") ?? ""
           const embedDisplay = value.startsWith("!") ? "!" : ""


### PR DESCRIPTION
Closes #1268

```ts
const blockRef = Boolean(anchor?.startsWith("^")) ? "^" : ""
```

Above line never matched, because `anchor` looks something like this: `#abcdef`.

It should be using `rawHeader` with a slightly different match. `rawHeader` looks something like this: `#^abcdef`.