### PR TITLE
feat(i18n): Lithuanian

### DIFF
--- a/quartz/i18n/index.ts
+++ b/quartz/i18n/index.ts
@@ -23,6 +23,7 @@ import pl from "./locales/pl-PL"
 import cs from "./locales/cs-CZ"
 import tr from "./locales/tr-TR"
 import th from "./locales/th-TH"
+import lt from "./locales/lt-LT"
 
 export const TRANSLATIONS = {
   "en-US": enUs,
@@ -70,6 +71,7 @@ export const TRANSLATIONS = {
   "cs-CZ": cs,
   "tr-TR": tr,
   "th-TH": th,
+  "lt-LT": lt,
 } as const
 
 export const defaultTranslation = "en-US"

--- a/quartz/i18n/locales/lt-LT.ts
+++ b/quartz/i18n/locales/lt-LT.ts
@@ -1,0 +1,87 @@
+import { Translation } from "./definition"
+
+export default {
+  propertyDefaults: {
+    title: "Be Pavadinimo",
+    description: "Aprašymas Nepateiktas",
+  },
+  components: {
+    callout: {
+      note: "Pastaba",
+      abstract: "Santrauka",
+      info: "Informacija",
+      todo: "Darbų sąrašas",
+      tip: "Patarimas",
+      success: "Sėkmingas",
+      question: "Klausimas",
+      warning: "Įspėjimas",
+      failure: "Nesėkmingas",
+      danger: "Pavojus",
+      bug: "Klaida",
+      example: "Pavyzdys",
+      quote: "Citata",
+    },
+    backlinks: {
+      title: "Atgalinės Nuorodos",
+      noBacklinksFound: "Atgalinių Nuorodų Nerasta",
+    },
+    themeToggle: {
+      lightMode: "Šviesus Režimas",
+      darkMode: "Tamsus Režimas",
+    },
+    explorer: {
+      title: "Naršyklė",
+    },
+    footer: {
+      createdWith: "Sukurta Su",
+    },
+    graph: {
+      title: "Grafiko Vaizdas",
+    },
+    recentNotes: {
+      title: "Naujausi Užrašai",
+      seeRemainingMore: ({ remaining }) => `Peržiūrėti dar ${remaining} →`,
+    },
+    transcludes: {
+      transcludeOf: ({ targetSlug }) => `Įterpimas iš ${targetSlug}`,
+      linkToOriginal: "Nuoroda į originalą",
+    },
+    search: {
+      title: "Paieška",
+      searchBarPlaceholder: "Ieškoti",
+    },
+    tableOfContents: {
+      title: "Turinys",
+    },
+    contentMeta: {
+      readingTime: ({ minutes }) => `${minutes} min skaitymo`,
+    },
+  },
+  pages: {
+    rss: {
+      recentNotes: "Naujausi užrašai",
+      lastFewNotes: ({ count }) => 
+        count === 1 ? "Paskutinis 1 užrašas" : count < 10 ? `Paskutiniai ${count} užrašai` : `Paskutiniai ${count} užrašų`,
+    },
+    error: {
+      title: "Nerasta",
+      notFound: "Arba šis puslapis yra pasiekiamas tik tam tikriems vartotojams, arba tokio puslapio nėra.",
+      home: "Grįžti į pagrindinį puslapį",
+    },
+    folderContent: {
+      folder: "Aplankas",
+      itemsUnderFolder: ({ count }) =>
+        count === 1 ? "1 elementas šiame aplanke." : count < 10 ? `${count} elementai šiame aplanke.` : `${count} elementų šiame aplanke.`,
+    },
+    tagContent: {
+      tag: "Žyma",
+      tagIndex: "Žymų indeksas",
+      itemsUnderTag: ({ count }) =>
+        count === 1 ? "1 elementas su šia žyma." : count < 10 ? `${count} elementai su šia žyma.` : `${count} elementų su šia žyma.`,
+      showingFirst: ({ count }) => 
+        count < 10 ? `Rodomos pirmosios ${count} žymos.` : `Rodomos pirmosios ${count} žymų.`,
+      totalTags: ({ count }) =>
+        count === 1 ? "Rasta iš viso 1 žyma." : count < 10 ? `Rasta iš viso ${count} žymos.` : `Rasta iš viso ${count} žymų.`,
+    },
+  },
+} as const satisfies Translation

--- a/quartz/i18n/locales/lt-LT.ts
+++ b/quartz/i18n/locales/lt-LT.ts
@@ -60,28 +60,45 @@ export default {
   pages: {
     rss: {
       recentNotes: "Naujausi užrašai",
-      lastFewNotes: ({ count }) => 
-        count === 1 ? "Paskutinis 1 užrašas" : count < 10 ? `Paskutiniai ${count} užrašai` : `Paskutiniai ${count} užrašų`,
+      lastFewNotes: ({ count }) =>
+        count === 1
+          ? "Paskutinis 1 užrašas"
+          : count < 10
+            ? `Paskutiniai ${count} užrašai`
+            : `Paskutiniai ${count} užrašų`,
     },
     error: {
       title: "Nerasta",
-      notFound: "Arba šis puslapis yra pasiekiamas tik tam tikriems vartotojams, arba tokio puslapio nėra.",
+      notFound:
+        "Arba šis puslapis yra pasiekiamas tik tam tikriems vartotojams, arba tokio puslapio nėra.",
       home: "Grįžti į pagrindinį puslapį",
     },
     folderContent: {
       folder: "Aplankas",
       itemsUnderFolder: ({ count }) =>
-        count === 1 ? "1 elementas šiame aplanke." : count < 10 ? `${count} elementai šiame aplanke.` : `${count} elementų šiame aplanke.`,
+        count === 1
+          ? "1 elementas šiame aplanke."
+          : count < 10
+            ? `${count} elementai šiame aplanke.`
+            : `${count} elementų šiame aplanke.`,
     },
     tagContent: {
       tag: "Žyma",
       tagIndex: "Žymų indeksas",
       itemsUnderTag: ({ count }) =>
-        count === 1 ? "1 elementas su šia žyma." : count < 10 ? `${count} elementai su šia žyma.` : `${count} elementų su šia žyma.`,
-      showingFirst: ({ count }) => 
+        count === 1
+          ? "1 elementas su šia žyma."
+          : count < 10
+            ? `${count} elementai su šia žyma.`
+            : `${count} elementų su šia žyma.`,
+      showingFirst: ({ count }) =>
         count < 10 ? `Rodomos pirmosios ${count} žymos.` : `Rodomos pirmosios ${count} žymų.`,
       totalTags: ({ count }) =>
-        count === 1 ? "Rasta iš viso 1 žyma." : count < 10 ? `Rasta iš viso ${count} žymos.` : `Rasta iš viso ${count} žymų.`,
+        count === 1
+          ? "Rasta iš viso 1 žyma."
+          : count < 10
+            ? `Rasta iš viso ${count} žymos.`
+            : `Rasta iš viso ${count} žymų.`,
     },
   },
 } as const satisfies Translation


### PR DESCRIPTION
# Initial (2025-01-21)
This pull request adds support for the Lithuanian language.
- [feat(i18n)-lithuanian-translations_implemented-lt-translations](https://github.com/jackyzha0/quartz/commit/b1e0d29a1a783445cafb9b15b39fe88e1888ecf9) Created a new file `lt-LT` in locales with correct translations into Lithuanian language.
- [feat(i18n)-lithuanian-translations_defined-lt-translation](https://github.com/jackyzha0/quartz/commit/306e69eb4a35874a1c460896d3211c449e46c6b9) Defined new `lt-LT` translation into `TRANSLATIONS` object.
- [feat(i18n)-lithuanian-translations_fixed-code-style](https://github.com/jackyzha0/quartz/pull/1733/commits/03357f6a0d943a6706fbfdc2b127bfdc296a4348) Fixed code style with predefined configuration.