### PR TITLE
fix(search): Fix super-inconsistent preview widths in search previews

### DIFF
--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -151,6 +151,7 @@
         }
 
         & > #preview-container {
+          flex-grow: 1;
           display: block;
           overflow: hidden;
           font-family: inherit;


### PR DESCRIPTION
Don't know if this was uncovered by my local setup or just nobody noticed, but page previews were pretty wonky for me

Another oneline fix