### PR TITLE
feat(backlinks): hide by default when empty

### DIFF
--- a/docs/features/backlinks.md
+++ b/docs/features/backlinks.md
@@ -9,7 +9,7 @@ A backlink for a note is a link from another note to that note. Links in the bac
 ## Customization
 
 - Removing backlinks: delete all usages of `Component.Backlinks()` from `quartz.layout.ts`.
-- Hide when empty: use `Component.Backlinks({ hideWhenEmpty: true })` to hide the backlinks component completely when there are no backlinks.
+- Hide when empty: hide `Backlinks` if given page doesn't contain any backlinks (default to `true`). To disable this, use `Component.Backlinks({ hideWhenEmpty: false })`.
 - Component: `quartz/components/Backlinks.tsx`
 - Style: `quartz/components/styles/backlinks.scss`
 - Script: `quartz/components/scripts/search.inline.ts`

--- a/docs/features/backlinks.md
+++ b/docs/features/backlinks.md
@@ -9,6 +9,7 @@ A backlink for a note is a link from another note to that note. Links in the bac
 ## Customization
 
 - Removing backlinks: delete all usages of `Component.Backlinks()` from `quartz.layout.ts`.
+- Hide when empty: use `Component.Backlinks({ hideWhenEmpty: true })` to hide the backlinks component completely when there are no backlinks.
 - Component: `quartz/components/Backlinks.tsx`
 - Style: `quartz/components/styles/backlinks.scss`
 - Script: `quartz/components/scripts/search.inline.ts`

--- a/quartz/components/Backlinks.tsx
+++ b/quartz/components/Backlinks.tsx
@@ -9,7 +9,7 @@ interface BacklinksOptions {
 }
 
 const defaultOptions: BacklinksOptions = {
-  hideWhenEmpty: false,
+  hideWhenEmpty: true,
 }
 
 export default ((opts?: Partial<BacklinksOptions>) => {

--- a/quartz/components/Backlinks.tsx
+++ b/quartz/components/Backlinks.tsx
@@ -4,33 +4,49 @@ import { resolveRelative, simplifySlug } from "../util/path"
 import { i18n } from "../i18n"
 import { classNames } from "../util/lang"
 
-const Backlinks: QuartzComponent = ({
-  fileData,
-  allFiles,
-  displayClass,
-  cfg,
-}: QuartzComponentProps) => {
-  const slug = simplifySlug(fileData.slug!)
-  const backlinkFiles = allFiles.filter((file) => file.links?.includes(slug))
-  return (
-    <div class={classNames(displayClass, "backlinks")}>
-      <h3>{i18n(cfg.locale).components.backlinks.title}</h3>
-      <ul class="overflow">
-        {backlinkFiles.length > 0 ? (
-          backlinkFiles.map((f) => (
-            <li>
-              <a href={resolveRelative(fileData.slug!, f.slug!)} class="internal">
-                {f.frontmatter?.title}
-              </a>
-            </li>
-          ))
-        ) : (
-          <li>{i18n(cfg.locale).components.backlinks.noBacklinksFound}</li>
-        )}
-      </ul>
-    </div>
-  )
+interface BacklinksOptions {
+  hideWhenEmpty: boolean
 }
 
-Backlinks.css = style
-export default (() => Backlinks) satisfies QuartzComponentConstructor
+const defaultOptions: BacklinksOptions = {
+  hideWhenEmpty: false,
+}
+
+export default ((opts?: Partial<BacklinksOptions>) => {
+  const options: BacklinksOptions = { ...defaultOptions, ...opts }
+
+  const Backlinks: QuartzComponent = ({
+    fileData,
+    allFiles,
+    displayClass,
+    cfg,
+  }: QuartzComponentProps) => {
+    const slug = simplifySlug(fileData.slug!)
+    const backlinkFiles = allFiles.filter((file) => file.links?.includes(slug))
+    if (options.hideWhenEmpty && backlinkFiles.length == 0) {
+      return null
+    }
+    return (
+      <div class={classNames(displayClass, "backlinks")}>
+        <h3>{i18n(cfg.locale).components.backlinks.title}</h3>
+        <ul class="overflow">
+          {backlinkFiles.length > 0 ? (
+            backlinkFiles.map((f) => (
+              <li>
+                <a href={resolveRelative(fileData.slug!, f.slug!)} class="internal">
+                  {f.frontmatter?.title}
+                </a>
+              </li>
+            ))
+          ) : (
+            <li>{i18n(cfg.locale).components.backlinks.noBacklinksFound}</li>
+          )}
+        </ul>
+      </div>
+    )
+  }
+
+  Backlinks.css = style
+
+  return Backlinks
+}) satisfies QuartzComponentConstructor


### PR DESCRIPTION
I moved backlinks to `afterBody` and felt it looks better when the component is fully hidden whenever there's no backlinks, so I added that as an option.