### PR TITLE
fix(404): update layout based on `grid` refactoring

### DIFF
--- a/quartz/plugins/emitters/404.tsx
+++ b/quartz/plugins/emitters/404.tsx
@@ -5,7 +5,7 @@ import { pageResources, renderPage } from "../../components/renderPage"
 import { FullPageLayout } from "../../cfg"
 import { FilePath, FullSlug } from "../../util/path"
 import { sharedPageComponents } from "../../../quartz.layout"
-import { NotFound } from "../../components"
+import { NotFound, Spacer } from "../../components"
 import { defaultProcessedContent } from "../vfile"
 import { write } from "./helpers"
 import { i18n } from "../../i18n"
@@ -16,8 +16,8 @@ export const NotFoundPage: QuartzEmitterPlugin = () => {
     ...sharedPageComponents,
     pageBody: NotFound(),
     beforeBody: [],
-    left: [],
-    right: [],
+    left: [Spacer()],
+    right: [Spacer()],
   }
 
   const { head: Head, pageBody, footer: Footer } = opts


### PR DESCRIPTION
update a regression given that our 404 pages would display weird layout, given that `left` and `right` are empty

cc @saberzero1 