### PR TITLE
feat: add a config option for a pageTitleSuffix

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,7 @@ const config: QuartzConfig = {
 This part of the configuration concerns anything that can affect the whole site. The following is a list breaking down all the things you can configure:
 
 - `pageTitle`: title of the site. This is also used when generating the [[RSS Feed]] for your site.
+- `pageTitleSuffix`: a string added to the end of the page title. This only applies to the browser tab title, not the title shown at the top of the page.
 - `enableSPA`: whether to enable [[SPA Routing]] on your site.
 - `enablePopovers`: whether to enable [[popover previews]] on your site.
 - `analytics`: what to use for analytics on your site. Values can be

--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -9,6 +9,7 @@ import * as Plugin from "./quartz/plugins"
 const config: QuartzConfig = {
   configuration: {
     pageTitle: "🪴 Quartz 4.0",
+    pageTitleSuffix: "",
     enableSPA: true,
     enablePopovers: true,
     analytics: {

--- a/quartz/cfg.ts
+++ b/quartz/cfg.ts
@@ -41,6 +41,7 @@ export type Analytics =
 
 export interface GlobalConfiguration {
   pageTitle: string
+  pageTitleSuffix: string
   /** Whether to enable single-page-app style rendering. this prevents flashes of unstyled content and improves smoothness of Quartz */
   enableSPA: boolean
   /** Whether to display Wikipedia-style popovers when hovering over links */

--- a/quartz/cfg.ts
+++ b/quartz/cfg.ts
@@ -41,7 +41,7 @@ export type Analytics =
 
 export interface GlobalConfiguration {
   pageTitle: string
-  pageTitleSuffix: string
+  pageTitleSuffix?: string
   /** Whether to enable single-page-app style rendering. this prevents flashes of unstyled content and improves smoothness of Quartz */
   enableSPA: boolean
   /** Whether to display Wikipedia-style popovers when hovering over links */

--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -6,7 +6,7 @@ import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } fro
 
 export default (() => {
   const Head: QuartzComponent = ({ cfg, fileData, externalResources }: QuartzComponentProps) => {
-    const title = fileData.frontmatter?.title ?? i18n(cfg.locale).propertyDefaults.title
+    const title = (fileData.frontmatter?.title ?? i18n(cfg.locale).propertyDefaults.title) + cfg.pageTitleSuffix
     const description =
       fileData.description?.trim() ?? i18n(cfg.locale).propertyDefaults.description
     const { css, js } = externalResources

--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -6,7 +6,8 @@ import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } fro
 
 export default (() => {
   const Head: QuartzComponent = ({ cfg, fileData, externalResources }: QuartzComponentProps) => {
-    const title = (fileData.frontmatter?.title ?? i18n(cfg.locale).propertyDefaults.title) + cfg.pageTitleSuffix
+    const title =
+      (fileData.frontmatter?.title ?? i18n(cfg.locale).propertyDefaults.title) + cfg.pageTitleSuffix
     const description =
       fileData.description?.trim() ?? i18n(cfg.locale).propertyDefaults.description
     const { css, js } = externalResources


### PR DESCRIPTION
This PR adds a configuration option for `pageTitleSuffix`. This adds a string to the end of the page title. This only applies to the browser tab title, not the title shown at the top of the page.

## Real-World Examples:

![image](https://github.com/user-attachments/assets/e351f26f-164b-49b1-bc8f-048637ac9cb0)
