### PR TITLE
fix(page-list): enforce intended behavior on GitHub-pages hosted websites

### DIFF
--- a/quartz/components/PageList.tsx
+++ b/quartz/components/PageList.tsx
@@ -42,6 +42,8 @@ export const PageList: QuartzComponent = ({ cfg, fileData, allFiles, limit, sort
       {list.map((page) => {
         const title = page.frontmatter?.title
         const tags = page.frontmatter?.tags ?? []
+        const isFolder = tags.includes("folder")
+        const href = resolveRelative(fileData.slug!, page.slug!) + (isFolder ? "/" : "")
 
         return (
           <li class="section-li">
@@ -51,7 +53,7 @@ export const PageList: QuartzComponent = ({ cfg, fileData, allFiles, limit, sort
               </p>
               <div class="desc">
                 <h3>
-                  <a href={resolveRelative(fileData.slug!, page.slug!)} class="internal">
+                  <a href={href} class="internal">
                     {title}
                   </a>
                 </h3>


### PR DESCRIPTION
Hello! 👋

I've been scratching my head for a while trying to figure out why URLs on my Quartz GitHub Pages site were occasionally missing the repo name:

Desired URL: https://username.github.io/repo-name/a/b/c
Obtained URL: https://username.github.io/a/b/c
This discrepancy often led to frustrating 404 errors.

After some digging, I came across [this issue](https://github.com/jackyzha0/quartz/issues/1013) and its [corresponding fix](https://github.com/jackyzha0/quartz/commit/265faef4e8717eab9678a5515ca9150b7776b148#diff-004aebf9b6ab92dadc6e7a25c433242c73e0640b7c359a77b94841591e904f77R206). While the original fix addressed the issue for specific cases, I realized I was encountering the same problem but with the PageList component. 😄

This PR proposes a similar solution: adding a trailing slash to folder URLs to ensure pathResolution works correctly, by prevent landing on URLs that are missing a slash.

Thank you for your time and consideration! I'm happy to provide more details if needed. 😊

Best regards,
Antoine