### PR TITLE
fix: Second ToC element not collapsible or highlight-able

### DIFF
--- a/quartz/components/scripts/toc.inline.ts
+++ b/quartz/components/scripts/toc.inline.ts
@@ -2,13 +2,13 @@ const bufferPx = 150
 const observer = new IntersectionObserver((entries) => {
   for (const entry of entries) {
     const slug = entry.target.id
-    const tocEntryElement = document.querySelector(`a[data-for="${slug}"]`)
+    const tocEntryElements = document.querySelectorAll(`a[data-for="${slug}"]`)
     const windowHeight = entry.rootBounds?.height
-    if (windowHeight && tocEntryElement) {
+    if (windowHeight && tocEntryElements.length > 0) {
       if (entry.boundingClientRect.y < windowHeight) {
-        tocEntryElement.classList.add("in-view")
+        tocEntryElements.forEach((tocEntryElement) => tocEntryElement.classList.add("in-view"))
       } else {
-        tocEntryElement.classList.remove("in-view")
+        tocEntryElements.forEach((tocEntryElement) => tocEntryElement.classList.remove("in-view"))
       }
     }
   }
@@ -26,14 +26,14 @@ function toggleToc(this: HTMLElement) {
 }
 
 function setupToc() {
-  const toc = document.getElementById("toc")
-  if (toc) {
+  const tocs = document.querySelectorAll("[id=toc]")
+  tocs.forEach((toc) => {
     const collapsed = toc.classList.contains("collapsed")
     const content = toc.nextElementSibling as HTMLElement | undefined
     if (!content) return
     toc.addEventListener("click", toggleToc)
     window.addCleanup(() => toc.removeEventListener("click", toggleToc))
-  }
+  })
 }
 
 window.addEventListener("resize", setupToc)


### PR DESCRIPTION
Here's a quick and dirty fix to ToC to make sure when multiple ToCs are added to the DOM (either visibly or not when say `Component.DesktopOnly()` is used), the rest of the ToC elements can be collapsed or title-highlighted.

<img width="1183" alt="Screenshot 2024-10-12 at 1 21 11 PM" src="https://github.com/user-attachments/assets/f5072136-63df-4879-bfcf-50872fb556f7">

ToC is useful for navigating long blog posts, but because it's typically to the right, it'd get pushed down to the bottom or hidden in tablet and mobile views. I feel adding multiple ToCs (e.g. one in `beforeBody` one in `right`) may be a common scenario worth supporting.

This fix might be a bit hacky, but I don't know how to generate dynamic IDs and deal with ARIA and styling otherwise. Please feel free to supersede this PR with a better fix.

## A note about other components that are broken when added twice

Explorer is another obvious example, if one is to add a second one in `afterBody` for the mobile view, that one is not collapsible.

But I'd think https://github.com/jackyzha0/quartz/pull/1471 is a much better solution for Explorer. Perhaps in the future it can be extended so that the hamburger menu becomes a new Quartz layout component (although I'd think double-adding components would become more of an issue to be solved then; it was briefly discussed in the original layout rework PR I was looking forward to: https://github.com/jackyzha0/quartz/pull/1339).

---

EDIT: This PR appears to overlap with https://github.com/jackyzha0/quartz/pull/1338 a bit. 1338 fixes the Explorer and ToC's collapse function, but doesn't fix ToC's title highlight function.