### PR TITLE
feat(ofm): inline footnotes support

### DIFF
--- a/docs/plugins/ObsidianFlavoredMarkdown.md
+++ b/docs/plugins/ObsidianFlavoredMarkdown.md
@@ -23,7 +23,7 @@ This plugin accepts the following configuration options:
 - `enableYouTubeEmbed`: If `true` (default), enables the embedding of YouTube videos and playlists using external image Markdown syntax.
 - `enableVideoEmbed`: If `true` (default), enables the embedding of video files.
 - `enableCheckbox`: If `true`, adds support for interactive checkboxes in content. Defaults to `false`.
-- `inlineFootnotes`: If `true` (default), enables parsing of inline footnotes.
+- `enableInlineFootnotes`: If `true` (default), enables parsing of inline footnotes.
 
 > [!warning]
 > Don't remove this plugin if you're using [[Obsidian compatibility|Obsidian]] to author the content!

--- a/docs/plugins/ObsidianFlavoredMarkdown.md
+++ b/docs/plugins/ObsidianFlavoredMarkdown.md
@@ -23,6 +23,7 @@ This plugin accepts the following configuration options:
 - `enableYouTubeEmbed`: If `true` (default), enables the embedding of YouTube videos and playlists using external image Markdown syntax.
 - `enableVideoEmbed`: If `true` (default), enables the embedding of video files.
 - `enableCheckbox`: If `true`, adds support for interactive checkboxes in content. Defaults to `false`.
+- `inlineFootnotes`: If `true` (default), enables parsing of inline footnotes.
 
 > [!warning]
 > Don't remove this plugin if you're using [[Obsidian compatibility|Obsidian]] to author the content!

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -225,13 +225,13 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options>>
       if (opts.enableInlineFootnotes) {
         // Replaces ^[inline] footnotes with regular footnotes [^1]:
         const footnotes: Record<string, string> = {}
-        let counter = 1
+        let counter = 0
 
         // Replace inline footnotes with references and collect definitions
         const result = (src as string).replace(
           inlineFootnoteRegex,
           (_match: string, content: string) => {
-            const id = `inline-${counter++}`
+            const id = `generated-inline-footnote-${counter++}`
             footnotes[id] = content.trim()
             return `[^${id}]`
           },

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -231,7 +231,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options>>
           },
         )
 
-        // Append footnote definitions if we found any
+        // Append footnote definitions if any are found
         if (Object.keys(footnotes).length > 0) {
           return (
             result +

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -222,7 +222,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options>>
         const footnotes: Record<string, string> = {}
         
         // Replace inline footnotes with references and collect definitions
-        const result = src.replace(inlineFootnoteRegex, (_match, content) => {
+        const result = (src as string).replace(inlineFootnoteRegex, (_match: string, content: string) => {
           const id = `inline-${Math.random().toString(36).substring(2, 8)}`
           footnotes[id] = content.trim()
           return `[^${id}]`

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -54,7 +54,7 @@ const defaultOptions: Options = {
   enableInHtmlEmbed: false,
   enableYouTubeEmbed: true,
   enableVideoEmbed: true,
-  enableCheckbox: true,
+  enableCheckbox: false,
   inlineFootnotes: true,
 }
 

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -220,19 +220,27 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options>>
       if (opts.inlineFootnotes) {
         // Replaces ^[inline] footnotes with regular footnotes [^1]:
         const footnotes: Record<string, string> = {}
-        
+
         // Replace inline footnotes with references and collect definitions
-        const result = (src as string).replace(inlineFootnoteRegex, (_match: string, content: string) => {
-          const id = `inline-${Math.random().toString(36).substring(2, 8)}`
-          footnotes[id] = content.trim()
-          return `[^${id}]`
-        })
+        const result = (src as string).replace(
+          inlineFootnoteRegex,
+          (_match: string, content: string) => {
+            const id = `inline-${Math.random().toString(36).substring(2, 8)}`
+            footnotes[id] = content.trim()
+            return `[^${id}]`
+          },
+        )
 
         // Append footnote definitions if we found any
         if (Object.keys(footnotes).length > 0) {
-          return result + "\n\n" + Object.entries(footnotes)
-            .map(([id, content]) => `[^${id}]: ${content}`)
-            .join("\n") + "\n"
+          return (
+            result +
+            "\n\n" +
+            Object.entries(footnotes)
+              .map(([id, content]) => `[^${id}]: ${content}`)
+              .join("\n") +
+            "\n"
+          )
         }
 
         return result

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -225,7 +225,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options>>
         const result = (src as string).replace(
           inlineFootnoteRegex,
           (_match: string, content: string) => {
-            const id = `inline-${Math.random().toString(36).substring(2, 8)}`
+            const id = `inline-${Object.keys(footnotes).length + 1}`
             footnotes[id] = content.trim()
             return `[^${id}]`
           },


### PR DESCRIPTION
Supports `^[inline footnotes]` by replacing them with regular footnotes and appending the references to the original src.

### Example
```
This is a sentence without inline footnotes.   
This is a sentence with one inline footnote.^[inline footnote 1]  
Sentence with two^[two] inline footnotes ^[inline footnotes]  
It handles footnotes with wikilinks ^[footnote with [[wikilink]] inside]  
It handles footnotes with regular links^[Link to [youtube](https://youtube.com)]  
Regular footnotes can still be used.[^1]  
[^1]: It's true.
```
![image](https://github.com/user-attachments/assets/0826b455-9697-4d6f-a587-6b4400733599)





