### PR TITLE
fix(layout): properly apply desktop-only to toc component

### DIFF
--- a/quartz/components/styles/toc.scss
+++ b/quartz/components/styles/toc.scss
@@ -1,9 +1,13 @@
+@use "../../styles/variables.scss" as *;
+
 .toc {
   display: flex;
   flex-direction: column;
   &.desktop-only {
-    display: flex;
-    max-height: 40%;
+    @media all and not ($mobile) {
+      display: flex;
+      max-height: 40%;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Fix a bug where `DesktopOnly` isn't properly applied to the `TableOfContents` component.

## Preview

- **Before**
  - Mobile
    <img width="440" alt="Screenshot 2024-10-10 at 21 14 32" src="https://github.com/user-attachments/assets/4f66fa10-8d0b-4072-b234-0f83185b3f4a">
  - Desktop
    <img width="1393" alt="Screenshot 2024-10-10 at 21 32 07" src="https://github.com/user-attachments/assets/c48c2054-af63-47c5-9ff7-f5768c3ed3df">

- **After**
  - Mobile
    <img width="439" alt="Screenshot 2024-10-10 at 21 15 08" src="https://github.com/user-attachments/assets/b4b847fa-697e-4811-9574-24a5bc9be61d">
   - Desktop
    <img width="1382" alt="Screenshot 2024-10-10 at 21 25 02" src="https://github.com/user-attachments/assets/3fce4206-fae0-4c19-bf89-ac25ad7aaf77">