### PR TITLE
feat: more advanced font specification

### DIFF
--- a/quartz/util/theme.ts
+++ b/quartz/util/theme.ts
@@ -19,11 +19,11 @@ interface FontInfo {
   /**
    * e.g. "ital,wght@0,400;1,200"
    */
-  features: string,
+  features: string
 }
 
 export interface Theme {
-  fonts?: Record<string, FontInfo>,
+  fonts?: Record<string, FontInfo>
   typography: {
     header: string | string[]
     body: string | string[]
@@ -42,14 +42,19 @@ const DEFAULT_MONO = "ui-monospace, SFMono-Regular, SF Mono, Menlo, monospace"
 
 function makeFamilySection(theme: Theme, family: string | string[], defaultFeatures: string) {
   const families = Array.isArray(family) ? family : [family]
-  return "family=" + families.map(f => {
-    const features = theme.fonts?.[f]?.features ?? defaultFeatures
-    if(features === "") {
-      return `${f}:wght@400` // matches unplugin-fonts; should be a sane default
-    } else {
-      return `${f}:${features}`
-    }
-  }).join("&family=")
+  return (
+    "family=" +
+    families
+      .map((f) => {
+        const features = theme.fonts?.[f]?.features ?? defaultFeatures
+        if (features === "") {
+          return `${f}:wght@400` // matches unplugin-fonts; should be a sane default
+        } else {
+          return `${f}:${features}`
+        }
+      })
+      .join("&family=")
+  )
 }
 
 export function googleFontHref(theme: Theme) {
@@ -63,8 +68,8 @@ export function googleFontHref(theme: Theme) {
 }
 
 function renderFonts(fonts: string | string[]) {
-  if(Array.isArray(fonts)) {
-    return fonts.map(s => `"${s}"`).join(", ")
+  if (Array.isArray(fonts)) {
+    return fonts.map((s) => `"${s}"`).join(", ")
   } else {
     return `"${fonts}"`
   }

--- a/quartz/util/theme.ts
+++ b/quartz/util/theme.ts
@@ -15,11 +15,19 @@ interface Colors {
   darkMode: ColorScheme
 }
 
+interface FontInfo {
+  /**
+   * e.g. "ital,wght@0,400;1,200"
+   */
+  features: string,
+}
+
 export interface Theme {
+  fonts?: Record<string, FontInfo>,
   typography: {
-    header: string
-    body: string
-    code: string
+    header: string | string[]
+    body: string | string[]
+    code: string | string[]
   }
   cdnCaching: boolean
   colors: Colors
@@ -32,9 +40,34 @@ const DEFAULT_SANS_SERIF =
   '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif'
 const DEFAULT_MONO = "ui-monospace, SFMono-Regular, SF Mono, Menlo, monospace"
 
+function makeFamilySection(theme: Theme, family: string | string[], defaultFeatures: string) {
+  const families = Array.isArray(family) ? family : [family]
+  return "family=" + families.map(f => {
+    const features = theme.fonts?.[f]?.features ?? defaultFeatures
+    if(features === "") {
+      return `${f}:wght@400` // matches unplugin-fonts; should be a sane default
+    } else {
+      return `${f}:${features}`
+    }
+  }).join("&family=")
+}
+
 export function googleFontHref(theme: Theme) {
   const { code, header, body } = theme.typography
-  return `https://fonts.googleapis.com/css2?family=${code}&family=${header}:wght@400;700&family=${body}:ital,wght@0,400;0,600;1,400;1,600&display=swap`
+
+  const codeSection = makeFamilySection(theme, code, "")
+  const headerSection = makeFamilySection(theme, header, "wght@400;700")
+  const bodySection = makeFamilySection(theme, body, "ital,wght@0,400;0,600;1,400;1,600")
+
+  return `https://fonts.googleapis.com/css2?${codeSection}&${headerSection}&${bodySection}&display=swap`
+}
+
+function renderFonts(fonts: string | string[]) {
+  if(Array.isArray(fonts)) {
+    return fonts.map(s => `"${s}"`).join(", ")
+  } else {
+    return `"${fonts}"`
+  }
 }
 
 export function joinStyles(theme: Theme, ...stylesheet: string[]) {
@@ -52,9 +85,9 @@ ${stylesheet.join("\n\n")}
   --highlight: ${theme.colors.lightMode.highlight};
   --textHighlight: ${theme.colors.lightMode.textHighlight};
 
-  --headerFont: "${theme.typography.header}", ${DEFAULT_SANS_SERIF};
-  --bodyFont: "${theme.typography.body}", ${DEFAULT_SANS_SERIF};
-  --codeFont: "${theme.typography.code}", ${DEFAULT_MONO};
+  --headerFont: ${renderFonts(theme.typography.header)}, ${DEFAULT_SANS_SERIF};
+  --bodyFont: ${renderFonts(theme.typography.body)}, ${DEFAULT_SANS_SERIF};
+  --codeFont: ${renderFonts(theme.typography.code)}, ${DEFAULT_MONO};
 }
 
 :root[saved-theme="dark"] {


### PR DESCRIPTION
This adds the ability to specify multiple fonts (e.g. for fallback purposes), as well as specifying font features for Google Fonts. The only related issue I could find was #609, which appears to have been closed without any progress?

A resultant config might look like:
```ts
theme: {
   // ...
  fonts: {
    "Schibsted Grotesk": {
      features: "ital,wght@0,400;0,700",
    }
  },
  typography: {
    header: "Schibsted Grotesk",
    body: ["Inter", "Noto Sans"],
    code: "IBM Plex Mono",
  },
}
```

Fonts that do not have features sent in the `fonts` object inherit the default features for header/body/code fonts that existed before this PR, so this is strictly a backwards-compatible change.