### PR TITLE
fix: only show files that are actually in the folder

### DIFF
--- a/quartz/components/pages/FolderContent.tsx
+++ b/quartz/components/pages/FolderContent.tsx
@@ -28,7 +28,7 @@ export default ((opts?: Partial<FolderContentOptions>) => {
 
   const FolderContent: QuartzComponent = (props: QuartzComponentProps) => {
     const { tree, fileData, allFiles, cfg } = props
-    const folderSlug = stripSlashes(simplifySlug(fileData.slug!))
+    const folderSlug = simplifySlug(fileData.slug!)
     const folderParts = folderSlug.split(path.posix.sep)
 
     const allPagesInFolder: QuartzPluginData[] = []
@@ -36,7 +36,7 @@ export default ((opts?: Partial<FolderContentOptions>) => {
 
     allFiles.forEach((file) => {
       const fileSlug = stripSlashes(simplifySlug(file.slug!))
-      const prefixed = fileSlug.startsWith(`${folderSlug}/`) && fileSlug !== folderSlug
+      const prefixed = fileSlug.startsWith(folderSlug) && fileSlug !== folderSlug
       const fileParts = fileSlug.split(path.posix.sep)
       const isDirectChild = fileParts.length === folderParts.length + 1
 

--- a/quartz/components/pages/FolderContent.tsx
+++ b/quartz/components/pages/FolderContent.tsx
@@ -36,7 +36,7 @@ export default ((opts?: Partial<FolderContentOptions>) => {
 
     allFiles.forEach((file) => {
       const fileSlug = stripSlashes(simplifySlug(file.slug!))
-      const prefixed = fileSlug.startsWith(folderSlug) && fileSlug !== folderSlug
+      const prefixed = fileSlug.startsWith(`${folderSlug}/`) && fileSlug !== folderSlug
       const fileParts = fileSlug.split(path.posix.sep)
       const isDirectChild = fileParts.length === folderParts.length + 1
 


### PR DESCRIPTION
Currently, it shows all files that start with the same characters as the folder e.g

```
/folder
 test.md
/folder1
 test2.md
```
If you look in the /folder page it will also show test2.md.

This pr makes sure the files are in the specified folder.