### PR TITLE
docs: Adds back Pelayo Arbues blog to showcase

### DIFF
--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -9,6 +9,7 @@ Want to see what Quartz can do? Here are some cool community gardens:
 - [Socratica Toolbox](https://toolbox.socratica.info/)
 - [Morrowind Modding Wiki](https://morrowind-modding.github.io/)
 - [Aaron Pham's Garden](https://aarnphm.xyz/)
+- [Pelayo Arbues' Notes](https://pelayoarbues.com/)
 - [Stanford CME 302 Numerical Linear Algebra](https://ericdarve.github.io/NLA/)
 - [A Pattern Language - Christopher Alexander (Architecture)](https://patternlanguage.cc/)
 - [oldwinter の数字花园](https://garden.oldwinter.top/)


### PR DESCRIPTION
My blog (pelayoarbues.com) was deleted in the latest cleanup of the showcase.

This PR adds it back.