### PR TITLE
feat: five additional configuration options to customize which components are shown on the home page

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -135,10 +135,11 @@ typography: {
 
 The home page is the main web page of your Quartz. The content for the home page lives in `content/index.md`, to change it see [[authoring content|the authoring content guide]].
 
-Customization of the home page can be achieved by conditionally hiding or unhiding components; by passing in a boolean value to the `hideOnRoot:` options in `quartz.config.ts`. The components that support this feature are:
+Customization of the home page can be achieved by conditionally hiding or unhiding components; by passing in a boolean value to the `hideOnRoot{:ts}` option for the components detailed in the `defaultContentPageLayout{:ts}` variable in `quartz.config.ts`. The components that support this feature are:
 
 - [[Backlinks]] are shown by default, to hide them the configuration looks like: `Component.Backlinks({ hideOnRoot: true }){:ts}`
 - [[Breadcrumbs]] are hidden by default, to unhide them the configuration looks like: `Component.Breadcrumbs({ hideOnRoot: false }){:ts}`
 - Date and reading time are shown by default, to hide them the configuration looks like: `Component.ContentMeta({ hideOnRoot: true }){:ts}`
+- [[Explorer]] is shown by default, to hide it the configuration looks like: `Component.Explorer({ hideOnRoot: true }){:ts}`
 
 A differnet method is used to configure the comment box on the home page, see [[Comments#Conditionally display comments|conditionally display comments]].

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -137,6 +137,7 @@ The home page is the main web page of your Quartz. The content for the home page
 
 Customization of the home page can be achieved by conditionally hiding or unhiding components; by passing in a boolean value to the `hideOnRoot:` options in `quartz.config.ts`. The components that support this feature are:
 
+- [[Backlinks]] are shown by default, to hide them the configuration looks like: `Component.Backlinks({ hideOnRoot: true }){:ts}`
 - [[Breadcrumbs]] are hidden by default, to unhide them the configuration looks like: `Component.Breadcrumbs({ hideOnRoot: false }){:ts}`
 - Date and reading time are shown by default, to hide them the configuration looks like: `Component.ContentMeta({ hideOnRoot: true }){:ts}`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -137,6 +137,7 @@ The home page is the main web page of your Quartz. The content for the home page
 
 Customization of the home page can be achieved by conditionally hiding or unhiding components; by passing in a boolean value to the `hideOnRoot{:ts}` option for the components detailed in the `defaultContentPageLayout{:ts}` variable in `quartz.config.ts`. The components that support this feature are:
 
+- Article title is shown by default, to hide it the configuration looks like: `Component.ArticleTitle({hideOnRoot:true}){:ts}`
 - [[Backlinks]] are shown by default, to hide them the configuration looks like: `Component.Backlinks({ hideOnRoot: true }){:ts}`
 - [[Breadcrumbs]] are hidden by default, to unhide them the configuration looks like: `Component.Breadcrumbs({ hideOnRoot: false }){:ts}`
 - Date and reading time are shown by default, to hide them the configuration looks like: `Component.ContentMeta({ hideOnRoot: true }){:ts}`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -142,5 +142,6 @@ Customization of the home page can be achieved by conditionally hiding or unhidi
 - [[Breadcrumbs]] are hidden by default, to unhide them the configuration looks like: `Component.Breadcrumbs({ hideOnRoot: false }){:ts}`
 - Date and reading time are shown by default, to hide them the configuration looks like: `Component.ContentMeta({ hideOnRoot: true }){:ts}`
 - [[Explorer]] is shown by default, to hide it the configuration looks like: `Component.Explorer({ hideOnRoot: true }){:ts}`
+- [[Graph view]] is shown by default, to hide it the configuration looks like: `Component.Graph({ hideOnRoot: true }){:ts}`
 
 A differnet method is used to configure the comment box on the home page, see [[Comments#Conditionally display comments|conditionally display comments]].

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,3 +130,14 @@ typography: {
   ...
 }
 ```
+
+## Home Page
+
+The home page is the main web page of your Quartz. The content for the home page lives in `content/index.md`, to change it see [[authoring content|the authoring content guide]].
+
+Customization of the home page can be achieved by conditionally hiding or unhiding components; by passing in a boolean value to the `hideOnRoot:` options in `quartz.config.ts`. The components that support this feature are:
+
+- [[Breadcrumbs]] are hidden by default, to unhide them the configuration looks like: `Component.Breadcrumbs({ hideOnRoot: false }){:ts}`
+- Date and reading time are shown by default, to hide them the configuration looks like: `Component.ContentMeta({ hideOnRoot: true }){:ts}`
+
+A differnet method is used to configure the comment box on the home page, see [[Comments#Conditionally display comments|conditionally display comments]].

--- a/docs/features/backlinks.md
+++ b/docs/features/backlinks.md
@@ -10,6 +10,7 @@ A backlink for a note is a link from another note to that note. Links in the bac
 
 - Removing backlinks: delete all usages of `Component.Backlinks()` from `quartz.layout.ts`.
 - Hide when empty: hide `Backlinks` if given page doesn't contain any backlinks (default to `true`). To disable this, use `Component.Backlinks({ hideWhenEmpty: false })`.
+- Hide on root: hide `Backlinks` on the home page `content/index.md` (default to `false`). To enable this, use `Component.Backlinks({ hideOnRoot: true })`.
 - Component: `quartz/components/Backlinks.tsx`
 - Style: `quartz/components/styles/backlinks.scss`
 - Script: `quartz/components/scripts/search.inline.ts`

--- a/docs/features/explorer.md
+++ b/docs/features/explorer.md
@@ -42,6 +42,7 @@ Want to customize it even more?
 
 - Removing explorer: remove `Component.Explorer()` from `quartz.layout.ts`
   - (optional): After removing the explorer component, you can move the [[table of contents | Table of Contents]] component back to the `left` part of the layout
+- Hide on root: hide `Explorer` on the home page `content/index.md` (default to `false`). To enable this, use `Component.Explorer({ hideOnRoot: true })`.
 - Changing `sort`, `filter` and `map` behavior: explained in [[#Advanced customization]]
 - Component:
   - Wrapper (Outer component, generates file tree, etc): `quartz/components/Explorer.tsx`

--- a/docs/features/graph view.md
+++ b/docs/features/graph view.md
@@ -23,7 +23,7 @@ Most configuration can be done by passing in options to `Component.Graph()`.
 For example, here's what the default configuration looks like:
 
 ```typescript title="quartz.layout.ts"
-Component.Graph({
+const defaultOptions: GraphOptions = {
   localGraph: {
     drag: true, // whether to allow panning the view around
     zoom: true, // whether to allow zooming in and out
@@ -34,8 +34,9 @@ Component.Graph({
     linkDistance: 30, // how long should the links be by default?
     fontSize: 0.6, // what size should the node labels be?
     opacityScale: 1, // how quickly do we fade out the labels when zooming out?
-    removeTags: [], // what tags to remove from the graph
     showTags: true, // whether to show tags in the graph
+    removeTags: [], // what tags to remove from the graph
+    focusOnHover: false,
     enableRadial: false, // whether to constrain the graph, similar to Obsidian
   },
   globalGraph: {
@@ -44,15 +45,17 @@ Component.Graph({
     depth: -1,
     scale: 0.9,
     repelForce: 0.5,
-    centerForce: 0.3,
+    centerForce: 0.2,
     linkDistance: 30,
     fontSize: 0.6,
     opacityScale: 1,
-    removeTags: [], // what tags to remove from the graph
-    showTags: true, // whether to show tags in the graph
-    enableRadial: true, // whether to constrain the graph, similar to Obsidian
+    showTags: true,
+    removeTags: [],
+    focusOnHover: true,
+    enableRadial: true,
   },
-})
+  hideOnRoot: false
+}
 ```
 
 When passing in your own options, you can omit any or all of these fields if you'd like to keep the default value for that field.

--- a/docs/features/graph view.md
+++ b/docs/features/graph view.md
@@ -54,7 +54,7 @@ const defaultOptions: GraphOptions = {
     focusOnHover: true,
     enableRadial: true,
   },
-  hideOnRoot: false
+  hideOnRoot: false,
 }
 ```
 

--- a/quartz/components/ArticleTitle.tsx
+++ b/quartz/components/ArticleTitle.tsx
@@ -6,7 +6,7 @@ interface ArticleTitleOptions {
 }
 
 const defaultOptions: ArticleTitleOptions = {
-  hideOnRoot: false
+  hideOnRoot: false,
 }
 
 export default ((opts?: Partial<ArticleTitleOptions>) => {

--- a/quartz/components/ArticleTitle.tsx
+++ b/quartz/components/ArticleTitle.tsx
@@ -1,19 +1,36 @@
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
 import { classNames } from "../util/lang"
 
-const ArticleTitle: QuartzComponent = ({ fileData, displayClass }: QuartzComponentProps) => {
-  const title = fileData.frontmatter?.title
-  if (title) {
-    return <h1 class={classNames(displayClass, "article-title")}>{title}</h1>
-  } else {
-    return null
+interface ArticleTitleOptions {
+  hideOnRoot: boolean
+}
+
+const defaultOptions: ArticleTitleOptions = {
+  hideOnRoot: false
+}
+
+export default ((opts?: Partial<ArticleTitleOptions>) => {
+  const options: ArticleTitleOptions = { ...defaultOptions, ...opts }
+
+  const ArticleTitle: QuartzComponent = ({ fileData, displayClass }: QuartzComponentProps) => {
+    // Hide article title on root if enabled
+    if (opts?.hideOnRoot && fileData.slug === "index") {
+      return null
+    }
+
+    const title = fileData.frontmatter?.title
+    if (title) {
+      return <h1 class={classNames(displayClass, "article-title")}>{title}</h1>
+    } else {
+      return null
+    }
   }
-}
 
-ArticleTitle.css = `
-.article-title {
-  margin: 2rem 0 0 0;
-}
-`
+  ArticleTitle.css = `
+  .article-title {
+    margin: 2rem 0 0 0;
+  }
+  `
 
-export default (() => ArticleTitle) satisfies QuartzComponentConstructor
+  return ArticleTitle
+}) satisfies QuartzComponentConstructor

--- a/quartz/components/Backlinks.tsx
+++ b/quartz/components/Backlinks.tsx
@@ -7,10 +7,12 @@ import OverflowListFactory from "./OverflowList"
 
 interface BacklinksOptions {
   hideWhenEmpty: boolean
+  hideOnRoot: boolean
 }
 
 const defaultOptions: BacklinksOptions = {
   hideWhenEmpty: true,
+  hideOnRoot: false
 }
 
 export default ((opts?: Partial<BacklinksOptions>) => {
@@ -23,6 +25,11 @@ export default ((opts?: Partial<BacklinksOptions>) => {
     displayClass,
     cfg,
   }: QuartzComponentProps) => {
+    // Hide backlinks on root if enabled
+    if (options.hideOnRoot && fileData.slug === "index") {
+      return null
+    }
+
     const slug = simplifySlug(fileData.slug!)
     const backlinkFiles = allFiles.filter((file) => file.links?.includes(slug))
     if (options.hideWhenEmpty && backlinkFiles.length == 0) {

--- a/quartz/components/Backlinks.tsx
+++ b/quartz/components/Backlinks.tsx
@@ -12,7 +12,7 @@ interface BacklinksOptions {
 
 const defaultOptions: BacklinksOptions = {
   hideWhenEmpty: true,
-  hideOnRoot: false
+  hideOnRoot: false,
 }
 
 export default ((opts?: Partial<BacklinksOptions>) => {

--- a/quartz/components/ContentMeta.tsx
+++ b/quartz/components/ContentMeta.tsx
@@ -18,7 +18,7 @@ interface ContentMetaOptions {
 const defaultOptions: ContentMetaOptions = {
   showReadingTime: true,
   showComma: true,
-  hideOnRoot: false
+  hideOnRoot: false,
 }
 
 export default ((opts?: Partial<ContentMetaOptions>) => {

--- a/quartz/components/ContentMeta.tsx
+++ b/quartz/components/ContentMeta.tsx
@@ -12,11 +12,13 @@ interface ContentMetaOptions {
    */
   showReadingTime: boolean
   showComma: boolean
+  hideOnRoot: boolean
 }
 
 const defaultOptions: ContentMetaOptions = {
   showReadingTime: true,
   showComma: true,
+  hideOnRoot: false
 }
 
 export default ((opts?: Partial<ContentMetaOptions>) => {
@@ -24,6 +26,11 @@ export default ((opts?: Partial<ContentMetaOptions>) => {
   const options: ContentMetaOptions = { ...defaultOptions, ...opts }
 
   function ContentMetadata({ cfg, fileData, displayClass }: QuartzComponentProps) {
+    // Hide metadata on root if enabled
+    if (options.hideOnRoot && fileData.slug === "index") {
+      return null
+    }
+
     const text = fileData.text
 
     if (text) {

--- a/quartz/components/Explorer.tsx
+++ b/quartz/components/Explorer.tsx
@@ -49,7 +49,7 @@ const defaultOptions: Options = {
   },
   filterFn: (node) => node.slugSegment !== "tags",
   order: ["filter", "map", "sort"],
-  hideOnRoot: false
+  hideOnRoot: false,
 }
 
 export type FolderState = {

--- a/quartz/components/Explorer.tsx
+++ b/quartz/components/Explorer.tsx
@@ -20,6 +20,7 @@ export interface Options {
   filterFn: (node: FileTrieNode) => boolean
   mapFn: (node: FileTrieNode) => void
   order: OrderEntries[]
+  hideOnRoot: boolean
 }
 
 const defaultOptions: Options = {
@@ -48,6 +49,7 @@ const defaultOptions: Options = {
   },
   filterFn: (node) => node.slugSegment !== "tags",
   order: ["filter", "map", "sort"],
+  hideOnRoot: false
 }
 
 export type FolderState = {
@@ -59,7 +61,12 @@ export default ((userOpts?: Partial<Options>) => {
   const opts: Options = { ...defaultOptions, ...userOpts }
   const { OverflowList, overflowListAfterDOMLoaded } = OverflowListFactory()
 
-  const Explorer: QuartzComponent = ({ cfg, displayClass }: QuartzComponentProps) => {
+  const Explorer: QuartzComponent = ({ cfg, fileData, displayClass }: QuartzComponentProps) => {
+    // Hide explorer on root if enabled
+    if (opts.hideOnRoot && fileData.slug === "index") {
+      return null
+    }
+
     return (
       <div
         class={classNames(displayClass, "explorer")}

--- a/quartz/components/Graph.tsx
+++ b/quartz/components/Graph.tsx
@@ -58,7 +58,7 @@ const defaultOptions: GraphOptions = {
     focusOnHover: true,
     enableRadial: true,
   },
-  hideOnRoot: false
+  hideOnRoot: false,
 }
 
 export default ((opts?: Partial<GraphOptions>) => {

--- a/quartz/components/Graph.tsx
+++ b/quartz/components/Graph.tsx
@@ -24,6 +24,7 @@ export interface D3Config {
 interface GraphOptions {
   localGraph: Partial<D3Config> | undefined
   globalGraph: Partial<D3Config> | undefined
+  hideOnRoot: boolean
 }
 
 const defaultOptions: GraphOptions = {
@@ -57,10 +58,16 @@ const defaultOptions: GraphOptions = {
     focusOnHover: true,
     enableRadial: true,
   },
+  hideOnRoot: false
 }
 
 export default ((opts?: Partial<GraphOptions>) => {
-  const Graph: QuartzComponent = ({ displayClass, cfg }: QuartzComponentProps) => {
+  const Graph: QuartzComponent = ({ displayClass, fileData, cfg }: QuartzComponentProps) => {
+    // Hide graph on root if enabled
+    if (opts?.hideOnRoot && fileData.slug === "index") {
+      return null
+    }
+
     const localGraph = { ...defaultOptions.localGraph, ...opts?.localGraph }
     const globalGraph = { ...defaultOptions.globalGraph, ...opts?.globalGraph }
     return (


### PR DESCRIPTION
It uses the same implementation that was used for Breadcrumbs in [PR 508](https://github.com/jackyzha0/quartz/pull/508). That is, the `hideOnRoot` boolean option configured in `quartz.layout.ts`.

The option to hide the article title, date and reading time on the home page was requested in [Issue 1460](https://github.com/jackyzha0/quartz/issues/1460)

ArticleTitle implementations in the wild:
- https://github.com/regexyl/notes-site/blob/46b77b364e33bf2a5ca9353ce6a0726149f987b5/quartz/components/ArticleTitle.tsx#L9

ContentMeta implementations in the wild:
- https://github.com/oestronaut/oestronaut.github.io/blob/c8553357fe47cf0ab59f6efbf7d0a914a0f5b8fa/quartz/components/ContentMeta.tsx#L31
- https://github.com/regexyl/notes-site/blob/46b77b364e33bf2a5ca9353ce6a0726149f987b5/quartz/components/ContentMeta.tsx#L11
- https://github.com/doiotyourself/digital-garden/blob/v4/quartz/components/ContentMeta.tsx#L33

Backlinks implementations in the wild:
- https://github.com/doiotyourself/digital-garden/blob/v4/quartz/components/Backlinks.tsx#L29

Explorer implementations in the wild:
- https://github.com/doiotyourself/digital-garden/blob/v4/quartz/components/Explorer.tsx#L69