### PR TITLE
fix(path): correct socialUrl rendering

### DIFF
--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -152,7 +152,9 @@ export default (() => {
 
     // Url of current page
     const socialUrl =
-      fileData.slug === "404" ? url.toString() : joinSegments(url.toString(), fileData.slug!)
+      fileData.slug === "404"
+        ? url.toString()
+        : `https://${joinSegments(cfg.baseUrl, fileData.slug!)}`
 
     return (
       <head>


### PR DESCRIPTION
Currently, `socialUrl` is incorrectly rendered as `https:/baseUrl/path`, with a missing slash in `://`.

Since `socialUrl` is only used when `cfg.baseUrl` is defined, we can simplify by using `cfg.baseUrl` directly, excluding the scheme portion of the URL.

This fix is much simpler than #1693 , as it avoids modifying a widely used function.