### PR TITLE
fix(popover): show description for tagPage

### DIFF
--- a/quartz/components/pages/TagContent.tsx
+++ b/quartz/components/pages/TagContent.tsx
@@ -110,7 +110,7 @@ export default ((opts?: Partial<TagContentOptions>) => {
 
       return (
         <div class={classes}>
-          <article>{content}</article>
+          <article class="popover-hint">{content}</article>
           <div class="page-listing">
             <p>{i18n(cfg.locale).pages.tagContent.itemsUnderTag({ count: pages.length })}</p>
             <div>


### PR DESCRIPTION
A tiny oneliner fix

<details>
<summary>Before</summary>

![image](https://github.com/user-attachments/assets/38d2d83d-ca5e-44d7-b6a4-26e3705e5333)
</details>

<details>
<summary>After</summary>

![image](https://github.com/user-attachments/assets/582f4220-5510-4b7d-98aa-c6225c1dbaae)
</details>
