### PR TITLE
Fix(cssclasses): Apply frontmatter classes uniformly between page types

### DIFF
--- a/quartz/components/pages/FolderContent.tsx
+++ b/quartz/components/pages/FolderContent.tsx
@@ -71,7 +71,7 @@ export default ((opts?: Partial<FolderContentOptions>) => {
     })
 
     const cssClasses: string[] = fileData.frontmatter?.cssclasses ?? []
-    const classes = ["popover-hint", ...cssClasses].join(" ")
+    const classes = cssClasses.join(" ")
     const listProps = {
       ...props,
       sort: options.sort,
@@ -84,8 +84,8 @@ export default ((opts?: Partial<FolderContentOptions>) => {
         : htmlToJsx(fileData.filePath!, tree)
 
     return (
-      <div class={classes}>
-        <article>{content}</article>
+      <div class="popover-hint">
+        <article class={classes}>{content}</article>
         <div class="page-listing">
           {options.showFolderCount && (
             <p>

--- a/quartz/components/pages/TagContent.tsx
+++ b/quartz/components/pages/TagContent.tsx
@@ -38,7 +38,7 @@ export default ((opts?: Partial<TagContentOptions>) => {
         ? fileData.description
         : htmlToJsx(fileData.filePath!, tree)
     const cssClasses: string[] = fileData.frontmatter?.cssclasses ?? []
-    const classes = ["popover-hint", ...cssClasses].join(" ")
+    const classes = cssClasses.join(" ")
     if (tag === "/") {
       const tags = [
         ...new Set(
@@ -50,8 +50,8 @@ export default ((opts?: Partial<TagContentOptions>) => {
         tagItemMap.set(tag, allPagesWithTag(tag))
       }
       return (
-        <div class={classes}>
-          <article>
+        <div class="popover-hint">
+          <article class={classes}>
             <p>{content}</p>
           </article>
           <p>{i18n(cfg.locale).pages.tagContent.totalTags({ count: tags.length })}</p>


### PR DESCRIPTION
Cssclasses specified in frontmatter were not applied uniformly between Content pages and Tag/Folder pages. This PR aims to rectify that by moving the frontmatter-specific classes on Tag/Folder pages to the article tag, similar to Content pages.