### PR TITLE
feat(head): allow customizations to favicon, opengraph

### DIFF
--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -3,7 +3,11 @@ import * as Component from "./quartz/components"
 
 // components shared across all pages
 export const sharedPageComponents: SharedLayout = {
-  head: Component.Head(),
+  head: Component.Head({
+    favicons: [
+      { path: "static/icon.png", size: "200x200", mime: "image/png" }
+    ]
+  }),
   header: [],
   afterBody: [],
   footer: Component.Footer({

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -4,17 +4,15 @@ import * as Component from "./quartz/components"
 // components shared across all pages
 export const sharedPageComponents: SharedLayout = {
   head: Component.Head({
-    favicons: [
-      { path: "static/icon.png", size: "200x200", mime: "image/png" }
-    ],
+    favicons: [{ path: "static/icon.png", size: "200x200", mime: "image/png" }],
 
     openGraph: {
       path: "static/og-image.png",
       mime: "image/png",
       width: "1200",
       height: "675",
-      alt: "Quartz logo"
-    }
+      alt: "Quartz logo",
+    },
   }),
   header: [],
   afterBody: [],

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -6,7 +6,15 @@ export const sharedPageComponents: SharedLayout = {
   head: Component.Head({
     favicons: [
       { path: "static/icon.png", size: "200x200", mime: "image/png" }
-    ]
+    ],
+
+    openGraph: {
+      path: "static/og-image.png",
+      mime: "image/png",
+      width: "1200",
+      height: "675",
+      alt: "Quartz logo"
+    }
   }),
   header: [],
   afterBody: [],

--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -10,8 +10,17 @@ interface Favicon {
   mime?: string
 }
 
+interface OpenGraphImage {
+  path: string
+  alt?: string
+  mime?: string
+  width?: string
+  height?: string
+}
+
 interface Options {
   favicons?: Favicon[]
+  openGraph?: OpenGraphImage
 }
 
 export default ((opts?: Options) => {
@@ -26,8 +35,6 @@ export default ((opts?: Options) => {
     const url = new URL(`https://${cfg.baseUrl ?? "example.com"}`)
     const path = url.pathname as FullSlug
     const baseDir = fileData.slug === "404" ? path : pathToRoot(fileData.slug!)
-
-    const ogImagePath = `https://${cfg.baseUrl}/static/og-image.png`
 
     const icons = opts?.favicons ?? []
 
@@ -45,9 +52,15 @@ export default ((opts?: Options) => {
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta property="og:title" content={title} />
         <meta property="og:description" content={description} />
-        {cfg.baseUrl && <meta property="og:image" content={ogImagePath} />}
-        <meta property="og:width" content="1200" />
-        <meta property="og:height" content="675" />
+        {cfg.baseUrl && opts?.openGraph && (
+          <>
+            <meta property="og:image" content={`https://${cfg.baseUrl}/${opts.openGraph.path}`} />
+            {opts.openGraph.mime && (<meta property="og:image:type" content={opts.openGraph.mime} />)}
+            {opts.openGraph.width && (<meta property="og:image:width" content={opts.openGraph.path} />)}
+            {opts.openGraph.height && (<meta property="og:image:height" content={opts.openGraph.height} />)}
+            {opts.openGraph.alt && (<meta property="og:image:alt" content={opts.openGraph.alt} />)}
+          </>
+        )}
         {icons.map(({ path, size, mime }) => (
           <link rel="icon" href={joinSegments(baseDir, path)} sizes={size} type={mime} />
         ))}

--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -55,10 +55,14 @@ export default ((opts?: Options) => {
         {cfg.baseUrl && opts?.openGraph && (
           <>
             <meta property="og:image" content={`https://${cfg.baseUrl}/${opts.openGraph.path}`} />
-            {opts.openGraph.mime && (<meta property="og:image:type" content={opts.openGraph.mime} />)}
-            {opts.openGraph.width && (<meta property="og:image:width" content={opts.openGraph.path} />)}
-            {opts.openGraph.height && (<meta property="og:image:height" content={opts.openGraph.height} />)}
-            {opts.openGraph.alt && (<meta property="og:image:alt" content={opts.openGraph.alt} />)}
+            {opts.openGraph.mime && <meta property="og:image:type" content={opts.openGraph.mime} />}
+            {opts.openGraph.width && (
+              <meta property="og:image:width" content={opts.openGraph.path} />
+            )}
+            {opts.openGraph.height && (
+              <meta property="og:image:height" content={opts.openGraph.height} />
+            )}
+            {opts.openGraph.alt && <meta property="og:image:alt" content={opts.openGraph.alt} />}
           </>
         )}
         {icons.map(({ path, size, mime }) => (

--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -4,7 +4,17 @@ import { JSResourceToScriptElement } from "../util/resources"
 import { googleFontHref } from "../util/theme"
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
 
-export default (() => {
+interface Favicon {
+  path: string
+  size?: string
+  mime?: string
+}
+
+interface Options {
+  favicons?: Favicon[]
+}
+
+export default ((opts?: Options) => {
   const Head: QuartzComponent = ({ cfg, fileData, externalResources }: QuartzComponentProps) => {
     const titleSuffix = cfg.pageTitleSuffix ?? ""
     const title =
@@ -17,8 +27,9 @@ export default (() => {
     const path = url.pathname as FullSlug
     const baseDir = fileData.slug === "404" ? path : pathToRoot(fileData.slug!)
 
-    const iconPath = joinSegments(baseDir, "static/icon.png")
     const ogImagePath = `https://${cfg.baseUrl}/static/og-image.png`
+
+    const icons = opts?.favicons ?? []
 
     return (
       <head>
@@ -37,7 +48,9 @@ export default (() => {
         {cfg.baseUrl && <meta property="og:image" content={ogImagePath} />}
         <meta property="og:width" content="1200" />
         <meta property="og:height" content="675" />
-        <link rel="icon" href={iconPath} />
+        {icons.map(({ path, size, mime }) => (
+          <link rel="icon" href={joinSegments(baseDir, path)} sizes={size} type={mime} />
+        ))}
         <meta name="description" content={description} />
         <meta name="generator" content="Quartz" />
         {css.map((href) => (


### PR DESCRIPTION
I agree to license this change under the MIT License.

I want to give this more testing and documentation before officially merging it, but this is mostly a design proposal for changing the Head.tsx component.

My own Quartz blog uses a variation of this, so that I can provide additional properties without modifying the actual component every time.

The high-level changes:

- Introduces an `opts` parameter for the existing Header component.
- Multiple icons can be specified.
- The width and height properties of the Open Graph image can be set, among other properties.

The only required option is `path`. `path` is a path which begins with `static`. If other options are omitted, they don't show up in the final output.

If this is something that you think *should* be changed, I'd appreciate some feedback or additional testing.