### PR TITLE
feat(open-graph): Allow custom OG images from any paths or URLs

### DIFF
--- a/docs/features/social images.md
+++ b/docs/features/social images.md
@@ -45,7 +45,11 @@ The following properties can be used to customize your link previews:
 | `socialDescription` | `description`    | Description to be used for preview. |
 | `socialImage`       | `image`, `cover` | Link to preview image.              |
 
-The `socialImage` property should contain a link to an image relative to your base URL. For example, if you have an image `cover.png` in `quartz/static/`, the `socialImage` value could be `"static/cover.png"`. If your image is in `content/assets/`, then the `socialImage` value would become `"assets/cover.png"`.
+The `socialImage` property should be a link to an image. It can be relative to your base URL, or you can provide a full URL with scheme (HTTP protocol only). For example:
+
+1. If you have an image `cover.png` in `quartz/static/`, the `socialImage` value could be `"static/cover.png"`.
+2. If your image is in `content/assets/`, then the `socialImage` value would become `"assets/cover.png"`.
+3. If your image is hosted elsewhere, say `https://example.com/cover.png`, then the `socialImage` value should be `"https://example.com/cover.png"`.
 
 > [!info] Info
 >

--- a/docs/features/social images.md
+++ b/docs/features/social images.md
@@ -45,7 +45,7 @@ The following properties can be used to customize your link previews:
 | `socialDescription` | `description`    | Description to be used for preview. |
 | `socialImage`       | `image`, `cover` | Link to preview image.              |
 
-The `socialImage` property should contain a link to an image relative to `quartz/static`. If you have a folder for all your images in `quartz/static/my-images`, an example for `socialImage` could be `"my-images/cover.png"`.
+The `socialImage` property should contain a link to an image relative to your base URL. For example, if you have an image `cover.png` in `quartz/static/`, the `socialImage` value could be `"static/cover.png"`. If your image is in `content/assets/`, then the `socialImage` value would become `"assets/cover.png"`.
 
 > [!info] Info
 >

--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -147,7 +147,7 @@ export default (() => {
 
     // Override with frontmatter url if existing
     if (frontmatterImgUrl) {
-      ogImagePath = `https://${cfg.baseUrl}/static/${frontmatterImgUrl}`
+      ogImagePath = `https://${cfg.baseUrl}/${frontmatterImgUrl}`
     }
 
     // Url of current page

--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -44,6 +44,8 @@ const defaultOptions: SocialImageOptions = {
   excludeRoot: false,
 }
 
+const urlSchemeRegex = new RegExp("^(http|https)://", "i")
+
 export default (() => {
   let fontsPromise: Promise<SatoriOptions["fonts"]>
 
@@ -147,7 +149,9 @@ export default (() => {
 
     // Override with frontmatter url if existing
     if (frontmatterImgUrl) {
-      ogImagePath = `https://${cfg.baseUrl}/${frontmatterImgUrl}`
+      ogImagePath = urlSchemeRegex.test(frontmatterImgUrl)
+        ? frontmatterImgUrl
+        : `https://${cfg.baseUrl}/${frontmatterImgUrl}`
     }
 
     // Url of current page


### PR DESCRIPTION
Proposing a small change to remove the `static` directory restriction when setting OG image path in frontmatter. Now it's either relative to the base URL, or a full URL.

So if someone wants to reuse an image `assets/cover.png` from their blog post in the `content` directory, they can set `socialImage` to say `assets/cover.png`. If the image is in the `static` directory, then they need to explicitly include it in the path: `static/cover.png`. If it's hosted elsewhere e.g. `https://example.com/cover.png`, then `socialImage` value should be the full URL including the HTTP protocol.