### PR TITLE
fix: timezone issue with ISO dates

### DIFF
--- a/quartz/plugins/transformers/lastmod.ts
+++ b/quartz/plugins/transformers/lastmod.ts
@@ -48,7 +48,15 @@ export const CreatedModifiedDate: QuartzTransformerPlugin<Partial<Options>> = (u
                 created ||= st.birthtimeMs
                 modified ||= st.mtimeMs
               } else if (source === "frontmatter" && file.data.frontmatter) {
-                created ||= file.data.frontmatter.date as MaybeDate
+                if (!created) {
+                  created = file.data.frontmatter.date as MaybeDate
+                  if (typeof created === "string" && /^\d{4}-\d{2}-\d{2}$/.test(created)) {
+                    // If the date is in YYYY-MM-DD format, it will be interpreted as UTC midnight
+                    // which will mean it renders incorrectly as the previous day. Adding a time
+                    // makes it interpret as the local timezone instead so it will render correctly.
+                    created += " 00:00"
+                  }
+                }
                 modified ||= file.data.frontmatter.lastmod as MaybeDate
                 modified ||= file.data.frontmatter.updated as MaybeDate
                 modified ||= file.data.frontmatter["last-modified"] as MaybeDate


### PR DESCRIPTION
If the date is in YYYY-MM-DD format, which is the default for the Obsidian 'date' file property, it will be interpreted as UTC midnight rather than local time midnight. If the local timezone is at a negative GMT offset, this means it will render incorrectly as the **previous day** when passed to 'getLocaleDateString'.

Adding a time to the input string before passing to the `Date()` constructor makes it interpret the string as midnight in the **local timezone** instead so it will render as expected.

⚠️ ***This draft PR a hacky fix, currently just for illustration purposes.*** ⚠️ 

Context:

> When the time zone offset is absent, date-only forms are interpreted as a UTC time and date-time forms are interpreted as a local time. The interpretation as a UTC time is due to a historical spec error that was not consistent with ISO 8601 but could not be changed due to web compatibility.
-- [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#date_time_string_format)
