### PR TITLE
feat(tags): Allow separating page tags from frontmatter tags

### DIFF
--- a/docs/plugins/ObsidianFlavoredMarkdown.md
+++ b/docs/plugins/ObsidianFlavoredMarkdown.md
@@ -16,7 +16,7 @@ This plugin accepts the following configuration options:
 - `wikilinks`:If `true` (default), turns [[wikilinks]] into regular links.
 - `callouts`: If `true` (default), adds support for [[callouts|callout]] blocks for emphasizing content.
 - `mermaid`: If `true` (default), enables [[Mermaid diagrams|Mermaid diagram]] rendering within Markdown files.
-- `parseTags`: If `true` (default), parses and links tags within the content.
+- `parseTags`: If `true` (default), parses and links tags within the content. This marks the page as tagged with those tags, you can set `parseTags` to `"link-only"` to only turn content tags into links.
 - `parseArrows`: If `true` (default), transforms arrow symbols into their HTML character equivalents.
 - `parseBlockReferences`: If `true` (default), handles block references, linking to specific content blocks.
 - `enableInHtmlEmbed`: If `true`, allows embedding of content directly within HTML. Defaults to `false`.

--- a/quartz/plugins/emitters/tagPage.tsx
+++ b/quartz/plugins/emitters/tagPage.tsx
@@ -17,10 +17,16 @@ import { TagContent } from "../../components"
 import { write } from "./helpers"
 import { i18n } from "../../i18n"
 import DepGraph from "../../depgraph"
+import { Data } from "vfile"
 
 interface TagPageOptions extends FullPageLayout {
   sort?: (f1: QuartzPluginData, f2: QuartzPluginData) => number
 }
+
+const getTags = ({ frontmatter, tagLinks }: Data) => [
+  ...(frontmatter?.tags ?? []),
+  ...(tagLinks ?? []),
+]
 
 export const TagPage: QuartzEmitterPlugin<Partial<TagPageOptions>> = (userOpts) => {
   const opts: FullPageLayout = {
@@ -55,7 +61,7 @@ export const TagPage: QuartzEmitterPlugin<Partial<TagPageOptions>> = (userOpts) 
 
       for (const [_tree, file] of content) {
         const sourcePath = file.data.filePath!
-        const tags = (file.data.frontmatter?.tags ?? []).flatMap(getAllSegmentPrefixes)
+        const tags = getTags(file.data).flatMap(getAllSegmentPrefixes)
         // if the file has at least one tag, it is used in the tag index page
         if (tags.length > 0) {
           tags.push("index")
@@ -76,9 +82,7 @@ export const TagPage: QuartzEmitterPlugin<Partial<TagPageOptions>> = (userOpts) 
       const allFiles = content.map((c) => c[1].data)
       const cfg = ctx.cfg.configuration
 
-      const tags: Set<string> = new Set(
-        allFiles.flatMap((data) => data.frontmatter?.tags ?? []).flatMap(getAllSegmentPrefixes),
-      )
+      const tags: Set<string> = new Set(allFiles.flatMap(getTags).flatMap(getAllSegmentPrefixes))
 
       // add base tag
       tags.add("index")

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -31,7 +31,7 @@ export interface Options {
   wikilinks: boolean
   callouts: boolean
   mermaid: boolean
-  parseTags: boolean
+  parseTags: boolean | "link-only"
   parseArrows: boolean
   parseBlockReferences: boolean
   enableInHtmlEmbed: boolean
@@ -338,9 +338,13 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options>>
                 }
 
                 tag = slugTag(tag)
-                if (file.data.frontmatter) {
+                if (opts.parseTags != "link-only" && file.data.frontmatter) {
                   const noteTags = file.data.frontmatter.tags ?? []
                   file.data.frontmatter.tags = [...new Set([...noteTags, tag])]
+                } else {
+                  // We store the content tags so that the tagPage can be generated even
+                  // if there's no pages tagged with them through the frontmatter
+                  file.data.tagLinks = (file.data.tagLinks ?? new Set()).add(tag)
                 }
 
                 return {
@@ -828,5 +832,6 @@ declare module "vfile" {
     blocks: Record<string, Element>
     htmlAst: HtmlRoot
     hasMermaidDiagram: boolean | undefined
+    tagLinks: Set<string>
   }
 }


### PR DESCRIPTION
I feel like tags in note content are just links to the tag page, and shouldn't mark the page with that tag.

~~Also the way it was done - adding content tags to frontmatter - interferes with my WIP page properties component, I want to only show "explicitly put in the frontmatter" tags.~~
(I made the frontmatter transformer add a `frontmatterRaw` copy to the file data to avoid this and a few other issues, so this no longer applies.)

Added an option to have those "outgoing" tags that don't tag the page, yet get a tag page generated (so that the popover is not 404 if there are no pages with this tag).

<details>
<summary>parseTags: true</summary>

![image](https://github.com/user-attachments/assets/f93fe2a1-c9f5-44ef-80bf-03e0658d8e81)
</details>


<details>
<summary>parseTags: "link-only"</summary>

![image](https://github.com/user-attachments/assets/e075bb8a-e3dd-41a5-a90c-5cae38dc9db2)
</details>

