### PR TITLE
feat: provide Biome configuration

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.7.3/schema.json",
+  "formatter": {
+    "enabled": true,
+    "formatWithErrors": false,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 100,
+    "attributePosition": "auto",
+    "ignore": ["**/public", "**/node_modules", "**/.quartz-cache"]
+  },
+  "organizeImports": { "enabled": true },
+  "linter": { "enabled": false, "rules": { "recommended": true } },
+  "javascript": {
+    "formatter": {
+      "jsxQuoteStyle": "double",
+      "quoteProperties": "asNeeded",
+      "trailingComma": "all",
+      "semicolons": "asNeeded",
+      "arrowParentheses": "always",
+      "bracketSpacing": true,
+      "bracketSameLine": false,
+      "attributePosition": "auto"
+    }
+  }
+}


### PR DESCRIPTION
[Biome](https://biomejs.dev/) is an increasingly popular piece of tooling that aims to replace formatters such as Prettier and linters such as ESLint. Written in Rust, it provides a solid performance gain over the tools it seeks to replace, and as such can be quite valuable for contributors who leverage it.

I already use Biome in my fork, both for formatting and linting, however, it seriously messed up my document formatting relative to upstream due to diverging from the defaults. Provided a clean slate, I made a conservative biome config that adheres to existing code style and should reduce friction for those seeking to leverage Biome in the codebase. Linting features are disabled, but could be leveraged in the future for code refactoring, as I find its advice to be generally quite sound.

As the project still treats Prettier as the default, Biome is not included in the dependencies (the config can still be leveraged via `npx` or through editor extensions). I think it should probably be mentioned somewhere that the code should still go through `format` command in case Biome's formatting diverges from Prettier's overall. 