### PR TITLE
fix(Date): Account for local timezone offset

### DIFF
--- a/quartz/components/Date.tsx
+++ b/quartz/components/Date.tsx
@@ -23,9 +23,10 @@ export function formatDate(d: Date, locale: ValidLocale = "en-US"): string {
     year: "numeric",
     month: "short",
     day: "2-digit",
+    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
   })
 }
 
 export function Date({ date, locale }: Props) {
-  return <time datetime={formatDate(date)}>{formatDate(date, locale)}</time>
+  return <time datetime={date.toISOString()}>{formatDate(date, locale)}</time>
 }

--- a/quartz/components/Date.tsx
+++ b/quartz/components/Date.tsx
@@ -27,5 +27,5 @@ export function formatDate(d: Date, locale: ValidLocale = "en-US"): string {
 }
 
 export function Date({ date, locale }: Props) {
-  return <time datetime={date.toISOString()}>{formatDate(date, locale)}</time>
+  return <time datetime={formatDate(date)}>{formatDate(date, locale)}</time>
 }


### PR DESCRIPTION
Dates sometimes are a day behind or ahead if the user is in a non-UTC timezone. This PR aims to fix that.

## TODO
- [ ] verify with several time zones
- [ ] optionally allow users to configure if their build server has a different time zone than their notes(?)