### PR TITLE
feat(search): keyboard-accessible search button

### DIFF
--- a/quartz/components/Search.tsx
+++ b/quartz/components/Search.tsx
@@ -18,19 +18,16 @@ export default ((userOpts?: Partial<SearchOptions>) => {
     const opts = { ...defaultOptions, ...userOpts }
     const searchPlaceholder = i18n(cfg.locale).components.search.searchBarPlaceholder
     return (
-      <div class={classNames(displayClass, "search")}>
+      <button class={classNames(displayClass, "search")}>
         <div id="search-icon">
           <p>{i18n(cfg.locale).components.search.title}</p>
           <div></div>
           <svg
-            tabIndex={0}
-            aria-labelledby="title desc"
             role="img"
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 19.9 19.7"
           >
-            <title id="title">Search</title>
-            <desc id="desc">Search</desc>
+            <title>Search</title>
             <g class="search-path" fill="none">
               <path stroke-linecap="square" d="M18.5 18.3l-5.4-5.4" />
               <circle cx="8" cy="8" r="7" />
@@ -50,7 +47,7 @@ export default ((userOpts?: Partial<SearchOptions>) => {
             <div id="search-layout" data-preview={opts.enablePreview}></div>
           </div>
         </div>
-      </div>
+      </button>
     )
   }
 

--- a/quartz/components/Search.tsx
+++ b/quartz/components/Search.tsx
@@ -18,10 +18,9 @@ export default ((userOpts?: Partial<SearchOptions>) => {
     const opts = { ...defaultOptions, ...userOpts }
     const searchPlaceholder = i18n(cfg.locale).components.search.searchBarPlaceholder
     return (
-      <button class={classNames(displayClass, "search")} id="search-button">
-        <div id="search-icon">
+      <div class={classNames(displayClass, "search")}>
+        <button class="search-button" id="search-button">
           <p>{i18n(cfg.locale).components.search.title}</p>
-          <div></div>
           <svg
             role="img"
             xmlns="http://www.w3.org/2000/svg"
@@ -33,7 +32,7 @@ export default ((userOpts?: Partial<SearchOptions>) => {
               <circle cx="8" cy="8" r="7" />
             </g>
           </svg>
-        </div>
+        </button>
         <div id="search-container">
           <div id="search-space">
             <input
@@ -47,7 +46,7 @@ export default ((userOpts?: Partial<SearchOptions>) => {
             <div id="search-layout" data-preview={opts.enablePreview}></div>
           </div>
         </div>
-      </button>
+      </div>
     )
   }
 

--- a/quartz/components/Search.tsx
+++ b/quartz/components/Search.tsx
@@ -21,11 +21,7 @@ export default ((userOpts?: Partial<SearchOptions>) => {
       <div class={classNames(displayClass, "search")}>
         <button class="search-button" id="search-button">
           <p>{i18n(cfg.locale).components.search.title}</p>
-          <svg
-            role="img"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 19.9 19.7"
-          >
+          <svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 19.9 19.7">
             <title>Search</title>
             <g class="search-path" fill="none">
               <path stroke-linecap="square" d="M18.5 18.3l-5.4-5.4" />

--- a/quartz/components/Search.tsx
+++ b/quartz/components/Search.tsx
@@ -18,7 +18,7 @@ export default ((userOpts?: Partial<SearchOptions>) => {
     const opts = { ...defaultOptions, ...userOpts }
     const searchPlaceholder = i18n(cfg.locale).components.search.searchBarPlaceholder
     return (
-      <button class={classNames(displayClass, "search")}>
+      <button class={classNames(displayClass, "search")} id="search-button">
         <div id="search-icon">
           <p>{i18n(cfg.locale).components.search.title}</p>
           <div></div>

--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -191,6 +191,8 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
     }
 
     searchType = "basic" // reset search type after closing
+
+    searchButton?.focus()
   }
 
   function showSearch(searchTypeNew: SearchType) {

--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -148,7 +148,7 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
   const data = await fetchData
   const container = document.getElementById("search-container")
   const sidebar = container?.closest(".sidebar") as HTMLElement
-  const searchIcon = document.getElementById("search-icon")
+  const searchButton = document.getElementById("search-button")
   const searchBar = document.getElementById("search-bar") as HTMLInputElement | null
   const searchLayout = document.getElementById("search-layout")
   const idDataMap = Object.keys(data) as FullSlug[]
@@ -458,8 +458,8 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
 
   document.addEventListener("keydown", shortcutHandler)
   window.addCleanup(() => document.removeEventListener("keydown", shortcutHandler))
-  searchIcon?.addEventListener("click", () => showSearch("basic"))
-  window.addCleanup(() => searchIcon?.removeEventListener("click", () => showSearch("basic")))
+  searchButton?.addEventListener("click", () => showSearch("basic"))
+  window.addCleanup(() => searchButton?.removeEventListener("click", () => showSearch("basic")))
   searchBar?.addEventListener("input", onType)
   window.addCleanup(() => searchBar?.removeEventListener("input", onType))
 

--- a/quartz/components/scripts/util.ts
+++ b/quartz/components/scripts/util.ts
@@ -3,6 +3,7 @@ export function registerEscapeHandler(outsideContainer: HTMLElement | null, cb: 
   function click(this: HTMLElement, e: HTMLElementEventMap["click"]) {
     if (e.target !== this) return
     e.preventDefault()
+    e.stopPropagation()
     cb()
   }
 

--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -3,10 +3,13 @@
 .search {
   border: none;
   background: none;
+  font-family: inherit;
+  font-size: inherit;
   min-width: fit-content;
   max-width: 14rem;
   padding: 0;
   flex-grow: 0.3;
+  text-align: inherit;
 
   & > #search-icon {
     background-color: var(--lightgray);

--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -1,28 +1,25 @@
 @use "../../styles/variables.scss" as *;
 
 .search {
-  border: none;
-  background: none;
-  font-family: inherit;
-  font-size: inherit;
   min-width: fit-content;
   max-width: 14rem;
-  padding: 0;
   flex-grow: 0.3;
-  text-align: inherit;
 
-  & > #search-icon {
+  & > .search-button {
     background-color: var(--lightgray);
+    border: none;
     border-radius: 4px;
+    font-family: inherit;
+    font-size: inherit;
     height: 2rem;
+    padding: 0;
     display: flex;
     align-items: center;
+    text-align: inherit;
     cursor: pointer;
     white-space: nowrap;
-
-    & > div {
-      flex-grow: 1;
-    }
+    width: 100%;
+    justify-content: space-between;
 
     & > p {
       display: inline;

--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -1,8 +1,11 @@
 @use "../../styles/variables.scss" as *;
 
 .search {
+  border: none;
+  background: none;
   min-width: fit-content;
   max-width: 14rem;
+  padding: 0;
   flex-grow: 0.3;
 
   & > #search-icon {


### PR DESCRIPTION
This PR reworks the search button to provide proper semantics and keyboard accessibility. It uses an HTML `<button>` element for the button that invokes the search overlay, ensures focus goes to that button element, and allows activation of that element with "space" and "enter" keys (as a natural consequence of `<button>` behavior). I've also made some minor flexbox tweaks.