### PR TITLE
fix(goatcounter): properly count SPA page hits

### DIFF
--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -122,12 +122,14 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
     `)
   } else if (cfg.analytics?.provider === "goatcounter") {
     componentResources.afterDOMLoaded.push(`
-      const goatcounterScript = document.createElement("script")
-      goatcounterScript.src = "${cfg.analytics.scriptSrc ?? "https://gc.zgo.at/count.js"}"
-      goatcounterScript.async = true
-      goatcounterScript.setAttribute("data-goatcounter",
-        "https://${cfg.analytics.websiteId}.${cfg.analytics.host ?? "goatcounter.com"}/count")
-      document.head.appendChild(goatcounterScript)
+      document.addEventListener("nav", () => {
+        const goatcounterScript = document.createElement("script")
+        goatcounterScript.src = "${cfg.analytics.scriptSrc ?? "https://gc.zgo.at/count.js"}"
+        goatcounterScript.async = true
+        goatcounterScript.setAttribute("data-goatcounter",
+          "https://${cfg.analytics.websiteId}.${cfg.analytics.host ?? "goatcounter.com"}/count")
+        document.head.appendChild(goatcounterScript)
+      })
     `)
   } else if (cfg.analytics?.provider === "posthog") {
     componentResources.afterDOMLoaded.push(`


### PR DESCRIPTION
On the surface it seems that only google and plausible scripts handle
the SPA correctly - but I don't know if maybe others handle
window.history API themselves somehow or something like that.

However, I am trying out goatcounter and in it's docs I see that it
does no special SPA handling, so this has to be added.

Note:
The whole `significantLoad` thing is to correctly count things -
goatcounter will not be loaded and initialized yet when the initial
"nav" is dispatched (because of the weird dynamic script tag insertion
thing you guys have going on here), but it will count that page load
when it itself is loaded.

If there was a way to ensure goatcounter is loaded before the first
nav, you could just configure it to not count anything on it's own load
(like in their spa [example](https://www.goatcounter.com/help/spa)) and
have the "nav" call it unconditionally, but that's not the case 🤷
