### PR TITLE
feat(frontmatter): Add an option to index frontmatter wikilinks

### DIFF
--- a/docs/plugins/CrawlLinks.md
+++ b/docs/plugins/CrawlLinks.md
@@ -19,6 +19,7 @@ This plugin accepts the following configuration options:
 - `openLinksInNewTab`: If `true`, configures external links to open in a new tab. Defaults to `false`.
 - `lazyLoad`: If `true`, adds lazy loading to resource elements (`img`, `video`, etc.) to improve page load performance. Defaults to `false`.
 - `externalLinkIcon`: Adds an icon next to external links when `true` (default) to visually distinguishing them from internal links.
+- `indexFrontmatterWikilinks`: If `true`, parses Obsidian-style wikilinks in the frontmatter and adds them to the graph (including things like backlinks) as if they were part of the note content. Defaults to `false`.
 
 > [!warning]
 > Removing this plugin is _not_ recommended and will likely break the page.


### PR DESCRIPTION
I was missing this feature and implemented it, not knowing that there was #944 already ¯\\\_(ツ)_/¯

Looking at it now I think that my impl is a little better, and I'd love to have it upstreamed.
Ready to get review comments, I know the option name is meh.

Closes #820 and #944

<details>
<summary>Before</summary>

![image](https://github.com/user-attachments/assets/8ee146dd-a9a5-4af7-ba27-e650a0c0ead2)
</details>


<details>
<summary>After (with indexFrontmatterWikilinks: true)</summary>

![image](https://github.com/user-attachments/assets/92e39561-da58-44d4-a8ba-d6188a09e344)

With my frontmatter component :)

![image](https://github.com/user-attachments/assets/7d266b40-1e6d-4e0f-9503-738630e222be)
</details>


