### PR TITLE
docs: added permalink description to supported frontmatter doc

### DIFF
--- a/docs/authoring content.md
+++ b/docs/authoring content.md
@@ -29,6 +29,7 @@ Some common frontmatter fields that are natively supported by Quartz:
 
 - `title`: Title of the page. If it isn't provided, Quartz will use the name of the file as the title.
 - `description`: Description of the page used for link previews.
+- `permalink`: A custom URL for the page that will remain constant even if the path to the file changes.
 - `aliases`: Other names for this note. This is a list of strings.
 - `tags`: Tags for this note.
 - `draft`: Whether to publish the page or not. This is one way to make [[private pages|pages private]] in Quartz.


### PR DESCRIPTION
I was trying to figure out how to use the "aliases" behavior for markdown files in my vault that I had moved to new directories, or for which I had changed the names of without breaking the links I had already posted online. I was really struggling to do this for a while and had the following issues:

1. I didn't immediately realize that the directory names produced the path elements, nor that I could change the way they were displayed in the `explorer` and on the page by changing those names with the `title` frontmatter.
2. I didn't realize that Aliases allowed for either the last item in path to be different, OR for a new absolute path to be listed.
3. My aliases were breaking because, in my directory folder names, I included space, which after a lot of observation seems to prevent aliases from working - I haven't determined why in the code yet.
4. I didn't realize the `permalink` frontmatter existed!

The differences I can observe between the `permalink` and the `aliases` frontmatter are:
- permalinks are redirects from the root of the site (`/`)
- And aliases are redirects to a different final element in the `path`

In light of all of this information, I'm thrilled by how flexible the routing is in Quartz out of the box. Unfortunately, to have made full use of it, I probably should have defined permalinks for some of my pages  a bit sooner. I've added the small bit of information including the permalinks as recommended frontmatter for authoring content, but I'd be happy to find a home for the rest of the information I've discovered in the hopes that I could help a newcomer to Quartz route their site correctly or at least know their options for doing so right off the bat. I just wanted to post these observations before making sprawling commit to the docs since this is my first contribution!