### PR TITLE
feat(layout): add component customisation options for the index page

### DIFF
--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -36,6 +36,11 @@ export const defaultContentPageLayout: PageLayout = {
   ],
 }
 
+// components for the index page
+export const indexContentPageLayout: PageLayout = {
+  ...defaultContentPageLayout
+}
+
 // components for pages that display lists of pages  (e.g. tags or folders)
 export const defaultListPageLayout: PageLayout = {
   beforeBody: [Component.Breadcrumbs(), Component.ArticleTitle(), Component.ContentMeta()],

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -38,7 +38,7 @@ export const defaultContentPageLayout: PageLayout = {
 
 // components for the index page
 export const indexContentPageLayout: PageLayout = {
-  ...defaultContentPageLayout
+  ...defaultContentPageLayout,
 }
 
 // components for pages that display lists of pages  (e.g. tags or folders)

--- a/quartz/plugins/emitters/contentPage.tsx
+++ b/quartz/plugins/emitters/contentPage.tsx
@@ -10,7 +10,7 @@ import { pageResources, renderPage } from "../../components/renderPage"
 import { FullPageLayout } from "../../cfg"
 import { Argv } from "../../util/ctx"
 import { FilePath, isRelativeURL, joinSegments, pathToRoot } from "../../util/path"
-import { defaultContentPageLayout, sharedPageComponents } from "../../../quartz.layout"
+import { defaultContentPageLayout, indexContentPageLayout, sharedPageComponents } from "../../../quartz.layout"
 import { Content } from "../../components"
 import chalk from "chalk"
 import { write } from "./helpers"
@@ -52,7 +52,7 @@ const parseDependencies = (argv: Argv, hast: Root, file: VFile): string[] => {
 }
 
 export const ContentPage: QuartzEmitterPlugin<Partial<FullPageLayout>> = (userOpts) => {
-  const opts: FullPageLayout = {
+  let opts: FullPageLayout = {
     ...sharedPageComponents,
     ...defaultContentPageLayout,
     pageBody: Content(),
@@ -104,6 +104,12 @@ export const ContentPage: QuartzEmitterPlugin<Partial<FullPageLayout>> = (userOp
         const slug = file.data.slug!
         if (slug === "index") {
           containsIndex = true
+          opts = {
+            ...sharedPageComponents,
+            ...indexContentPageLayout,
+            pageBody: Content(),
+            ...userOpts,
+          } 
         }
 
         const externalResources = pageResources(pathToRoot(slug), file.data, resources)

--- a/quartz/plugins/emitters/contentPage.tsx
+++ b/quartz/plugins/emitters/contentPage.tsx
@@ -10,7 +10,11 @@ import { pageResources, renderPage } from "../../components/renderPage"
 import { FullPageLayout } from "../../cfg"
 import { Argv } from "../../util/ctx"
 import { FilePath, isRelativeURL, joinSegments, pathToRoot } from "../../util/path"
-import { defaultContentPageLayout, indexContentPageLayout, sharedPageComponents } from "../../../quartz.layout"
+import {
+  defaultContentPageLayout,
+  indexContentPageLayout,
+  sharedPageComponents,
+} from "../../../quartz.layout"
 import { Content } from "../../components"
 import chalk from "chalk"
 import { write } from "./helpers"
@@ -109,7 +113,7 @@ export const ContentPage: QuartzEmitterPlugin<Partial<FullPageLayout>> = (userOp
             ...indexContentPageLayout,
             pageBody: Content(),
             ...userOpts,
-          } 
+          }
         }
 
         const externalResources = pageResources(pathToRoot(slug), file.data, resources)


### PR DESCRIPTION
This PR adds the option to customize the components on the index page via the `quartz.layout.ts` file.

For example, to have the local graph have max depth on only the index page modify `indexContentPageLayout` like so:
```ts
export const indexContentPageLayout: PageLayout = {
  ...defaultContentPageLayout,
  right: [
    Component.Graph({
      localGraph: {
        depth: -1
      },
      globalGraph: {}
    })
  ]
}
```