### PR TITLE
fix(explorer): vertically center the Explorer toggle under mobile view

### DIFF
--- a/quartz/components/styles/explorer.scss
+++ b/quartz/components/styles/explorer.scss
@@ -52,6 +52,8 @@
     overflow: hidden;
     flex-shrink: 0;
     align-self: flex-start;
+    margin-top: auto;
+    margin-bottom: auto;
   }
 
   button.mobile-explorer {


### PR DESCRIPTION
Before:

<img width="485" alt="image" src="https://github.com/user-attachments/assets/8631d86a-ce56-455b-8f96-9389ff5c8240" />

After:

<img width="446" alt="image" src="https://github.com/user-attachments/assets/075b1805-fcb7-428f-830e-2ab144d5ed9e" />
