### PR TITLE
Fix CreatedModifiedDate plugin when storing content in a separate repo

### DIFF
--- a/quartz/plugins/transformers/lastmod.ts
+++ b/quartz/plugins/transformers/lastmod.ts
@@ -35,6 +35,7 @@ export const CreatedModifiedDate: QuartzTransformerPlugin<Partial<Options>> = (u
       return [
         () => {
           let repo: Repository | undefined = undefined
+          let repoRoot: string | undefined = undefined
           return async (_tree, file) => {
             let created: MaybeDate = undefined
             let modified: MaybeDate = undefined
@@ -57,10 +58,13 @@ export const CreatedModifiedDate: QuartzTransformerPlugin<Partial<Options>> = (u
                   // It's either the same as the workdir,
                   // or 1+ level higher in case of a submodule/subtree setup
                   repo = Repository.discover(ctx.argv.directory)
+                  repoRoot = path.join(repo.path(), "..")
                 }
 
                 try {
-                  modified ||= await repo.getFileLatestModifiedDateAsync(fullFp)
+                  modified ||= await repo.getFileLatestModifiedDateAsync(
+                    path.relative(repoRoot!, fullFp),
+                  )
                 } catch {
                   console.log(
                     chalk.yellow(


### PR DESCRIPTION
Following on from https://github.com/jackyzha0/quartz/pull/1791. The change in https://github.com/jackyzha0/quartz/commit/a7372079817fb1a1e69b2632405d759f9c5e913d did not fix the issue for me. Another important change in my PR was the relative path of the file within the repo that gets passed to `repo.getFileLatestModifiedDateAsync`.