### PR TITLE
fix(explorer): vertically center the Explorer toggle under mobile view

### DIFF
--- a/quartz/components/styles/explorer.scss
+++ b/quartz/components/styles/explorer.scss
@@ -52,6 +52,8 @@
     overflow: hidden;
     flex-shrink: 0;
     align-self: flex-start;
+    margin-top: auto;
+    margin-bottom: auto;
   }
 
   button.mobile-explorer {


### PR DESCRIPTION
Before:

<img width="480" alt="image" src="https://github.com/user-attachments/assets/1d530ace-334f-4d36-959f-93258fc319e8" />

After:

<img width="480" alt="image" src="https://github.com/user-attachments/assets/50160697-a0df-40b8-910a-a49c51b1c3e7" />

Demo:

https://draftz.felixnie.com/