### PR TITLE
feat(frontmatter) Visibility

### DIFF
--- a/quartz/components/ArticleTitle.tsx
+++ b/quartz/components/ArticleTitle.tsx
@@ -3,7 +3,8 @@ import { classNames } from "../util/lang"
 
 const ArticleTitle: QuartzComponent = ({ fileData, displayClass }: QuartzComponentProps) => {
   const title = fileData.frontmatter?.title
-  if (title) {
+  const visible = fileData.frontmatter?.visible
+  if (title && visible) {
     return <h1 class={classNames(displayClass, "article-title")}>{title}</h1>
   } else {
     return null

--- a/quartz/components/Breadcrumbs.tsx
+++ b/quartz/components/Breadcrumbs.tsx
@@ -59,8 +59,9 @@ export default ((opts?: Partial<BreadcrumbOptions>) => {
     allFiles,
     displayClass,
   }: QuartzComponentProps) => {
-    // Hide crumbs on root if enabled
-    if (options.hideOnRoot && fileData.slug === "index") {
+    const visible = fileData.frontmatter?.visible
+    // Hide crumbs on root if enabled or if visible is false
+    if ((options.hideOnRoot && fileData.slug === "index") || !visible) {
       return <></>
     }
 

--- a/quartz/components/ContentMeta.tsx
+++ b/quartz/components/ContentMeta.tsx
@@ -25,8 +25,9 @@ export default ((opts?: Partial<ContentMetaOptions>) => {
 
   function ContentMetadata({ cfg, fileData, displayClass }: QuartzComponentProps) {
     const text = fileData.text
+    const visible = fileData.frontmatter?.visible
 
-    if (text) {
+    if (text && visible) {
       const segments: (string | JSX.Element)[] = []
 
       if (fileData.dates) {

--- a/quartz/components/TagList.tsx
+++ b/quartz/components/TagList.tsx
@@ -4,8 +4,9 @@ import { classNames } from "../util/lang"
 
 const TagList: QuartzComponent = ({ fileData, displayClass }: QuartzComponentProps) => {
   const tags = fileData.frontmatter?.tags
+  const visible = fileData.frontmatter?.visible
   const baseDir = pathToRoot(fileData.slug!)
-  if (tags && tags.length > 0) {
+  if (tags && tags.length > 0 && visible) {
     return (
       <ul class={classNames(displayClass, "tags")}>
         {tags.map((tag) => {

--- a/quartz/plugins/transformers/frontmatter.ts
+++ b/quartz/plugins/transformers/frontmatter.ts
@@ -87,6 +87,13 @@ export const FrontMatter: QuartzTransformerPlugin<Partial<Options>> = (userOpts)
 
             if (socialImage) data.socialImage = socialImage
 
+            if (data.visible != null) {
+              // set visible to false only when provided correct value, otherwise default to true
+              data.visible = !(data.visible.toString().trim().toLowerCase() === "false")
+            } else {
+              data.visible = true
+            }
+
             // fill in frontmatter
             file.data.frontmatter = data as QuartzPluginData["frontmatter"]
           }
@@ -114,6 +121,7 @@ declare module "vfile" {
         cssclasses: string[]
         socialImage: string
         comments: boolean | string
+        visible: boolean
       }>
   }
 }


### PR DESCRIPTION
# Initial (2025-01-21)
### Logic
This feature introduces a new `optional` frontmatter field `visible` which enhances the flexibility of markdown files by allowing components in the `beforeBody` section (using default repository page layout) to be conditionally hidden. This addition provides both flexibility and simplicity for content-driven design.

The `visible` field provides a simple mechanism to control the visibility of specific UI elements such as `Breadcrumbs`, `ArticleTitle`, `ContentMeta`, and `TagList` on pages rendered from markdown files. When the visible field is set to false, these components are not displayed on the page.

### Use Case
A common scenario where this feature proves useful is for pages like landing pages, where the design often includes a banner at the top that doubles as the article title. By setting `visible: false`, developers can remove redundant elements, resulting in a cleaner and more tailored presentation for specific pages.

### Example of Landing Page
A markdown file could include a banner component at the top, serving as the primary visual focus and title for the page. By using the `visible` field, developers can suppress unnecessary `beforeBody` components that might detract from the intended layout.

```md
---
title: Welcome to Quartz
tag: Entry
visible: false
---

<div align="center">
  <img src="/static/og-image.png" style="width: 600px; height: auto;">
</div>

### Project Overview
EcoSphere is a mobile application designed to promote sustainable living by helping users track their environmental
impact, adopt eco-friendly habits, and connect with a community of like-minded individuals.
```

_visible set to true_
![visible_true](https://github.com/user-attachments/assets/1b554547-e931-43aa-b64b-153beff41519)

_visible set to false_
![visible_false](https://github.com/user-attachments/assets/c2eac756-6af2-43a5-9f00-699f395bd710)

### Better Implementation Suggestion
While the current implementation works as described, a more robust approach might involve conditionally checking the visible field at the layout level. If visible is set to false, the entire `beforeBody` layout component could be excluded. This would result in a cleaner and more centralized way of managing the visibility logic. It would also resolve the issue when there is custom configuration done to layout (added new components into `beforeBody` layout component).

However, I am not familiar with the full details of the codebase, so I wasn’t able to implement this better solution. If this approach aligns with the project’s vision, I’d be happy to update the implementation with guidance, or you’re welcome to make modifications as needed. I recognize that this change may not align with the overall goals or vision of the project. If so, feel free to suggest improvements, discuss alternative implementations, or reject this pull request entirely.

### Commits
- [feat(frontmatter)-visibility_defined-frontmatter-visible-field](https://github.com/jackyzha0/quartz/commit/4bc8834f250057938a8f8e02a5de5a91819d4346) Implemented optional frontmatter field `visible`.
- [feat(frontmatter)-visibility_visibility-checking-in-beforebody](https://github.com/jackyzha0/quartz/commit/05fcdf49387940e2fa34100be9299542ae43d7f6) Added conditional checks in separate components that are in `beforeBody` component.

