### PR TITLE
fix: comments on spa should work (closes #1296)

### DIFF
--- a/quartz/components/Comments.tsx
+++ b/quartz/components/Comments.tsx
@@ -19,8 +19,12 @@ function boolToStringBool(b: boolean): string {
 }
 
 export default ((opts: Options) => {
-  const Comments: QuartzComponent = (_props: QuartzComponentProps) => <div class="giscus"></div>
-  Comments.afterDOMLoaded = `
+  const Comments: QuartzComponent = (props: QuartzComponentProps) => {
+    props.externalResources.js.push({
+      loadTime: "afterDOMReady",
+      spaPreserve: true,
+      contentType: "inline",
+      script: `
       const giscusScript = document.createElement("script")
       giscusScript.src = "https://giscus.app/client.js"
       giscusScript.async = true
@@ -57,10 +61,21 @@ export default ((opts: Options) => {
       }
 
       document.addEventListener("nav", () => {
+        iframe.contentWindow.postMessage({
+          giscus: {
+            setConfig: {
+              term: window.document.body.dataset.slug
+            },
+          },
+        }, 'https://giscus.app')
+
         document.addEventListener("themechange", changeTheme)
         window.addCleanup(() => document.removeEventListener("themechange", changeTheme))
-      })
-  `
+      })`,
+    })
+
+    return <div class="giscus"></div>
+  }
 
   return Comments
 }) satisfies QuartzComponentConstructor<Options>

--- a/quartz/components/Comments.tsx
+++ b/quartz/components/Comments.tsx
@@ -19,12 +19,27 @@ function boolToStringBool(b: boolean): string {
 }
 
 export default ((opts: Options) => {
-  const Comments: QuartzComponent = (props: QuartzComponentProps) => {
-    props.externalResources.js.push({
-      loadTime: "afterDOMReady",
-      spaPreserve: true,
-      contentType: "inline",
-      script: `
+  const Comments: QuartzComponent = (_props: QuartzComponentProps) => <div class="giscus"></div>
+
+  Comments.afterDOMLoaded = `
+    const changeTheme = (e) => {
+      const theme = e.detail.theme
+      const iframe = document.querySelector('iframe.giscus-frame')
+      if (!iframe) {
+        return
+      }
+
+      iframe.contentWindow.postMessage({
+        giscus: {
+          setConfig: {
+            theme: theme
+          }
+        }
+      }, 'https://giscus.app')
+    }
+
+    document.addEventListener("nav", () => {
+      const giscusContainer = document.querySelector(".giscus")
       const giscusScript = document.createElement("script")
       giscusScript.src = "https://giscus.app/client.js"
       giscusScript.async = true
@@ -42,40 +57,11 @@ export default ((opts: Options) => {
 
       const theme = document.documentElement.getAttribute("saved-theme")
       giscusScript.setAttribute("data-theme", theme)
-      document.head.appendChild(giscusScript)
+      giscusContainer.appendChild(giscusScript)
 
-      const changeTheme = (e) => {
-        const theme = e.detail.theme
-        const iframe = document.querySelector('iframe.giscus-frame')
-        if (!iframe) {
-          return
-        }
-
-        iframe.contentWindow.postMessage({
-          giscus: {
-            setConfig: {
-              theme: theme
-            }
-          }
-        }, 'https://giscus.app')
-      }
-
-      document.addEventListener("nav", () => {
-        iframe.contentWindow.postMessage({
-          giscus: {
-            setConfig: {
-              term: window.document.body.dataset.slug
-            },
-          },
-        }, 'https://giscus.app')
-
-        document.addEventListener("themechange", changeTheme)
-        window.addCleanup(() => document.removeEventListener("themechange", changeTheme))
-      })`,
-    })
-
-    return <div class="giscus"></div>
-  }
+      document.addEventListener("themechange", changeTheme)
+      window.addCleanup(() => document.removeEventListener("themechange", changeTheme))
+    })`
 
   return Comments
 }) satisfies QuartzComponentConstructor<Options>

--- a/quartz/components/scripts/graph.inline.ts
+++ b/quartz/components/scripts/graph.inline.ts
@@ -1,4 +1,4 @@
-import type { ContentDetails, ContentIndex } from "../../plugins/emitters/contentIndex"
+import type { ContentDetails } from "../../plugins/emitters/contentIndex"
 import * as d3 from "d3"
 import { registerEscapeHandler, removeAllChildren } from "./util"
 import { FullSlug, SimpleSlug, getFullSlug, resolveRelative, simplifySlug } from "../../util/path"

--- a/quartz/plugins/index.ts
+++ b/quartz/plugins/index.ts
@@ -28,10 +28,10 @@ export function getStaticResourcesFromPlugins(ctx: BuildCtx) {
       loadTime: "afterDOMReady",
       contentType: "inline",
       script: `
-            const socket = new WebSocket('${wsUrl}')
-            // reload(true) ensures resources like images and scripts are fetched again in firefox
-            socket.addEventListener('message', () => document.location.reload(true))
-          `,
+        const socket = new WebSocket('${wsUrl}')
+        // reload(true) ensures resources like images and scripts are fetched again in firefox
+        socket.addEventListener('message', () => document.location.reload(true))
+      `,
     })
   }
 


### PR DESCRIPTION
- use `externalResources` so we can add explicit `spaPreserve`
- rely on iframe postMessage to update giscus without reloading the script