### PR TITLE
Responsive Design Rework

### DIFF
--- a/docs/advanced/creating components.md
+++ b/docs/advanced/creating components.md
@@ -66,7 +66,7 @@ export type QuartzComponentProps = {
   cfg: GlobalConfiguration
   tree: Node<QuartzPluginData>
   allFiles: QuartzPluginData[]
-  displayClass?: "mobile-only" | "desktop-only"
+  displayClass?: "mobile-only" | "tablet-only" | "desktop-only"
 }
 ```
 

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -13,8 +13,8 @@ export interface FullPageLayout {
   beforeBody: QuartzComponent[] // laid out vertically
   pageBody: QuartzComponent // single component
   afterBody: QuartzComponent[] // laid out vertically
-  left: QuartzComponent[] // vertical on desktop, horizontal on mobile
-  right: QuartzComponent[] // vertical on desktop, horizontal on mobile
+  left: QuartzComponent[] // vertical on desktop and tablet, horizontal on mobile
+  right: QuartzComponent[] // vertical on desktop, horizontal on tablet and mobile
   footer: QuartzComponent // single component
 }
 ```
@@ -32,6 +32,23 @@ These correspond to following parts of the page:
 Quartz **components**, like plugins, can take in additional properties as configuration options. If you're familiar with React terminology, you can think of them as Higher-order Components.
 
 See [a list of all the components](component.md) for all available components along with their configuration options. You can also checkout the guide on [[creating components]] if you're interested in further customizing the behaviour of Quartz.
+
+### Layout breakpoints
+
+Quartz has different layouts depending on the width the screen viewing the website.
+
+The breakpoints for layouts can be configured in `variables.scss`.
+
+ - `mobile`: screen width below this size will use mobile layout.
+ - `desktop`: screen width above this size will use desktop layout.
+ - Screen width between `mobile` and `desktop` width will use the tablet layout.
+
+```scss
+$breakpoints: (
+  mobile: 750px,
+  desktop: 1500px,
+);
+```
 
 ### Style
 

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -39,9 +39,9 @@ Quartz has different layouts depending on the width the screen viewing the websi
 
 The breakpoints for layouts can be configured in `variables.scss`.
 
- - `mobile`: screen width below this size will use mobile layout.
- - `desktop`: screen width above this size will use desktop layout.
- - Screen width between `mobile` and `desktop` width will use the tablet layout.
+- `mobile`: screen width below this size will use mobile layout.
+- `desktop`: screen width above this size will use desktop layout.
+- Screen width between `mobile` and `desktop` width will use the tablet layout.
 
 ```scss
 $breakpoints: (

--- a/package-lock.json
+++ b/package-lock.json
@@ -200,6 +200,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -27,6 +27,8 @@ export const defaultContentPageLayout: PageLayout = {
     Component.MobileOnly(Component.Spacer()),
     Component.Search(),
     Component.Darkmode(),
+    Component.TabletOnly(Component.TableOfContents()),
+    Component.TabletOnly(Component.Explorer()),
     Component.DesktopOnly(Component.Explorer()),
   ],
   right: [
@@ -44,6 +46,7 @@ export const defaultListPageLayout: PageLayout = {
     Component.MobileOnly(Component.Spacer()),
     Component.Search(),
     Component.Darkmode(),
+    Component.TabletOnly(Component.Explorer()),
     Component.DesktopOnly(Component.Explorer()),
   ],
   right: [],

--- a/quartz/components/Backlinks.tsx
+++ b/quartz/components/Backlinks.tsx
@@ -14,20 +14,22 @@ const Backlinks: QuartzComponent = ({
   const backlinkFiles = allFiles.filter((file) => file.links?.includes(slug))
   return (
     <div class={classNames(displayClass, "backlinks")}>
-      <h3>{i18n(cfg.locale).components.backlinks.title}</h3>
-      <ul class="overflow">
-        {backlinkFiles.length > 0 ? (
-          backlinkFiles.map((f) => (
-            <li>
-              <a href={resolveRelative(fileData.slug!, f.slug!)} class="internal">
-                {f.frontmatter?.title}
-              </a>
-            </li>
-          ))
-        ) : (
-          <li>{i18n(cfg.locale).components.backlinks.noBacklinksFound}</li>
-        )}
-      </ul>
+      <div class="backlinks-container">
+        <h3>{i18n(cfg.locale).components.backlinks.title}</h3>
+        <ul class="overflow">
+          {backlinkFiles.length > 0 ? (
+            backlinkFiles.map((f) => (
+              <li>
+                <a href={resolveRelative(fileData.slug!, f.slug!)} class="internal">
+                  {f.frontmatter?.title}
+                </a>
+              </li>
+            ))
+          ) : (
+            <li>{i18n(cfg.locale).components.backlinks.noBacklinksFound}</li>
+          )}
+        </ul>
+      </div>
     </div>
   )
 }

--- a/quartz/components/TabletOnly.tsx
+++ b/quartz/components/TabletOnly.tsx
@@ -1,0 +1,18 @@
+import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
+
+export default ((component?: QuartzComponent) => {
+  if (component) {
+    const Component = component
+    const TabletOnly: QuartzComponent = (props: QuartzComponentProps) => {
+      return <Component displayClass="tablet-only" {...props} />
+    }
+
+    TabletOnly.displayName = component.displayName
+    TabletOnly.afterDOMLoaded = component?.afterDOMLoaded
+    TabletOnly.beforeDOMLoaded = component?.beforeDOMLoaded
+    TabletOnly.css = component?.css
+    return TabletOnly
+  } else {
+    return () => <></>
+  }
+}) satisfies QuartzComponentConstructor

--- a/quartz/components/index.ts
+++ b/quartz/components/index.ts
@@ -16,6 +16,7 @@ import Backlinks from "./Backlinks"
 import Search from "./Search"
 import Footer from "./Footer"
 import DesktopOnly from "./DesktopOnly"
+import TabletOnly from "./TabletOnly"
 import MobileOnly from "./MobileOnly"
 import RecentNotes from "./RecentNotes"
 import Breadcrumbs from "./Breadcrumbs"
@@ -39,6 +40,7 @@ export {
   Search,
   Footer,
   DesktopOnly,
+  TabletOnly,
   MobileOnly,
   RecentNotes,
   NotFound,

--- a/quartz/components/styles/backlinks.scss
+++ b/quartz/components/styles/backlinks.scss
@@ -1,19 +1,48 @@
-.backlinks {
-  position: relative;
+@use "../../styles/variables.scss" as *;
 
-  & > h3 {
-    font-size: 1rem;
-    margin: 0;
+.backlinks {
+  @media all and not ($desktop) {
+    overflow-y: auto;
+    display: initial;
+    &:after {
+      pointer-events: none;
+      content: "";
+      width: 100%;
+      height: 50px;
+      position: absolute;
+      left: 0;
+      bottom: 0;
+      opacity: 1;
+      transition: opacity 0.3s ease;
+      background: linear-gradient(transparent 0px, var(--light));
+    }
   }
 
-  & > ul {
-    list-style: none;
-    padding: 0;
-    margin: 0.5rem 0;
+  & > .backlinks-container {
+    & > h3 {
+      font-size: 1rem;
+      margin: 0;
+    }
 
-    & > li {
-      & > a {
-        background-color: transparent;
+    & > ul {
+      list-style: none;
+      padding: 0;
+      margin: 0.5rem 0;
+
+      & > li {
+        & > a {
+          background-color: transparent;
+        }
+      }
+    }
+
+    & > .overflow {
+      max-height: unset;
+      & > li:last-of-type {
+        margin-bottom: 0;
+      }
+      &:after {
+        display: none;
       }
     }
   }

--- a/quartz/components/styles/explorer.scss
+++ b/quartz/components/styles/explorer.scss
@@ -5,6 +5,18 @@
   &.tablet-only {
     overflow-y: auto;
   }
+  &:after {
+    pointer-events: none;
+    content: "";
+    width: 100%;
+    height: 50px;
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    opacity: 1;
+    transition: opacity 0.3s ease;
+    background: linear-gradient(transparent 0px, var(--light));
+  }
 }
 
 button#explorer {
@@ -66,7 +78,7 @@ button#explorer {
   }
 
   &.collapsed > .overflow::after {
-    opacity: 0;
+    display: none;
   }
 
   & ul {

--- a/quartz/components/styles/explorer.scss
+++ b/quartz/components/styles/explorer.scss
@@ -1,5 +1,12 @@
 @use "../../styles/variables.scss" as *;
 
+.explorer {
+  &.desktop-only,
+  &.tablet-only {
+    overflow-y: auto;
+  }
+}
+
 button#explorer {
   background-color: transparent;
   border: none;
@@ -75,6 +82,9 @@ button#explorer {
       opacity: 0.75;
       pointer-events: all;
     }
+  }
+  > #explorer-ul {
+    max-height: none;
   }
 }
 

--- a/quartz/components/styles/graph.scss
+++ b/quartz/components/styles/graph.scss
@@ -62,7 +62,7 @@
       height: 60vh;
       width: 50vw;
 
-      @media all and (max-width: $fullPageWidth) {
+      @media all and (max-width: $desktopBreakpoint) {
         width: 90%;
       }
     }

--- a/quartz/components/styles/graph.scss
+++ b/quartz/components/styles/graph.scss
@@ -62,7 +62,7 @@
       height: 60vh;
       width: 50vw;
 
-      @media all and (max-width: $desktopBreakpoint) {
+      @media all and ($desktop) {
         width: 90%;
       }
     }

--- a/quartz/components/styles/listPage.scss
+++ b/quartz/components/styles/listPage.scss
@@ -13,7 +13,7 @@ li.section-li {
     display: grid;
     grid-template-columns: fit-content(8em) 3fr 1fr;
 
-    @media all and (max-width: $mobileBreakpoint) {
+    @media all and ($mobile) {
       & > .tags {
         display: none;
       }

--- a/quartz/components/styles/popover.scss
+++ b/quartz/components/styles/popover.scss
@@ -70,7 +70,7 @@
     opacity 0.3s ease,
     visibility 0.3s ease;
 
-  @media all and (max-width: $mobileBreakpoint) {
+  @media all and ($mobile) {
     display: none !important;
   }
 }

--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -62,7 +62,7 @@
       margin-left: auto;
       margin-right: auto;
 
-      @media all and (max-width: $fullPageWidth) {
+      @media all and (max-width: $desktopBreakpoint) {
         width: 90%;
       }
 

--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -62,7 +62,7 @@
       margin-left: auto;
       margin-right: auto;
 
-      @media all and (max-width: $desktopBreakpoint) {
+      @media all and ($desktop) {
         width: 90%;
       }
 
@@ -104,7 +104,7 @@
           flex: 0 0 min(30%, 450px);
         }
 
-        @media all and (min-width: $tabletBreakpoint) {
+        @media all and not ($tablet) {
           &[data-preview] {
             & .result-card > p.preview {
               display: none;
@@ -130,7 +130,7 @@
           border-radius: 5px;
         }
 
-        @media all and (max-width: $tabletBreakpoint) {
+        @media all and ($tablet) {
           & > #preview-container {
             display: none !important;
           }

--- a/quartz/components/types.ts
+++ b/quartz/components/types.ts
@@ -13,7 +13,7 @@ export type QuartzComponentProps = {
   children: (QuartzComponent | JSX.Element)[]
   tree: Node
   allFiles: QuartzPluginData[]
-  displayClass?: "mobile-only" | "desktop-only"
+  displayClass?: "mobile-only" | "tablet-only" | "desktop-only"
 } & JSX.IntrinsicAttributes & {
     [key: string]: any
   }

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -188,10 +188,12 @@ a {
 
     & .sidebar.left {
       left: calc(calc(100vw - $pageWidth) / 2 - $sidePanelWidth);
+      max-height: calc(100vh - $topSpacing);
       @media all and ($desktop) {
         left: 0;
       }
       @media all and ($mobile) {
+        max-height: unset;
         gap: 0;
         align-items: center;
         position: initial;

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -109,11 +109,11 @@ a {
 
 .desktop-only {
   display: initial;
-  @media all and (max-width: $mobileBreakpoint) {
+  @media all and ($mobile) {
     display: none;
   }
   &.toc {
-    @media all and (max-width: $tabletBreakpoint) {
+    @media all and ($tablet) {
       display: none;
     }
   }
@@ -121,21 +121,21 @@ a {
 
 .mobile-only {
   display: none;
-  @media all and (max-width: $mobileBreakpoint) {
+  @media all and ($mobile) {
     display: initial;
   }
   &.toc {
-    @media all and (max-width: $tabletBreakpoint) {
+    @media all and ($tablet) {
       display: initial;
     }
   }
 }
 
 .page {
-  @media all and (max-width: $desktopBreakpoint) {
+  @media all and ($desktop) {
     padding: 0 1rem;
   }
-  @media all and (max-width: $mobileBreakpoint) {
+  @media all and ($mobile) {
     margin: 0 auto;
     max-width: 100%;
   }
@@ -169,10 +169,10 @@ a {
   & > #quartz-body {
     width: 100%;
     display: flex;
-    @media all and (max-width: $desktopBreakpoint) {
+    @media all and ($desktop) {
       flex-direction: column;
     }
-    @media all and (max-width: $mobileBreakpoint) {
+    @media all and ($mobile) {
       padding: 0 1rem;
     }
 
@@ -190,11 +190,11 @@ a {
     }
 
     & .sidebar.left {
-      left: 0;
-      @media all and (min-width: $desktopBreakpoint) {
-        left: calc(calc(100vw - $pageWidth) / 2 - $sidePanelWidth);
+      left: calc(calc(100vw - $pageWidth) / 2 - $sidePanelWidth);
+      @media all and ($desktop) {
+        left: 0;
       }
-      @media all and (max-width: $mobileBreakpoint) {
+      @media all and ($mobile) {
         gap: 0;
         align-items: center;
         position: initial;
@@ -208,11 +208,13 @@ a {
     & .sidebar.right {
       right: calc(calc(100vw - $pageWidth) / 2 - $sidePanelWidth);
       flex-wrap: wrap;
-      @media all and (min-width: $mobileBreakpoint) {
-        margin-left: $sidePanelWidth;
-        margin-right: 0;
+      margin-left: $sidePanelWidth;
+      margin-right: 0;
+      @media all and ($mobile) {
+        margin-left: inherit;
+        margin-right: inherit;
       }
-      @media all and (max-width: $desktopBreakpoint) {
+      @media all and ($desktop) {
         position: initial;
         flex-direction: row;
         padding: 0;
@@ -232,17 +234,17 @@ a {
     width: $pageWidth;
     margin-top: 1rem;
 
-    @media all and (max-width: $tabletBreakpoint) {
+    @media all and ($tablet) {
       width: initial;
     }
   }
 
   & .page-header {
     margin: $topSpacing auto 0 auto;
-    @media all and (max-width: $desktopBreakpoint) {
+    @media all and ($desktop) {
       margin: $topSpacing 0 0 0;
     }
-    @media all and (max-width: $mobileBreakpoint) {
+    @media all and ($mobile) {
       margin-top: 2rem;
     }
   }
@@ -252,13 +254,13 @@ a {
     margin-left: auto;
     margin-right: auto;
     width: $pageWidth;
-    @media all and (max-width: $desktopBreakpoint) {
+    @media all and ($desktop) {
       width: calc(100% - $sidePanelWidth);
       right: 0;
       margin-left: $sidePanelWidth;
       margin-right: 0;
     }
-    @media all and (max-width: $mobileBreakpoint) {
+    @media all and ($mobile) {
       width: initial;
       margin-left: 0;
     }

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -137,7 +137,7 @@ a {
   }
   @media all and (max-width: $mobileBreakpoint) {
     margin: 0 auto;
-    max-width: $pageWidth;
+    max-width: 100%;
   }
 
   & article {
@@ -171,6 +171,9 @@ a {
     display: flex;
     @media all and (max-width: $desktopBreakpoint) {
       flex-direction: column;
+    }
+    @media all and (max-width: $mobileBreakpoint) {
+      padding: 0 1rem;
     }
 
     & .sidebar {
@@ -239,7 +242,7 @@ a {
     @media all and (max-width: $desktopBreakpoint) {
       margin: $topSpacing 0 0 0;
     }
-    @media all and (max-width: $tabletBreakpoint) {
+    @media all and (max-width: $mobileBreakpoint) {
       margin-top: 2rem;
     }
   }

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -109,22 +109,34 @@ a {
 
 .desktop-only {
   display: initial;
-  @media all and (max-width: $fullPageWidth) {
+  @media all and (max-width: $mobileBreakpoint) {
     display: none;
+  }
+  &.toc {
+    @media all and (max-width: $tabletBreakpoint) {
+      display: none;
+    }
   }
 }
 
 .mobile-only {
   display: none;
-  @media all and (max-width: $fullPageWidth) {
+  @media all and (max-width: $mobileBreakpoint) {
     display: initial;
+  }
+  &.toc {
+    @media all and (max-width: $tabletBreakpoint) {
+      display: initial;
+    }
   }
 }
 
 .page {
-  @media all and (max-width: $fullPageWidth) {
-    margin: 0 auto;
+  @media all and (max-width: $desktopBreakpoint) {
     padding: 0 1rem;
+  }
+  @media all and (max-width: $mobileBreakpoint) {
+    margin: 0 auto;
     max-width: $pageWidth;
   }
 
@@ -157,7 +169,7 @@ a {
   & > #quartz-body {
     width: 100%;
     display: flex;
-    @media all and (max-width: $fullPageWidth) {
+    @media all and (max-width: $desktopBreakpoint) {
       flex-direction: column;
     }
 
@@ -172,7 +184,16 @@ a {
       box-sizing: border-box;
       padding: 0 4rem;
       position: fixed;
-      @media all and (max-width: $fullPageWidth) {
+    }
+
+    & .sidebar.left {
+      left: 0;
+      @media all and (min-width: $desktopBreakpoint) {
+        left: calc(calc(100vw - $pageWidth) / 2 - $sidePanelWidth);
+      }
+      @media all and (max-width: $mobileBreakpoint) {
+        gap: 0;
+        align-items: center;
         position: initial;
         flex-direction: row;
         padding: 0;
@@ -181,19 +202,21 @@ a {
       }
     }
 
-    & .sidebar.left {
-      left: calc(calc(100vw - $pageWidth) / 2 - $sidePanelWidth);
-      @media all and (max-width: $fullPageWidth) {
-        gap: 0;
-        align-items: center;
-      }
-    }
-
     & .sidebar.right {
       right: calc(calc(100vw - $pageWidth) / 2 - $sidePanelWidth);
       flex-wrap: wrap;
-      & > * {
-        @media all and (max-width: $fullPageWidth) {
+      @media all and (min-width: $mobileBreakpoint) {
+        margin-left: $sidePanelWidth;
+        margin-right: 0;
+      }
+      @media all and (max-width: $desktopBreakpoint) {
+        position: initial;
+        flex-direction: row;
+        padding: 0;
+        width: initial;
+        margin-top: 2rem;
+        display: flex;
+        & > * {
           flex: 1;
           min-width: 140px;
         }
@@ -206,14 +229,17 @@ a {
     width: $pageWidth;
     margin-top: 1rem;
 
-    @media all and (max-width: $fullPageWidth) {
+    @media all and (max-width: $tabletBreakpoint) {
       width: initial;
     }
   }
 
   & .page-header {
     margin: $topSpacing auto 0 auto;
-    @media all and (max-width: $fullPageWidth) {
+    @media all and (max-width: $desktopBreakpoint) {
+      margin: $topSpacing 0 0 0;
+    }
+    @media all and (max-width: $tabletBreakpoint) {
       margin-top: 2rem;
     }
   }
@@ -223,10 +249,15 @@ a {
     margin-left: auto;
     margin-right: auto;
     width: $pageWidth;
-    @media all and (max-width: $fullPageWidth) {
+    @media all and (max-width: $desktopBreakpoint) {
+      width: calc(100% - $sidePanelWidth);
+      right: 0;
+      margin-left: $sidePanelWidth;
+      margin-right: 0;
+    }
+    @media all and (max-width: $mobileBreakpoint) {
       width: initial;
       margin-left: 0;
-      margin-right: 0;
     }
   }
 }

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -109,13 +109,15 @@ a {
 
 .desktop-only {
   display: initial;
-  @media all and ($mobile) {
+  @media all and ($desktop) {
     display: none;
   }
-  &.toc {
-    @media all and ($tablet) {
-      display: none;
-    }
+}
+
+.tablet-only {
+  display: none;
+  @media all and ($desktop) and (not ($mobile)) {
+    display: initial;
   }
 }
 
@@ -123,11 +125,6 @@ a {
   display: none;
   @media all and ($mobile) {
     display: initial;
-  }
-  &.toc {
-    @media all and ($tablet) {
-      display: initial;
-    }
   }
 }
 

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -130,7 +130,7 @@ a {
 
 .page {
   @media all and ($desktop) {
-    padding: 0 1rem;
+    padding: 0 2rem;
   }
   @media all and ($mobile) {
     margin: 0 auto;
@@ -168,9 +168,6 @@ a {
     display: flex;
     @media all and ($desktop) {
       flex-direction: column;
-    }
-    @media all and ($mobile) {
-      padding: 0 1rem;
     }
 
     & .sidebar {

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -181,11 +181,11 @@ a {
       box-sizing: border-box;
       padding: 0 4rem;
       position: fixed;
+      max-height: calc(100vh - $topSpacing - 4rem);
     }
 
     & .sidebar.left {
       left: calc(calc(100vw - $pageWidth) / 2 - $sidePanelWidth);
-      max-height: calc(100vh - $topSpacing);
       @media all and ($desktop) {
         left: 0;
       }
@@ -203,7 +203,6 @@ a {
 
     & .sidebar.right {
       right: calc(calc(100vw - $pageWidth) / 2 - $sidePanelWidth);
-      flex-wrap: wrap;
       margin-left: $sidePanelWidth;
       margin-right: 0;
       @media all and ($mobile) {
@@ -211,6 +210,7 @@ a {
         margin-right: inherit;
       }
       @media all and ($desktop) {
+        max-height: unset;
         position: initial;
         flex-direction: row;
         padding: 0;

--- a/quartz/styles/variables.scss
+++ b/quartz/styles/variables.scss
@@ -1,7 +1,21 @@
+/**
+ * Layout breakpoints
+ * $mobile: screen width below this value will use mobile styles
+ * $tablet: screen width below this value will use tablet styles
+ * $desktop: screen width below this value will use desktop styles
+ * assuming mobile < tablet < desktop
+ */
+$breakpoints: (
+  mobile: 750px,
+  tablet: 1000px,
+  desktop: 1500px,
+);
+
+$mobile: "(max-width: #{map-get($breakpoints, mobile)})";
+$tablet: "(max-width: #{map-get($breakpoints, tablet)})";
+$desktop: "(max-width: #{map-get($breakpoints, desktop)})";
+
 $pageWidth: 750px;
-$mobileBreakpoint: 750px;
-$tabletBreakpoint: 1000px;
-$desktopBreakpoint: 1500px;
 $sidePanelWidth: 380px;
 $topSpacing: 6rem;
 $boldWeight: 700;

--- a/quartz/styles/variables.scss
+++ b/quartz/styles/variables.scss
@@ -1,21 +1,20 @@
 /**
  * Layout breakpoints
  * $mobile: screen width below this value will use mobile styles
- * $tablet: screen width below this value will use tablet styles
- * $desktop: screen width below this value will use desktop styles
- * assuming mobile < tablet < desktop
+ * $desktop: screen width above this value will use desktop styles
+ * Screen width between $mobile and $desktop width will use the tablet layout.
+ * assuming mobile < desktop
  */
 $breakpoints: (
   mobile: 750px,
-  tablet: 1000px,
   desktop: 1500px,
 );
 
 $mobile: "(max-width: #{map-get($breakpoints, mobile)})";
-$tablet: "(max-width: #{map-get($breakpoints, tablet)})";
+$tablet: "(min-width: #{map-get($breakpoints, mobile)}) and (max-width: #{map-get($breakpoints, desktop)})";
 $desktop: "(max-width: #{map-get($breakpoints, desktop)})";
 
-$pageWidth: 750px;
+$pageWidth: #{map-get($breakpoints, mobile)};
 $sidePanelWidth: 380px;
 $topSpacing: 6rem;
 $boldWeight: 700;

--- a/quartz/styles/variables.scss
+++ b/quartz/styles/variables.scss
@@ -1,9 +1,9 @@
 $pageWidth: 750px;
-$mobileBreakpoint: 600px;
+$mobileBreakpoint: 750px;
 $tabletBreakpoint: 1000px;
+$desktopBreakpoint: 1500px;
 $sidePanelWidth: 380px;
 $topSpacing: 6rem;
-$fullPageWidth: $pageWidth + 2 * $sidePanelWidth;
 $boldWeight: 700;
 $semiBoldWeight: 600;
 $normalWeight: 400;

--- a/quartz/util/lang.ts
+++ b/quartz/util/lang.ts
@@ -3,7 +3,7 @@ export function capitalize(s: string): string {
 }
 
 export function classNames(
-  displayClass?: "mobile-only" | "desktop-only",
+  displayClass?: "mobile-only" | "tablet-only" | "desktop-only",
   ...classes: string[]
 ): string {
   if (displayClass) {


### PR DESCRIPTION
closes https://github.com/jackyzha0/quartz/issues/455

<details>
  <summary>Old preview</summary>
  https://github.com/user-attachments/assets/4c88b377-8c42-46a0-8465-e5556a8c64a6
</details>

https://github.com/user-attachments/assets/379eb329-4ed8-4b80-88ab-97c3e23057c9

## Description

This PR introduces different layouts depending on the width of the viewport visiting the website. The specific width breakpoints can be configured.

The breakpoints for layouts can be configured in `variables.scss`.

- `mobile`: screen width below this size will use mobile layout.
- `desktop`: screen width above this size will use desktop layout.
- Screen width between `mobile` and `desktop` width will use the `tablet` layout.

```scss
// variables.scss
$breakpoints: (
  mobile: 750px,
  desktop: 1500px,
);
```

## TODO

 - [x] Working proof of concept
 - [x] Configurable layout shift breakpoints (via `quartz.config.ts`(?))
 - [x] Mobile view
 - [x] Tablet view
   - [x] Table of Content position
   - [x] Determine preferred component view (mobile or desktop version)
     - [x] Graph overlay
     - [x] Search overlay
 - [x] Desktop view
 - [x] Refactor
 - [x] Update documentation