### PR TITLE
fix(fonts): update `system-ui` trick for wider support range

### DIFF
--- a/quartz/util/theme.ts
+++ b/quartz/util/theme.ts
@@ -29,7 +29,7 @@ export interface Theme {
 export type ThemeKey = keyof Colors
 
 const DEFAULT_SANS_SERIF =
-  '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif'
+  'system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"'
 const DEFAULT_MONO = "ui-monospace, SFMono-Regular, SF Mono, Menlo, monospace"
 
 export function googleFontHref(theme: Theme) {


### PR DESCRIPTION
The default sans-serif font stack doesn't contain any popular Linux fonts, due to which the font falls back to Helvetica and Arial if the `fontOrigin` property is set to `local` in `quartz.config.ts`.

We can fix this by specifying some popular Linux system fonts in the list:
- `Oxygen-Sans` : default on KDE Plasma systems
- `Ubuntu` : default font on Ubuntu
- `Cantarell` : default for GNOME based systems 

Reference: [CSS Tricks: System Font Stack](https://css-tricks.com/snippets/css/system-font-stack/)