### PR TITLE
fix(tags): Set consistent titles for tags with description pages

### DIFF
--- a/quartz/plugins/emitters/tagPage.tsx
+++ b/quartz/plugins/emitters/tagPage.tsx
@@ -105,6 +105,9 @@ export const TagPage: QuartzEmitterPlugin<Partial<TagPageOptions>> = (userOpts) 
           const tag = slug.slice("tags/".length)
           if (tags.has(tag)) {
             tagDescriptions[tag] = [tree, file]
+            if (file.data.frontmatter?.title === tag) {
+              file.data.frontmatter.title = `${i18n(cfg.locale).pages.tagContent.tag}: ${tag}`
+            }
           }
         }
       }


### PR DESCRIPTION
Right now for some tag `my-tag` a tag page with title `Tag: my-tag` is generated.
However if you create a page `tags/my-tag.md` to add a description the page will have the title `my-tag` by default.

Set the tag page title to have the `Tag: ` prefix if the tag page does not have a custom title for consistency between tags with and without descriptions.

<details>
<summary>Before</summary>

![image](https://github.com/user-attachments/assets/38d2d83d-ca5e-44d7-b6a4-26e3705e5333)
(yes it's the same screenshot lol)
</details>

<details>
<summary>After</summary>

![image](https://github.com/user-attachments/assets/529d59d4-b5ae-4363-9390-667690be3d64)
</details>

<details>
<summary>Tag without a dedicated page</summary>

![image](https://github.com/user-attachments/assets/9859492f-d5fb-4463-b50b-18ed0ae18022)
</details>

Don't like modifying the frontmatter like that, but it's done like that in other places.
Also if user specifically wants the page to have the title of a tag without the `Tag: ` prefix they can't do that easily (could add a ZWJ or some other unicode nonsense to spoof the string equality as a hack).
But imo this is better than what it was.

