### PR TITLE
fix(spa): Fix relative alias redirects

### DIFF
--- a/quartz/components/scripts/util.ts
+++ b/quartz/components/scripts/util.ts
@@ -41,5 +41,5 @@ export async function fetchCanonical(url: URL): Promise<Response> {
   // to allow the caller to read it if it's was not a redirect
   const text = await res.clone().text()
   const [_, redirect] = text.match(canonicalRegex) ?? []
-  return redirect ? fetch(redirect) : res
+  return redirect ? fetch(`${new URL(redirect, url)}`) : res
 }


### PR DESCRIPTION
Missed this in my initial fix, but for subpath hosting support the redirects are relative, and aliases from deeply nested folders try to fetch the wrong thing.

For example:
In page a/b/C.md we have a link [[K]], and in page x/y/Z.md we specify `aliases: K`.
The emitted alias redirect will be x/y/K.html and will redirect to `../Z.html`.

The emitted html link will point to `x/y/K.html`, which the SPA/popover will fetch, read `../Z.html` from it, and try to fetch `a/b/Z.html`, because it'll be relative to where the link is, which is wrong.

So we resolve the relative URL by using the URL constructor and giving it `x/y/K.html` as the base, so that `../Z.html` will correctly resolve