### PR TITLE
fix(layout): restore footer to the proper position

### DIFF
--- a/quartz/components/styles/toc.scss
+++ b/quartz/components/styles/toc.scss
@@ -74,6 +74,7 @@ button#toc {
   }
   > ul.overflow {
     max-height: none;
+    width: 100%;
   }
 
   @for $i from 0 through 6 {

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -190,7 +190,7 @@ a {
 
     & .sidebar.left {
       z-index: 1;
-      grid-area: sidebar-left;
+      grid-area: grid-sidebar-left;
       flex-direction: column;
       @media all and ($mobile) {
         gap: 0;
@@ -205,7 +205,7 @@ a {
     }
 
     & .sidebar.right {
-      grid-area: sidebar-right;
+      grid-area: grid-sidebar-right;
       margin-right: 0;
       flex-direction: column;
       @media all and ($mobile) {
@@ -232,7 +232,7 @@ a {
     }
 
     & .page-header {
-      grid-area: page-header;
+      grid-area: grid-header;
       margin: $topSpacing 0 0 0;
       @media all and ($mobile) {
         margin-top: 0;
@@ -241,11 +241,11 @@ a {
     }
 
     & .center > article {
-      grid-area: page-center;
+      grid-area: grid-center;
     }
 
-    & .page-footer {
-      grid-area: page-footer;
+    & footer {
+      grid-area: grid-footer;
     }
 
     & .center,

--- a/quartz/styles/variables.scss
+++ b/quartz/styles/variables.scss
@@ -27,11 +27,11 @@ $mobileGrid: (
   rowGap: "5px",
   columnGap: "5px",
   templateAreas:
-    '"sidebar-left"\
-      "page-header"\
-      "page-center"\
-      "sidebar-right"\
-      "page-footer"',
+    '"grid-sidebar-left"\
+      "grid-header"\
+      "grid-center"\
+      "grid-sidebar-right"\
+      "grid-footer"',
 );
 $tabletGrid: (
   templateRows: "auto auto auto auto",
@@ -39,10 +39,10 @@ $tabletGrid: (
   rowGap: "5px",
   columnGap: "5px",
   templateAreas:
-    '"sidebar-left page-header"\
-      "sidebar-left page-center"\
-      "sidebar-left sidebar-right"\
-      "sidebar-left page-footer"',
+    '"grid-sidebar-left grid-header"\
+      "grid-sidebar-left grid-center"\
+      "grid-sidebar-left grid-sidebar-right"\
+      "grid-sidebar-left grid-footer"',
 );
 $desktopGrid: (
   templateRows: "auto auto auto",
@@ -50,7 +50,7 @@ $desktopGrid: (
   rowGap: "5px",
   columnGap: "5px",
   templateAreas:
-    '"sidebar-left page-header sidebar-right"\
-      "sidebar-left page-center sidebar-right"\
-      "sidebar-left page-footer sidebar-right"',
+    '"grid-sidebar-left grid-header grid-sidebar-right"\
+      "grid-sidebar-left grid-center grid-sidebar-right"\
+      "grid-sidebar-left grid-footer grid-sidebar-right"',
 );


### PR DESCRIPTION
- [x] Restores the footer position to the bottom, putting the right sidebar between the center and footer on mobile and tablet layouts.
- [x] Renamed the grid-areas to more accurately reflect their usage and reduce confusion with similar CSS classes.
- [x] Table of Content scrollbar alignment.

## Before:

### Mobile
![Screenshot from 2024-10-01 14-56-16](https://github.com/user-attachments/assets/a12416b5-8132-422c-8e25-d2d4947d4963)


### Tablet
![Screenshot from 2024-10-01 14-56-29](https://github.com/user-attachments/assets/14c0e88d-9154-470e-837c-2fb30df02de6)


## After:

### Mobile
![Screenshot from 2024-10-01 14-57-07](https://github.com/user-attachments/assets/2963d331-a396-48de-8841-573b3194bcd0)


### Tablet
![Screenshot from 2024-10-01 14-57-21](https://github.com/user-attachments/assets/8c11204c-8bfe-4661-beb5-978d435fc78a)
