### PR TITLE
feat(i18n): add turkish language

### DIFF
--- a/quartz/i18n/index.ts
+++ b/quartz/i18n/index.ts
@@ -20,6 +20,7 @@ import hu from "./locales/hu-HU"
 import fa from "./locales/fa-IR"
 import pl from "./locales/pl-PL"
 import cs from "./locales/cs-CZ"
+import tr from "./locales/tr-TR"
 
 export const TRANSLATIONS = {
   "en-US": enUs,
@@ -64,6 +65,7 @@ export const TRANSLATIONS = {
   "fa-IR": fa,
   "pl-PL": pl,
   "cs-CZ": cs,
+  "tr-TR": tr,
 } as const
 
 export const defaultTranslation = "en-US"

--- a/quartz/i18n/locales/tr-TR.ts
+++ b/quartz/i18n/locales/tr-TR.ts
@@ -1,0 +1,84 @@
+import { Translation } from "./definition"
+
+export default {
+  propertyDefaults: {
+    title: "İsimsiz",
+    description: "Herhangi bir açıklama eklenmedi",
+  },
+  components: {
+    callout: {
+      note: "Not",
+      abstract: "Özet",
+      info: "Bilgi",
+      todo: "Yapılacaklar",
+      tip: "İpucu",
+      success: "Başarılı",
+      question: "Soru",
+      warning: "Uyarı",
+      failure: "Başarısız",
+      danger: "Tehlike",
+      bug: "Hata",
+      example: "Örnek",
+      quote: "Alıntı",
+    },
+    backlinks: {
+      title: "Backlinkler",
+      noBacklinksFound: "Backlink bulunamadı",
+    },
+    themeToggle: {
+      lightMode: "Açık mod",
+      darkMode: "Koyu mod",
+    },
+    explorer: {
+      title: "Gezgin",
+    },
+    footer: {
+      createdWith: "Şununla oluşturuldu",
+    },
+    graph: {
+      title: "Grafik Görünümü",
+    },
+    recentNotes: {
+      title: "Son Notlar",
+      seeRemainingMore: ({ remaining }) => `${remaining} tane daha gör →`,
+    },
+    transcludes: {
+      transcludeOf: ({ targetSlug }) => `${targetSlug} sayfasından alıntı`,
+      linkToOriginal: "Orijinal bağlantı",
+    },
+    search: {
+      title: "Arama",
+      searchBarPlaceholder: "Bir şey arayın",
+    },
+    tableOfContents: {
+      title: "İçindekiler",
+    },
+    contentMeta: {
+      readingTime: ({ minutes }) => `${minutes} dakika okuma süresi`,
+    },
+  },
+  pages: {
+    rss: {
+      recentNotes: "Son notlar",
+      lastFewNotes: ({ count }) => `Son ${count} not`,
+    },
+    error: {
+      title: "Bulunamadı",
+      notFound: "Bu sayfa ya özel ya da mevcut değil.",
+      home: "Anasayfaya geri dön",
+    },
+    folderContent: {
+      folder: "Klasör",
+      itemsUnderFolder: ({ count }) =>
+        count === 1 ? "Bu klasör altında 1 öğe." : `Bu klasör altındaki ${count} öğe.`,
+    },
+    tagContent: {
+      tag: "Etiket",
+      tagIndex: "Etiket Sırası",
+      itemsUnderTag: ({ count }) =>
+        count === 1 ? "Bu etikete sahip 1 öğe." : `Bu etiket altındaki ${count} öğe.`,
+      showingFirst: ({ count }) => `İlk ${count} etiket gösteriliyor.`,
+      totalTags: ({ count }) => `Toplam ${count} adet etiket bulundu.`,
+    },
+  },
+} as const satisfies Translation


### PR DESCRIPTION
### **Turkish Language Support**

This PR adds full Turkish language support to Quartz, making the application accessible to Turkish-speaking users. The following files were added and updated to ensure comprehensive translation across all key components:

### Summary of Changes:
- **`quartz/i18n/index.ts`**: Added Turkish (`tr-TR`) to the `TRANSLATIONS` object and updated `ValidLocale` types to include the new locale.
- **`quartz/i18n/locales/tr-TR.ts`**: Introduced a new translation file with Turkish strings for interface components, error messages, aligned for a consistent user experience.

This contribution ensures a localized experience, allowing Turkish-speaking users to navigate and interact with Quartz in their preferred language. Let me know if there are any areas that need further refinement. Thank you!