### PR TITLE
chore(ci): group dependabot upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      production-dependencies:
+        applies-to: "version-updates"
+        patterns:
+          - "*"


### PR DESCRIPTION
probably one of the nicer features from dependabot: ability to group deps update altogether.

for esbuild and all plugins it should be possible to upgrade everything now :)

Signed-off-by: Aaron Pham <contact@aarnphm.xyz>
