### PR TITLE
fix(comments): properly check if comments is in frontmatter

### DIFF
--- a/quartz/components/Comments.tsx
+++ b/quartz/components/Comments.tsx
@@ -28,7 +28,8 @@ export default ((opts: Options) => {
   const Comments: QuartzComponent = ({ displayClass, fileData, cfg }: QuartzComponentProps) => {
     // check if comments should be displayed according to frontmatter
     const disableComment: boolean =
-      !fileData.frontmatter?.comments || fileData.frontmatter?.comments === "false"
+      typeof fileData.frontmatter?.comments !== "undefined" &&
+      (!fileData.frontmatter?.comments || fileData.frontmatter?.comments === "false")
     if (disableComment) {
       return <></>
     }


### PR DESCRIPTION
Currently enabling the comments component hides the comments unless the `comments` frontmatter value is set to true.

This is due to `!undefined` evaluating to `true`.

This PR adds a check to ensure the comments component are only disabled on a page if the `comments` key is present in the frontmatter and its value is `false` or `"false"`.

Closes https://github.com/jackyzha0/quartz/issues/1582