### PR TITLE
fix(darkmode): check for null

### DIFF
--- a/quartz/components/scripts/darkmode.inline.ts
+++ b/quartz/components/scripts/darkmode.inline.ts
@@ -27,9 +27,10 @@ document.addEventListener("nav", () => {
 
   // Darkmode toggle
   const themeButton = document.querySelector("#darkmode") as HTMLButtonElement
-  themeButton.addEventListener("click", switchTheme)
-  window.addCleanup(() => themeButton.removeEventListener("click", switchTheme))
-
+  if(themeButton){
+    themeButton.addEventListener("click", switchTheme)
+    window.addCleanup(() => themeButton.removeEventListener("click", switchTheme))
+  }
   // Listen for changes in prefers-color-scheme
   const colorSchemeMediaQuery = window.matchMedia("(prefers-color-scheme: dark)")
   colorSchemeMediaQuery.addEventListener("change", themeChange)

--- a/quartz/components/scripts/darkmode.inline.ts
+++ b/quartz/components/scripts/darkmode.inline.ts
@@ -27,7 +27,7 @@ document.addEventListener("nav", () => {
 
   // Darkmode toggle
   const themeButton = document.querySelector("#darkmode") as HTMLButtonElement
-  if(themeButton){
+  if (themeButton) {
     themeButton.addEventListener("click", switchTheme)
     window.addCleanup(() => themeButton.removeEventListener("click", switchTheme))
   }


### PR DESCRIPTION
This is to avoid operations against null objects (themeButton) which happens with the default 404 error handler that does not contain #darkmode .