### PR TITLE
fix(path): correct handle URI schemes in joinSegments

### DIFF
--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -185,8 +185,13 @@ export function slugTag(tag: string) {
 export function joinSegments(...args: string[]): string {
   return args
     .filter((segment) => segment !== "")
+    .map((segment, index) =>
+      index === 0
+        ? // Deduplicate but not remove leading slashes for first segment
+          segment.replace(/\/+$/g, "").replace(/^\/\/+/g, "/")
+        : segment.replace(/^\/+|\/+$/g, ""),
+    )
     .join("/")
-    .replace(/\/\/+/g, "/")
 }
 
 export function getAllSegmentPrefixes(tags: string): string[] {


### PR DESCRIPTION
In Head component, joinSegments is used to build a socialUrl with (`https://${baseUrl}`, slug), which causes a slash to be lost in the result.

For example, `joinSegments("https://quartz.jzhao.xyz", "layout")` will return `"https:/quartz.jzhao.xyz/layout"`.

The result is then used in og:url and twitter:url in `<head><meta>`.

This fix tries to preserve each segment, but removes all leading and trailing slashes. In addition, for the first segment, the leading slash is only de-duplicated, not fully trimmed.

> [!NOTE]
> I'm not a TypeScript expert—far from it, actually. If there's a better way to handle this, I'd appreciate any suggestions.
>
> This description is subtly modified from the commit message to conform to the GitHub Flavored Markdown.