### PR TITLE
fix(graph): mobile global graph overlay

### DIFF
--- a/quartz/components/styles/explorer.scss
+++ b/quartz/components/styles/explorer.scss
@@ -4,7 +4,6 @@
   .page > #quartz-body {
     // Shift page position when toggling Explorer on mobile.
     & > :not(.sidebar.left:has(.explorer)) {
-      transform: translateX(0);
       transition: transform 300ms ease-in-out;
     }
     &.lock-scroll > :not(.sidebar.left:has(.explorer)) {


### PR DESCRIPTION
Global graph overlay was not properly displaying on mobile. This was because the mobile version of the Explorer component has a translate transform of 0, thus making it the new [Containing Block](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_display/Containing_block) instead of the viewport. We can safely remove this CSS rule, as it is only applied when the mobile Explorer is closed.