### PR TITLE
feat(i18n): add Thai translations

### DIFF
--- a/quartz/i18n/index.ts
+++ b/quartz/i18n/index.ts
@@ -22,6 +22,7 @@ import fa from "./locales/fa-IR"
 import pl from "./locales/pl-PL"
 import cs from "./locales/cs-CZ"
 import tr from "./locales/tr-TR"
+import th from "./locales/th-TH"
 
 export const TRANSLATIONS = {
   "en-US": enUs,
@@ -68,6 +69,7 @@ export const TRANSLATIONS = {
   "pl-PL": pl,
   "cs-CZ": cs,
   "tr-TR": tr,
+  "th-TH": th,
 } as const
 
 export const defaultTranslation = "en-US"

--- a/quartz/i18n/locales/th-TH.ts
+++ b/quartz/i18n/locales/th-TH.ts
@@ -1,0 +1,82 @@
+import { Translation } from "./definition"
+
+export default {
+  propertyDefaults: {
+    title: "ไม่มีชื่อ",
+    description: "ไม่ได้ระบุคำอธิบายย่อ",
+  },
+  components: {
+    callout: {
+      note: "หมายเหตุ",
+      abstract: "บทคัดย่อ",
+      info: "ข้อมูล",
+      todo: "ต้องทำเพิ่มเติม",
+      tip: "คำแนะนำ",
+      success: "เรียบร้อย",
+      question: "คำถาม",
+      warning: "คำเตือน",
+      failure: "ข้อผิดพลาด",
+      danger: "อันตราย",
+      bug: "บั๊ก",
+      example: "ตัวอย่าง",
+      quote: "คำพูกยกมา",
+    },
+    backlinks: {
+      title: "หน้าที่กล่าวถึง",
+      noBacklinksFound: "ไม่มีหน้าที่โยงมาหน้านี้",
+    },
+    themeToggle: {
+      lightMode: "โหมดสว่าง",
+      darkMode: "โหมดมืด",
+    },
+    explorer: {
+      title: "รายการหน้า",
+    },
+    footer: {
+      createdWith: "สร้างด้วย",
+    },
+    graph: {
+      title: "มุมมองกราฟ",
+    },
+    recentNotes: {
+      title: "บันทึกล่าสุด",
+      seeRemainingMore: ({ remaining }) => `ดูเพิ่มอีก ${remaining} รายการ →`,
+    },
+    transcludes: {
+      transcludeOf: ({ targetSlug }) => `รวมข้ามเนื้อหาจาก ${targetSlug}`,
+      linkToOriginal: "ดูหน้าต้นทาง",
+    },
+    search: {
+      title: "ค้นหา",
+      searchBarPlaceholder: "ค้นหาบางอย่าง",
+    },
+    tableOfContents: {
+      title: "สารบัญ",
+    },
+    contentMeta: {
+      readingTime: ({ minutes }) => `อ่านราว ${minutes} นาที`,
+    },
+  },
+  pages: {
+    rss: {
+      recentNotes: "บันทึกล่าสุด",
+      lastFewNotes: ({ count }) => `${count} บันทึกล่าสุด`,
+    },
+    error: {
+      title: "ไม่มีหน้านี้",
+      notFound: "หน้านี้อาจตั้งค่าเป็นส่วนตัวหรือยังไม่ถูกสร้าง",
+      home: "กลับหน้าหลัก",
+    },
+    folderContent: {
+      folder: "โฟลเดอร์",
+      itemsUnderFolder: ({ count }) => `มี ${count} รายการในโฟลเดอร์นี้`,
+    },
+    tagContent: {
+      tag: "แท็ก",
+      tagIndex: "แท็กทั้งหมด",
+      itemsUnderTag: ({ count }) => `มี ${count} รายการในแท็กนี้`,
+      showingFirst: ({ count }) => `แสดง ${count} แท็กแรก`,
+      totalTags: ({ count }) => `มีทั้งหมด ${count} แท็ก`,
+    },
+  },
+} as const satisfies Translation


### PR DESCRIPTION
This pull request adds support for the Thai language support. The most important changes include importing the Thai language file, adding the Thai translations to the `TRANSLATIONS` object, and creating a new file with the Thai translations.

### Thai language support:

* [`quartz/i18n/index.ts`](diffhunk://#diff-b18cbbd9903c624cac2174f106e360258196c1aa301a2ad767572f0c609d5343R25): Imported the Thai language file and added the Thai translations to the `TRANSLATIONS` object. [[1]](diffhunk://#diff-b18cbbd9903c624cac2174f106e360258196c1aa301a2ad767572f0c609d5343R25) [[2]](diffhunk://#diff-b18cbbd9903c624cac2174f106e360258196c1aa301a2ad767572f0c609d5343R72)
* [`quartz/i18n/locales/th-TH.ts`](diffhunk://#diff-758c7c7691cc8f19c1a57917a8b587118f534dbe7722484906782d1bb93b5349R1-R82): Created a new file with Thai translations for various components and pages.