### PR TITLE
feat(i18n): add Finnish translations for i18n

### DIFF
--- a/quartz/i18n/index.ts
+++ b/quartz/i18n/index.ts
@@ -24,6 +24,7 @@ import cs from "./locales/cs-CZ"
 import tr from "./locales/tr-TR"
 import th from "./locales/th-TH"
 import lt from "./locales/lt-LT"
+import fi from "./locales/fi-FI"
 
 export const TRANSLATIONS = {
   "en-US": enUs,
@@ -72,6 +73,7 @@ export const TRANSLATIONS = {
   "tr-TR": tr,
   "th-TH": th,
   "lt-LT": lt,
+  "fi-FI": fi,
 } as const
 
 export const defaultTranslation = "en-US"

--- a/quartz/i18n/locales/fi-FI.ts
+++ b/quartz/i18n/locales/fi-FI.ts
@@ -1,0 +1,84 @@
+import { Translation } from "./definition"
+
+export default {
+  propertyDefaults: {
+    title: "Nimetön",
+    description: "Ei kuvausta saatavilla",
+  },
+  components: {
+    callout: {
+      note: "Merkintä",
+      abstract: "Tiivistelmä",
+      info: "Info",
+      todo: "Tehtävälista",
+      tip: "Vinkki",
+      success: "Onnistuminen",
+      question: "Kysymys",
+      warning: "Varoitus",
+      failure: "Epäonnistuminen",
+      danger: "Vaara",
+      bug: "Virhe",
+      example: "Esimerkki",
+      quote: "Lainaus",
+    },
+    backlinks: {
+      title: "Takalinkit",
+      noBacklinksFound: "Takalinkkejä ei löytynyt",
+    },
+    themeToggle: {
+      lightMode: "Vaalea tila",
+      darkMode: "Tumma tila",
+    },
+    explorer: {
+      title: "Selain",
+    },
+    footer: {
+      createdWith: "Luotu käyttäen",
+    },
+    graph: {
+      title: "Verkkonäkymä",
+    },
+    recentNotes: {
+      title: "Viimeisimmät muistiinpanot",
+      seeRemainingMore: ({ remaining }) => `Näytä ${remaining} lisää →`,
+    },
+    transcludes: {
+      transcludeOf: ({ targetSlug }) => `Upote kohteesta ${targetSlug}`,
+      linkToOriginal: "Linkki alkuperäiseen",
+    },
+    search: {
+      title: "Haku",
+      searchBarPlaceholder: "Hae jotain",
+    },
+    tableOfContents: {
+      title: "Sisällysluettelo",
+    },
+    contentMeta: {
+      readingTime: ({ minutes }) => `${minutes} min lukuaika`,
+    },
+  },
+  pages: {
+    rss: {
+      recentNotes: "Viimeisimmät muistiinpanot",
+      lastFewNotes: ({ count }) => `Viimeiset ${count} muistiinpanoa`,
+    },
+    error: {
+      title: "Ei löytynyt",
+      notFound: "Tämä sivu on joko yksityinen tai sitä ei ole olemassa.",
+      home: "Palaa etusivulle",
+    },
+    folderContent: {
+      folder: "Kansio",
+      itemsUnderFolder: ({ count }) =>
+        count === 1 ? "1 kohde tässä kansiossa." : `${count} kohdetta tässä kansiossa.`,
+    },
+    tagContent: {
+      tag: "Tunniste",
+      tagIndex: "Tunnisteluettelo",
+      itemsUnderTag: ({ count }) =>
+        count === 1 ? "1 kohde tällä tunnisteella." : `${count} kohdetta tällä tunnisteella.`,
+      showingFirst: ({ count }) => `Näytetään ensimmäiset ${count} tunnistetta.`,
+      totalTags: ({ count }) => `Löytyi yhteensä ${count} tunnistetta.`,
+    },
+  },
+} as const satisfies Translation


### PR DESCRIPTION
I noticed that localization looks quite simple for Quartz, so I added a quick Finnish translation for my own project. I decided to offer it separately here, if you want it. Let me know if I missed any "hidden" places that need to be localized in addition to these!