### PR TITLE
feat(rss): configurable RSS feed URL

### DIFF
--- a/docs/features/RSS Feed.md
+++ b/docs/features/RSS Feed.md
@@ -1,7 +1,7 @@
 Quartz emits an RSS feed for all the content on your site by generating an `index.xml` file that RSS readers can subscribe to. Because of the RSS spec, this requires the `baseUrl` property in your [[configuration]] to be set properly for RSS readers to pick it up properly.
 
 > [!info]
-> After deploying, the generated RRS link will be available at `https://${baseUrl}/index.xml`.
+> After deploying, the generated RSS link will be available at `https://${baseUrl}/index.xml`.
 >
 > The `index` part can be customized by passing the `rssSlug` option to the [[ContentIndex]] plugin.
 

--- a/docs/features/RSS Feed.md
+++ b/docs/features/RSS Feed.md
@@ -1,9 +1,9 @@
 Quartz emits an RSS feed for all the content on your site by generating an `index.xml` file that RSS readers can subscribe to. Because of the RSS spec, this requires the `baseUrl` property in your [[configuration]] to be set properly for RSS readers to pick it up properly.
 
 > [!info]
-> After deploying, the generated RSS link will be available at `https://${baseUrl}/index.xml`.
+> After deploying, the generated RSS link will be available at `https://${baseUrl}/index.xml` by default.
 >
-> The `index` part can be customized by passing the `rssSlug` option to the [[ContentIndex]] plugin.
+> The `index.xml` path can be customized by passing the `rssSlug` option to the [[ContentIndex]] plugin.
 
 ## Configuration
 

--- a/docs/features/RSS Feed.md
+++ b/docs/features/RSS Feed.md
@@ -1,5 +1,10 @@
 Quartz emits an RSS feed for all the content on your site by generating an `index.xml` file that RSS readers can subscribe to. Because of the RSS spec, this requires the `baseUrl` property in your [[configuration]] to be set properly for RSS readers to pick it up properly.
 
+> [!info]
+> After deploying, the generated RRS link will be available at `https://${baseUrl}/index.xml`.
+>
+> The `index` part can be customized by passing the `rssSlug` option to the [[ContentIndex]] plugin.
+
 ## Configuration
 
 This functionality is provided by the [[ContentIndex]] plugin. See the plugin page for customization options.

--- a/docs/plugins/ContentIndex.md
+++ b/docs/plugins/ContentIndex.md
@@ -17,6 +17,7 @@ This plugin accepts the following configuration options:
 - `enableRSS`: If `true` (default), produces an RSS feed (`index.xml`) with recent content updates.
 - `rssLimit`: Defines the maximum number of entries to include in the RSS feed, helping to focus on the most recent or relevant content. Defaults to `10`.
 - `rssFullHtml`: If `true`, the RSS feed includes full HTML content. Otherwise it includes just summaries.
+- `rssSlug`: Slug to the generated RSS feed XML file. Defaults to `"index"`.
 - `includeEmptyFiles`: If `true` (default), content files with no body text are included in the generated index and resources.
 
 ## API

--- a/quartz/plugins/emitters/contentIndex.ts
+++ b/quartz/plugins/emitters/contentIndex.ts
@@ -25,6 +25,7 @@ interface Options {
   enableRSS: boolean
   rssLimit?: number
   rssFullHtml: boolean
+  rssSlug: string
   includeEmptyFiles: boolean
 }
 
@@ -33,6 +34,7 @@ const defaultOptions: Options = {
   enableRSS: true,
   rssLimit: 10,
   rssFullHtml: false,
+  rssSlug: "index",
   includeEmptyFiles: true,
 }
 
@@ -151,7 +153,7 @@ export const ContentIndex: QuartzEmitterPlugin<Partial<Options>> = (opts) => {
           await write({
             ctx,
             content: generateRSSFeed(cfg, linkIndex, opts.rssLimit),
-            slug: "index" as FullSlug,
+            slug: (opts?.rssSlug ?? "index") as FullSlug,
             ext: ".xml",
           }),
         )


### PR DESCRIPTION
closes https://github.com/jackyzha0/quartz/issues/1347

Adds `rssSlug` as option to the `ContentIndex` plugin. `rssSlug` is used to customize the location of the RSS feed XML file.

The documentation has been updated to reflect this change.