### PR TITLE
feat(links.ts): custom identifiers for custom icons

### DIFF
--- a/docs/plugins/CrawlLinks.md
+++ b/docs/plugins/CrawlLinks.md
@@ -19,6 +19,14 @@ This plugin accepts the following configuration options:
 - `openLinksInNewTab`: If `true`, configures external links to open in a new tab. Defaults to `false`.
 - `lazyLoad`: If `true`, adds lazy loading to resource elements (`img`, `video`, etc.) to improve page load performance. Defaults to `false`.
 - `externalLinkIcon`: Adds an icon next to external links when `true` (default) to visually distinguishing them from internal links.
+- `substitutions`: default `[]`, a list of regex-image pairs. When you write a link's URL to match the regex, it will display the image after the link on your webpage.
+  - images may either be an `Image(url)`, `Emoji(text)`, or `Path({code: code, viewbox: viewbox})`. Examples:
+    - `Image("https://website.com/image.jpg")`
+    - `Image("/static/icon.png")`
+    - `Emoji("🪴")`
+    - `Path({code: "really long string like M320 0H288V64h32 82.7L201.4 265.4...", viewbox: "0 0 512 512"})`
+  - Example use: `substitutions: [ [/garden!(.+)/, Emoji("🪴")], ],` 
+    - This would let you write links in Markdown like `[Someone's garden](garden!https://their-website.com)`, which would look like `Someone's Garden🪴` on the website.
 
 > [!warning]
 > Removing this plugin is _not_ recommended and will likely break the page.

--- a/docs/plugins/CrawlLinks.md
+++ b/docs/plugins/CrawlLinks.md
@@ -25,7 +25,7 @@ This plugin accepts the following configuration options:
     - `Image("/static/icon.png")`
     - `Emoji("🪴")`
     - `Path({code: "really long string like M320 0H288V64h32 82.7L201.4 265.4...", viewbox: "0 0 512 512"})`
-  - Example use: `substitutions: [ [/garden!(.+)/, Emoji("🪴")], ],` 
+  - Example use: `substitutions: [ [/garden!(.+)/, Emoji("🪴")], ],`
     - This would let you write links in Markdown like `[Someone's garden](garden!https://their-website.com)`, which would look like `Someone's Garden🪴` on the website.
 
 > [!warning]

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "hast-util-to-html": "^9.0.3",
         "hast-util-to-jsx-runtime": "^2.3.2",
         "hast-util-to-string": "^3.0.1",
-        "is-absolute-url": "^4.0.1",
         "js-yaml": "^4.1.0",
         "lightningcss": "^1.28.1",
         "mdast-util-find-and-replace": "^3.0.1",
@@ -4092,17 +4091,6 @@
       "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/is-absolute-url": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
-      "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-alphabetical": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "hast-util-to-html": "^9.0.3",
     "hast-util-to-jsx-runtime": "^2.3.2",
     "hast-util-to-string": "^3.0.1",
-    "is-absolute-url": "^4.0.1",
     "js-yaml": "^4.1.0",
     "lightningcss": "^1.28.1",
     "mdast-util-find-and-replace": "^3.0.1",

--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -1,5 +1,6 @@
 import { QuartzConfig } from "./quartz/cfg"
 import * as Plugin from "./quartz/plugins"
+import { Image, Path, Emoji } from "./quartz/plugins/transformers/links"
 
 /**
  * Quartz 4.0 Configuration
@@ -70,7 +71,12 @@ const config: QuartzConfig = {
       Plugin.ObsidianFlavoredMarkdown({ enableInHtmlEmbed: false }),
       Plugin.GitHubFlavoredMarkdown(),
       Plugin.TableOfContents(),
-      Plugin.CrawlLinks({ markdownLinkResolution: "shortest" }),
+      Plugin.CrawlLinks({
+        markdownLinkResolution: "shortest",
+        // See https://quartz.jzhao.xyz/plugins/CrawlLinks
+        // Try uncommenting the below line and writing [Someone's Garden](garden!https://jzhao.xyz/) in markdown
+        // substitutions: [ [/garden!(.+)/, Emoji("🪴")], ],
+      }),
       Plugin.Description(),
       Plugin.Latex({ renderEngine: "katex" }),
     ],

--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -75,7 +75,7 @@ const config: QuartzConfig = {
         markdownLinkResolution: "shortest",
         // See https://quartz.jzhao.xyz/plugins/CrawlLinks
         // Try uncommenting the below line and writing [Someone's Garden](garden!https://jzhao.xyz/) in markdown
-        // substitutions: [ [/garden!(.+)/, Emoji("🪴")], ],
+        // substitutions: [[/garden!(.+)/, Emoji("🪴")]],
       }),
       Plugin.Description(),
       Plugin.Latex({ renderEngine: "katex" }),

--- a/quartz/plugins/transformers/links.ts
+++ b/quartz/plugins/transformers/links.ts
@@ -228,13 +228,11 @@ export const CrawlLinks: QuartzTransformerPlugin<Partial<Options>> = (userOpts) 
 
                 if (!URL.canParse(node.properties.src)) {
                   let dest = node.properties.src as RelativeURL
-                  console.log(dest)
                   dest = node.properties.src = transformLink(
                     file.data.slug!,
                     dest,
                     transformOptions,
                   )
-                  console.log(dest)
                   node.properties.src = dest
                 }
               }

--- a/quartz/plugins/transformers/links.ts
+++ b/quartz/plugins/transformers/links.ts
@@ -97,7 +97,7 @@ export const CrawlLinks: QuartzTransformerPlugin<Partial<Options>> = (userOpts) 
                         type: "element",
                         tagName: "img",
                         properties: {
-                          src: (sub as Image).src as FullSlug,
+                          src: (sub as Image).src,
                           style: "max-width:1em;max-height:1em",
                         },
                         children: [],

--- a/quartz/plugins/transformers/links.ts
+++ b/quartz/plugins/transformers/links.ts
@@ -98,7 +98,7 @@ export const CrawlLinks: QuartzTransformerPlugin<Partial<Options>> = (userOpts) 
                         tagName: "img",
                         properties: {
                           src: (sub as Image).src,
-                          style: "max-width:1em;max-height:1em",
+                          style: "max-width:1em;max-height:1em;margin:0px",
                         },
                         children: [],
                       }
@@ -137,6 +137,8 @@ export const CrawlLinks: QuartzTransformerPlugin<Partial<Options>> = (userOpts) 
                 const isExternal = URL.canParse(dest)
                 classes.push(isExternal || matched ? "external" : "internal")
 
+                // If the link matched a substitution, display the corresponding image afterwards;
+                //  otherwise, if it's an external link, display the default external link icon
                 if ((isExternal && opts.externalLinkIcon) || matched) {
                   node.children.push(
                     refIcon != null

--- a/quartz/plugins/transformers/links.ts
+++ b/quartz/plugins/transformers/links.ts
@@ -11,7 +11,6 @@ import {
 } from "../../util/path"
 import path from "path"
 import { visit } from "unist-util-visit"
-import isAbsoluteUrl from "is-absolute-url"
 import { ElementContent, Root } from "hast"
 
 type Sub = [RegExp, string | ElementContent]
@@ -124,7 +123,7 @@ export const CrawlLinks: QuartzTransformerPlugin<Partial<Options>> = (userOpts) 
                 }
 
                 // don't process external links or intra-document anchors
-                const isInternal = !(isAbsoluteUrl(dest) || dest.startsWith("#"))
+                const isInternal = !(URL.canParse(dest) || dest.startsWith("#"))
                 if (isInternal) {
                   dest = node.properties.href = transformLink(
                     file.data.slug!,
@@ -170,8 +169,9 @@ export const CrawlLinks: QuartzTransformerPlugin<Partial<Options>> = (userOpts) 
                   node.properties.loading = "lazy"
                 }
 
-                if (!isAbsoluteUrl(node.properties.src)) {
+                if (!URL.canParse(node.properties.src)) {
                   let dest = node.properties.src as RelativeURL
+                  console.log(dest)
                   dest = node.properties.src = transformLink(
                     file.data.slug!,
                     dest,

--- a/quartz/plugins/transformers/links.ts
+++ b/quartz/plugins/transformers/links.ts
@@ -58,12 +58,12 @@ export const CrawlLinks: QuartzTransformerPlugin<Partial<Options>> = (userOpts) 
                 node.properties &&
                 typeof node.properties.href === "string"
               ) {
-                let href = node.properties.href
-                var dest = href as RelativeURL
-                var refIcon: string | ElementContent | null = null
-                var matched = false
+                const href = node.properties.href
+                let dest = href as RelativeURL
+                let refIcon: string | ElementContent | null = null
+                let matched = false
                 opts.substitutions?.every(([regex, sub]) => {
-                  let parts = href.match(regex)
+                  const parts = href.match(regex)
                   if (parts != null) {
                     dest = parts.slice(1).join("") as RelativeURL
                     if (typeof sub == "object") {
@@ -86,25 +86,25 @@ export const CrawlLinks: QuartzTransformerPlugin<Partial<Options>> = (userOpts) 
                     refIcon != null
                       ? refIcon
                       : {
-                          type: "element",
-                          tagName: "svg",
-                          properties: {
-                            "aria-hidden": "true",
-                            class: "external-icon",
-                            style: "max-width:0.8em;max-height:0.8em",
-                            viewBox: "0 0 512 512",
-                          },
-                          children: [
-                            {
-                              type: "element",
-                              tagName: "path",
-                              properties: {
-                                d: "M320 0H288V64h32 82.7L201.4 265.4 178.7 288 224 333.3l22.6-22.6L448 109.3V192v32h64V192 32 0H480 320zM32 32H0V64 480v32H32 456h32V480 352 320H424v32 96H64V96h96 32V32H160 32z",
-                              },
-                              children: [],
-                            },
-                          ],
+                        type: "element",
+                        tagName: "svg",
+                        properties: {
+                          "aria-hidden": "true",
+                          class: "external-icon",
+                          style: "max-width:0.8em;max-height:0.8em",
+                          viewBox: "0 0 512 512",
                         },
+                        children: [
+                          {
+                            type: "element",
+                            tagName: "path",
+                            properties: {
+                              d: "M320 0H288V64h32 82.7L201.4 265.4 178.7 288 224 333.3l22.6-22.6L448 109.3V192v32h64V192 32 0H480 320zM32 32H0V64 480v32H32 456h32V480 352 320H424v32 96H64V96h96 32V32H160 32z",
+                            },
+                            children: [],
+                          },
+                        ],
+                      },
                   )
                 }
 

--- a/quartz/plugins/transformers/links.ts
+++ b/quartz/plugins/transformers/links.ts
@@ -86,25 +86,25 @@ export const CrawlLinks: QuartzTransformerPlugin<Partial<Options>> = (userOpts) 
                     refIcon != null
                       ? refIcon
                       : {
-                        type: "element",
-                        tagName: "svg",
-                        properties: {
-                          "aria-hidden": "true",
-                          class: "external-icon",
-                          style: "max-width:0.8em;max-height:0.8em",
-                          viewBox: "0 0 512 512",
-                        },
-                        children: [
-                          {
-                            type: "element",
-                            tagName: "path",
-                            properties: {
-                              d: "M320 0H288V64h32 82.7L201.4 265.4 178.7 288 224 333.3l22.6-22.6L448 109.3V192v32h64V192 32 0H480 320zM32 32H0V64 480v32H32 456h32V480 352 320H424v32 96H64V96h96 32V32H160 32z",
-                            },
-                            children: [],
+                          type: "element",
+                          tagName: "svg",
+                          properties: {
+                            "aria-hidden": "true",
+                            class: "external-icon",
+                            style: "max-width:0.8em;max-height:0.8em",
+                            viewBox: "0 0 512 512",
                           },
-                        ],
-                      },
+                          children: [
+                            {
+                              type: "element",
+                              tagName: "path",
+                              properties: {
+                                d: "M320 0H288V64h32 82.7L201.4 265.4 178.7 288 224 333.3l22.6-22.6L448 109.3V192v32h64V192 32 0H480 320zM32 32H0V64 480v32H32 456h32V480 352 320H424v32 96H64V96h96 32V32H160 32z",
+                              },
+                              children: [],
+                            },
+                          ],
+                        },
                   )
                 }
 

--- a/quartz/plugins/transformers/links.ts
+++ b/quartz/plugins/transformers/links.ts
@@ -12,7 +12,9 @@ import {
 import path from "path"
 import { visit } from "unist-util-visit"
 import isAbsoluteUrl from "is-absolute-url"
-import { Root } from "hast"
+import { ElementContent, Root } from "hast"
+
+type Sub = [RegExp, string | ElementContent]
 
 interface Options {
   /** How to resolve Markdown paths */
@@ -22,6 +24,7 @@ interface Options {
   openLinksInNewTab: boolean
   lazyLoad: boolean
   externalLinkIcon: boolean
+  substitutions?: Sub[]
 }
 
 const defaultOptions: Options = {
@@ -55,32 +58,54 @@ export const CrawlLinks: QuartzTransformerPlugin<Partial<Options>> = (userOpts) 
                 node.properties &&
                 typeof node.properties.href === "string"
               ) {
-                let dest = node.properties.href as RelativeURL
+                let href = node.properties.href
+                var dest = href as RelativeURL
+                var refIcon: string | ElementContent | null = null
+                var matched = false
+                opts.substitutions?.every(([regex, sub]) => {
+                  let parts = href.match(regex)
+                  if (parts != null) {
+                    dest = parts.slice(1).join("") as RelativeURL
+                    if (typeof sub == "object") {
+                      refIcon = sub
+                    } else {
+                      refIcon = { type: "text", value: sub }
+                    }
+                    matched = true
+                    return false // break equivalent
+                  }
+                  return true
+                })
+                node.properties.href = dest
                 const classes = (node.properties.className ?? []) as string[]
                 const isExternal = isAbsoluteUrl(dest)
                 classes.push(isExternal ? "external" : "internal")
 
-                if (isExternal && opts.externalLinkIcon) {
-                  node.children.push({
-                    type: "element",
-                    tagName: "svg",
-                    properties: {
-                      "aria-hidden": "true",
-                      class: "external-icon",
-                      style: "max-width:0.8em;max-height:0.8em",
-                      viewBox: "0 0 512 512",
-                    },
-                    children: [
-                      {
+                if ((isExternal && opts.externalLinkIcon) || matched) {
+                  node.children.push(
+                    refIcon != null
+                      ? refIcon
+                      : {
                         type: "element",
-                        tagName: "path",
+                        tagName: "svg",
                         properties: {
-                          d: "M320 0H288V64h32 82.7L201.4 265.4 178.7 288 224 333.3l22.6-22.6L448 109.3V192v32h64V192 32 0H480 320zM32 32H0V64 480v32H32 456h32V480 352 320H424v32 96H64V96h96 32V32H160 32z",
+                          "aria-hidden": "true",
+                          class: "external-icon",
+                          style: "max-width:0.8em;max-height:0.8em",
+                          viewBox: "0 0 512 512",
                         },
-                        children: [],
+                        children: [
+                          {
+                            type: "element",
+                            tagName: "path",
+                            properties: {
+                              d: "M320 0H288V64h32 82.7L201.4 265.4 178.7 288 224 333.3l22.6-22.6L448 109.3V192v32h64V192 32 0H480 320zM32 32H0V64 480v32H32 456h32V480 352 320H424v32 96H64V96h96 32V32H160 32z",
+                            },
+                            children: [],
+                          },
+                        ],
                       },
-                    ],
-                  })
+                  )
                 }
 
                 // Check if the link has alias text


### PR DESCRIPTION
{ *I am pathologically incapable of rebasing, apparently --* #1653 }

This feature gives site authors more control over how links are displayed. You can define a regex that, on match, will auto-append either a string of your choice (so, an emoji) or a Hast element such as a vector path or an image to the link in the rendered HTML.

As an example, I have a substitution:
```ts
[
  /Qx!(.+)/, // Qx!https://quartz.jzhao.xyz
  Image("/static/external-quartz.png"), // I went into paint and magic wand deleted the background of the Quartz favicon
]
```
Which for `[Quartz](Qx!https://quartz.jzhao.xyz)` yields:
![image](https://github.com/user-attachments/assets/580e0f47-245d-4fa6-9e57-04dfd861cc50)
which links to the correct website as specified in the capturing group.

changes:
- [x] switch from requiring manual hast to newtypes for the three most common use cases: `Image`, `Path`, or `Emoji`
- [ ] discuss -- should this be as freeform as a regex, or should it be constrained to a prefix for better ergonomics and a lower barrier to entry?
- [x] documentation
- [ ] favicon newtype - see [the pond: transformers/AddFavicons](https://github.com/alexander-turner/TurnTrout.com/blob/main/quartz/plugins/transformers/linkfavicons.ts)
  - behavior: if `Favicon()` is a replacement, then links matching that regex will attempt to fetch their favicon and put it after the link. Could also set this to automatically attempt for all links like the plugin linked as inspiration, but I'd also like to expose it as optional per-link should the author define a substitution like `[/f!(.+)/, Favicon()]`