### PR TITLE
docs: Update Gitlab CI runner tag to use Gitlab runner

### DIFF
--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -208,7 +208,7 @@ build:
     paths:
       - public
   tags:
-    - docker
+    - gitlab-org-docker
 
 pages:
   stage: deploy


### PR DESCRIPTION
I was having issues with getting Quartz to build on Gitlab as it couldn't find a runner with the `docker` tag. Looks like GitLab has updated their instance runners to use the `gitlab-org-docker` tag. Updating the `.gitlab-ci.yml` file results in a successful build.