### PR TITLE
fix(popover): callouts

### DIFF
--- a/quartz/styles/callouts.scss
+++ b/quartz/styles/callouts.scss
@@ -6,7 +6,6 @@
   background-color: var(--bg);
   border-radius: 5px;
   padding: 0 1rem;
-  overflow-y: hidden;
   transition: max-height 0.3s ease;
   box-sizing: border-box;
 


### PR DESCRIPTION
If within callout we have a links/footnotes, the popover content will be hidden

cc @saberzero1 