### PR TITLE
fix(search): restore mobile search view

### DIFF
--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -132,7 +132,7 @@
           border-radius: 5px;
         }
 
-        @media all and ($tablet) {
+        @media all and ($mobile) {
           & > #preview-container {
             display: none !important;
           }

--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -106,7 +106,7 @@
           flex: 0 0 min(30%, 450px);
         }
 
-        @media all and not ($tablet) {
+        @media all and not ($mobile) {
           &[data-preview] {
             & .result-card > p.preview {
               display: none;


### PR DESCRIPTION
This PR restores the mobile search view to mobile layout and the desktop search view to tablet layout, instead of using the wrong layout for both.

## After

### Mobile

![image](https://github.com/user-attachments/assets/e8d7c3a2-3629-483f-85a2-99de37d159c5)

### Tablet

![image](https://github.com/user-attachments/assets/f1e9f6b8-a671-4deb-86e5-0683be737afe)

## Before

### Mobile

![image](https://github.com/user-attachments/assets/379822e4-5add-45da-9973-0f6274e5de8d)

### Tablet

![image](https://github.com/user-attachments/assets/780698ec-8273-4fe8-b868-ed70b09699e0)
