### PR TITLE
Update page title to current version

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -8,7 +8,7 @@ import * as Plugin from "./quartz/plugins"
  */
 const config: QuartzConfig = {
   configuration: {
-    pageTitle: "🪴 Quartz 4.0",
+    pageTitle: "🪴 Quartz 4.4",
     pageTitleSuffix: "",
     enableSPA: true,
     enablePopovers: true,


### PR DESCRIPTION
First of all, thanks a lot for providing quartz! I am happily using it to [document my Dojo's Karate techniques](https://realjohndoe.github.io/kenpo-notes/) and me and some other Dojo members enjoy the resulting page as a valuable learning resource.

I noticed that the title of the quartz docs still says '4.0', in spite the current version being at 4.4. Is this intentional?