### PR TITLE
fix(aliases): prevent alias emitter from infinite redirect

### DIFF
--- a/quartz/plugins/emitters/aliases.ts
+++ b/quartz/plugins/emitters/aliases.ts
@@ -49,6 +49,12 @@ export const AliasRedirects: QuartzEmitterPlugin = () => ({
       }
 
       for (let slug of slugs) {
+        // prevent infinite redirect if permalink is same as fullSlug
+        if (`/${ogSlug}/` == `${slug}`) {
+          console.warn(`AliasRedirects: ${slug} is the same as the original slug`)
+          continue
+        }
+
         // fix any slugs that have trailing slash
         if (slug.endsWith("/")) {
           slug = joinSegments(slug, "index") as FullSlug


### PR DESCRIPTION
Obsidian digital garden plugin make permalink frontmatter same as a fullSlug in quartz. To prevent buggy generation skip alias same as fullSlug.