### PR TITLE
Fix CreatedModifiedDate plugin when storing content in a separate repo

### DIFF
--- a/quartz/plugins/transformers/lastmod.ts
+++ b/quartz/plugins/transformers/lastmod.ts
@@ -35,6 +35,7 @@ export const CreatedModifiedDate: QuartzTransformerPlugin<Partial<Options>> = (u
       return [
         () => {
           let repo: Repository | undefined = undefined
+          let repoRoot: string | undefined = undefined
           return async (_tree, file) => {
             let created: MaybeDate = undefined
             let modified: MaybeDate = undefined
@@ -56,11 +57,14 @@ export const CreatedModifiedDate: QuartzTransformerPlugin<Partial<Options>> = (u
                   // Get a reference to the main git repo.
                   // It's either the same as the workdir,
                   // or 1+ level higher in case of a submodule/subtree setup
-                  repo = Repository.discover(file.cwd)
+                  repo = Repository.discover(fp)
+                  repoRoot = path.join(repo.path(), "..")
                 }
 
                 try {
-                  modified ||= await repo.getFileLatestModifiedDateAsync(file.data.filePath!)
+                  modified ||= await repo.getFileLatestModifiedDateAsync(
+                    path.relative(repoRoot!, fp),
+                  )
                 } catch {
                   console.log(
                     chalk.yellow(


### PR DESCRIPTION
Hello. First, thank you for making Quartz - it's a great project.

This patch fixes the date reported when leveraging the `git` option with the `CreatedModifiedDate` plugin and storing content outside of the Quartz repo. Rather than trying to discover the repository from the current working directory (which is always the quartz repo with the way things work right now), this will respect the location of the file itself.