### PR TITLE
fix(style): ensure images have no background color when linked

### DIFF
--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -85,7 +85,7 @@ a {
     line-height: 1.4rem;
 
     &:has(> img) {
-      background-color: none;
+      background-color: transparent;
       border-radius: 0;
       padding: 0;
     }


### PR DESCRIPTION
The value of `none` is not valid for the `background-color` property. The CSS spec only allows for the `<color> | transparent | inherit` values (with `transparent` being the initial value), so this wasn't working as intended.

See:
- https://www.w3.org/TR/CSS2/colors.html#propdef-background-color