### PR TITLE
fix: constrain link icon size

### DIFF
--- a/quartz/plugins/transformers/links.ts
+++ b/quartz/plugins/transformers/links.ts
@@ -67,6 +67,7 @@ export const CrawlLinks: QuartzTransformerPlugin<Partial<Options>> = (userOpts) 
                     properties: {
                       "aria-hidden": "true",
                       class: "external-icon",
+                      style: "max-width:0.8em;max-height:0.8em",
                       viewBox: "0 0 512 512",
                     },
                     children: [


### PR DESCRIPTION
Because of the 512x512 viewport, viewing the page without CSS will render the external-icon as 512x512, which is massive. This line constrains the size of the icon to the size of the text for better readability of RSS content. It doesn't change the look of the site in browser.

Before:
![image](https://github.com/user-attachments/assets/f55d009b-c1d2-444b-9697-7432e66781ae)

After:
![image](https://github.com/user-attachments/assets/5e1a921a-a65d-4e3d-9684-d40b0c87e473)
