### PR TITLE
Add link to obsidian garden gallery

### DIFF
--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -2,7 +2,9 @@
 title: "Quartz Showcase"
 ---
 
-Want to see what Quartz can do? Here are some cool community gardens:
+Want to see what Quartz can do? 
+Check out [the largest community-driven gallery](https://obsidian-gallery.craftengineer.com/?category=quartz) of sites built on Obsidian, 
+or here are some cool community gardens as well:
 
 - [Quartz Documentation (this site!)](https://quartz.jzhao.xyz/)
 - [Jacky Zhao's Garden](https://jzhao.xyz/)
@@ -33,4 +35,4 @@ Want to see what Quartz can do? Here are some cool community gardens:
 - [Zen Browser Docs](https://docs.zen-browser.app)
 - [🪴8cat life](https://8cat.life)
 
-If you want to see your own on here, submit a [Pull Request adding yourself to this file](https://github.com/jackyzha0/quartz/blob/v4/docs/showcase.md)!
+If you want to add your own site, submit it at [Obsidian Garden Gallery](https://obsidian-gallery.craftengineer.com/?category=quartz)


### PR DESCRIPTION
Recently, I have launched obsidian sites gallery [https://obsidian-gallery.craftengineer.com/](https://obsidian-gallery.craftengineer.com/?category=quartz), and it was quite nicely accepted by the community (launch post on [Reddit](https://www.reddit.com/r/ObsidianMD/comments/1iihmgx/showcase_gallery_of_sitesgardens_built_with/)). 

Today, I have added support for Quartz websites as well, so users can submit their sites built with quartz and if approved by the community, the site will appear in the gallery - it reduces the burden of creating PR with every single new site (plus,, it is more accessible for creators to share their websites, since they do not need to work with github)

I hope you will consider this because it helps a lot for quartz users to share their vaults with the rest of the community :) 
