### PR TITLE
feat: Mark the external link icon as aria-hidden

### DIFF
--- a/quartz/plugins/transformers/links.ts
+++ b/quartz/plugins/transformers/links.ts
@@ -65,6 +65,7 @@ export const CrawlLinks: QuartzTransformerPlugin<Partial<Options>> = (userOpts) 
                     type: "element",
                     tagName: "svg",
                     properties: {
+                      "aria-hidden": "true",
                       class: "external-icon",
                       viewBox: "0 0 512 512",
                     },


### PR DESCRIPTION
Unmarked icons/images can cause confusion for screenreader users, and this icon is purely decorative. This [CSS-Tricks example](https://css-tricks.com/accessible-svgs/#aa-example-2-standalone-icon-decorative) is pretty close. This [W3C example](https://www.w3.org/WAI/tutorials/images/decorative/#example-2-decorative-image-as-part-of-a-text-link) is also similar but concerns <img> elements (<svg>s have no alt attribute). Also compare to Wikipedia implementation, which is done in CSS but yields the same result, namely that the icon is completely hidden from assistive technology.