### PR TITLE
chore: use Google Fonts API v2

### DIFF
--- a/quartz/util/og.tsx
+++ b/quartz/util/og.tsx
@@ -35,7 +35,9 @@ export async function getSatoriFont(headerFontName: string, bodyFontName: string
 async function fetchTtf(fontName: string, weight: FontWeight): Promise<ArrayBuffer> {
   try {
     // Get css file from google fonts
-    const cssResponse = await fetch(`https://fonts.googleapis.com/css?family=${fontName}:${weight}`)
+    const cssResponse = await fetch(
+      `https://fonts.googleapis.com/css2?family=${fontName}:wght@${weight}`,
+    )
     const css = await cssResponse.text()
 
     // Extract .ttf url from css file


### PR DESCRIPTION
Hi,

Now, google provide Google Fonts CSS API v2 https://developers.google.com/fonts/docs/css2
Using v1 for ogp generation, I faced an issue on Japanese Fonts.
Fonts got via v1 API do not include Japanese glyph correctly and TOFU fonts shown in generated OGP Image.
After I changed to v2 API, correctly rendered.
While not a radical solution, this fix will help Japanese users.

Regards,
Nanamiiiii