### PR TITLE
fix(aliases): Make sure the graph shows aliased pages

### DIFF
--- a/quartz/components/scripts/graph.inline.ts
+++ b/quartz/components/scripts/graph.inline.ts
@@ -101,6 +101,13 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
   const tags: SimpleSlug[] = []
   const validLinks = new Set(data.keys())
 
+  const aliases = new Map<SimpleSlug, SimpleSlug>()
+  for (const [slug, details] of data.entries()) {
+    for (const alias of details.aliases) {
+      aliases.set(simplifySlug(alias), slug)
+    }
+  }
+
   const tweens = new Map<string, TweenNode>()
   for (const [source, details] of data.entries()) {
     const outgoing = details.links ?? []
@@ -108,6 +115,10 @@ async function renderGraph(container: string, fullSlug: FullSlug) {
     for (const dest of outgoing) {
       if (validLinks.has(dest)) {
         links.push({ source: source, target: dest })
+      }
+      const aliased = aliases.get(dest)
+      if (aliased) {
+        links.push({ source: source, target: aliased })
       }
     }
 

--- a/quartz/plugins/emitters/contentIndex.ts
+++ b/quartz/plugins/emitters/contentIndex.ts
@@ -14,6 +14,7 @@ export type ContentDetails = {
   title: string
   links: SimpleSlug[]
   tags: string[]
+  aliases: FullSlug[]
   content: string
   richContent?: string
   date?: Date
@@ -125,6 +126,7 @@ export const ContentIndex: QuartzEmitterPlugin<Partial<Options>> = (opts) => {
             title: file.data.frontmatter?.title!,
             links: file.data.links ?? [],
             tags: file.data.frontmatter?.tags ?? [],
+            aliases: file.data.aliases ?? [],
             content: file.data.text ?? "",
             richContent: opts?.rssFullHtml
               ? escapeHTML(toHtml(tree as Root, { allowDangerousHtml: true }))


### PR DESCRIPTION
Given pages A and B, where B has an alias Z, if page A had a link [[Z]] you'd expect the graph to show an edge from A to B and B to have A as a backlink.

That didn't happen, here's a fix

Depends on #1681 (reusing the `file.data.aliases` introduced there)