### PR TITLE
fix: Link visibility in exampanded TOC while collapseByDefault is true

### DIFF
--- a/quartz/components/TableOfContents.tsx
+++ b/quartz/components/TableOfContents.tsx
@@ -49,7 +49,7 @@ const TableOfContents: QuartzComponent = ({
           <polyline points="6 9 12 15 18 9"></polyline>
         </svg>
       </button>
-      <div id="toc-content">
+      <div id="toc-content" class={fileData.collapseToc ? "collapsed" : ""}>
         <ul class="overflow">
           {fileData.toc.map((tocEntry) => (
             <li key={tocEntry.slug} class={`depth-${tocEntry.depth}`}>


### PR DESCRIPTION
closes #1366

## Issue
Link in TOC are hidden when TOC is expanded with option `collapseByDefault: true`

## Solution
Add `.collapsed` class to the div with id `#toc-content`