### PR TITLE
feat(breadcrumb): add optional path-style

### DIFF
--- a/docs/features/breadcrumbs.md
+++ b/docs/features/breadcrumbs.md
@@ -21,6 +21,7 @@ Component.Breadcrumbs({
   resolveFrontmatterTitle: true, // whether to resolve folder names through frontmatter titles
   hideOnRoot: true, // whether to hide breadcrumbs on root `index.md` page
   showCurrentPage: true, // whether to display the current page in the breadcrumbs
+  style: "full", // determine the style of breadcrumb, currently support `full`, `letter`, `unique`.
 })
 ```
 

--- a/quartz/components/Breadcrumbs.tsx
+++ b/quartz/components/Breadcrumbs.tsx
@@ -102,6 +102,9 @@ export default ((opts?: Partial<BreadcrumbOptions>) => {
       // full path until current part
       let currentPath = ""
 
+      // Map to store the shortened names for each path segment
+      const shortenedNames: Map<string, string> = new Map()
+
       for (let i = 0; i < slugParts.length - 1; i++) {
         let curPathSegment = slugParts[i]
 
@@ -127,22 +130,17 @@ export default ((opts?: Partial<BreadcrumbOptions>) => {
             }
             break
           case "unique":
-            let uniquePart = curPathSegment.charAt(0)
-            let maxLength = Math.min(curPathSegment.length, 5)
-            let isUnique = false
-            while (!isUnique && uniquePart.length <= maxLength) {
-              isUnique = true
-              for (let j = 0; j < i; j++) {
-                if (slugParts[j].startsWith(uniquePart)) {
-                  isUnique = false
-                  break
-                }
-              }
-              if (!isUnique) {
-                uniquePart = curPathSegment.slice(0, uniquePart.length + 1)
-              }
+            let shortenedName = curPathSegment.charAt(0)
+            let uniqueName = shortenedName
+            let counter = 1
+
+            while (shortenedNames.has(uniqueName)) {
+              uniqueName = curPathSegment.slice(0, counter + 1)
+              counter++
             }
-            curPathSegment = uniquePart
+
+            shortenedNames.set(uniqueName, currentPath)
+            curPathSegment = uniqueName
             break
         }
 

--- a/quartz/components/Breadcrumbs.tsx
+++ b/quartz/components/Breadcrumbs.tsx
@@ -153,6 +153,10 @@ export default ((opts?: Partial<BreadcrumbOptions>) => {
         crumbs.push(crumb)
       }
 
+      if (isTagPath) {
+        crumbs.push({ displayName: slugParts.at(-1) ?? "", path: "" })
+      }
+
       // Add current file to crumb (can directly use frontmatter title)
       if (options.showCurrentPage && slugParts.at(-1) !== "index") {
         crumbs.push({

--- a/quartz/components/Breadcrumbs.tsx
+++ b/quartz/components/Breadcrumbs.tsx
@@ -153,7 +153,7 @@ export default ((opts?: Partial<BreadcrumbOptions>) => {
         crumbs.push(crumb)
       }
 
-      if (isTagPath) {
+      if (isTagPath && !options.showCurrentPage) {
         crumbs.push({ displayName: slugParts.at(-1) ?? "", path: "" })
       }
 


### PR DESCRIPTION
add optional breadcrumb styling for path. This somewhat follow agnoster styling.

Currently support `full`, `letter`, and `unique`. Default to `full`.

`letter` format:
<img width="828" alt="breadcrumbs-letter" src="https://github.com/user-attachments/assets/c518bc65-dcf2-463d-8b88-1bac0b9da105">

`unique` format:
<img width="827" alt="Screenshot 2024-08-03 at 04 00 19" src="https://github.com/user-attachments/assets/239ca73a-d8f2-4d8e-8541-d7c3cf1d727e">