### PR TITLE
fix(ogImage): update socialImage path to include base URL if defined

### DIFF
--- a/docs/plugins/CustomOgImages.md
+++ b/docs/plugins/CustomOgImages.md
@@ -62,7 +62,7 @@ The following properties can be used to customize your link previews:
 | `socialDescription` | `description`    | Description to be used for preview. |
 | `socialImage`       | `image`, `cover` | Link to preview image.              |
 
-The `socialImage` property should contain a link to an image relative to `quartz/static`. If you have a folder for all your images in `quartz/static/my-images`, an example for `socialImage` could be `"my-images/cover.png"`.
+The `socialImage` property should contain a link to an image either relative to `quartz/static`, or a full URL. If you have a folder for all your images in `quartz/static/my-images`, an example for `socialImage` could be `"my-images/cover.png"` or `"https://<base-url>/quartz/static/my-images/conver.png"`.
 
 > [!info] Info
 >

--- a/docs/plugins/CustomOgImages.md
+++ b/docs/plugins/CustomOgImages.md
@@ -62,7 +62,7 @@ The following properties can be used to customize your link previews:
 | `socialDescription` | `description`    | Description to be used for preview. |
 | `socialImage`       | `image`, `cover` | Link to preview image.              |
 
-The `socialImage` property should contain a link to an image either relative to `quartz/static`, or a full URL. If you have a folder for all your images in `quartz/static/my-images`, an example for `socialImage` could be `"my-images/cover.png"` or `"https://<base-url>/quartz/static/my-images/conver.png"`.
+The `socialImage` property should contain a link to an image either relative to `quartz/static`, or a full URL. If you have a folder for all your images in `quartz/static/my-images`, an example for `socialImage` could be `"my-images/cover.png"`. Alternatively, you can use a fully qualified URL like `"https://example.com/cover.png"`.
 
 > [!info] Info
 >

--- a/quartz/plugins/emitters/ogImage.tsx
+++ b/quartz/plugins/emitters/ogImage.tsx
@@ -157,6 +157,7 @@ export const CustomOgImages: QuartzEmitterPlugin<Partial<SocialImageOptions>> = 
               userDefinedOgImagePath = isAbsoluteFilePath(socialImage)
                 ? socialImage
                 : `https://${baseUrl}/static/${socialImage}`
+            }
 
             const generatedOgImagePath = isRealFile
               ? `https://${baseUrl}/${pageData.slug!}-og-image.webp`

--- a/quartz/plugins/emitters/ogImage.tsx
+++ b/quartz/plugins/emitters/ogImage.tsx
@@ -150,12 +150,11 @@ export const CustomOgImages: QuartzEmitterPlugin<Partial<SocialImageOptions>> = 
         additionalHead: [
           (pageData) => {
             const isRealFile = pageData.filePath !== undefined
-            const socialImage = pageData.frontmatter?.socialImage
+            let userDefinedOgImagePath = pageData.frontmatter?.socialImage
 
-            let userDefinedOgImagePath = undefined
-            if (socialImage) {
-              userDefinedOgImagePath = isAbsoluteFilePath(socialImage)
-                ? socialImage
+            if (userDefinedOgImagePath) {
+              userDefinedOgImagePath = isAbsoluteFilePath(userDefinedOgImagePath)
+                ? userDefinedOgImagePath
                 : `https://${baseUrl}/static/${socialImage}`
             }
 

--- a/quartz/plugins/emitters/ogImage.tsx
+++ b/quartz/plugins/emitters/ogImage.tsx
@@ -155,7 +155,7 @@ export const CustomOgImages: QuartzEmitterPlugin<Partial<SocialImageOptions>> = 
             if (userDefinedOgImagePath) {
               userDefinedOgImagePath = isAbsoluteFilePath(userDefinedOgImagePath)
                 ? userDefinedOgImagePath
-                : `https://${baseUrl}/static/${socialImage}`
+                : `https://${baseUrl}/static/${userDefinedOgImagePath}`
             }
 
             const generatedOgImagePath = isRealFile

--- a/quartz/plugins/emitters/ogImage.tsx
+++ b/quartz/plugins/emitters/ogImage.tsx
@@ -145,6 +145,8 @@ export const CustomOgImages: QuartzEmitterPlugin<Partial<SocialImageOptions>> = 
           (pageData) => {
             const isRealFile = pageData.filePath !== undefined
             const userDefinedOgImagePath = pageData.frontmatter?.socialImage
+              ? `https://${baseUrl}/static/${pageData.frontmatter?.socialImage}`
+              : undefined
             const generatedOgImagePath = isRealFile
               ? `https://${baseUrl}/${pageData.slug!}-og-image.webp`
               : undefined

--- a/quartz/plugins/emitters/ogImage.tsx
+++ b/quartz/plugins/emitters/ogImage.tsx
@@ -1,7 +1,13 @@
 import { QuartzEmitterPlugin } from "../types"
 import { i18n } from "../../i18n"
 import { unescapeHTML } from "../../util/escape"
-import { FullSlug, getFileExtension, joinSegments, QUARTZ } from "../../util/path"
+import {
+  FullSlug,
+  getFileExtension,
+  isAbsoluteFilePath,
+  joinSegments,
+  QUARTZ,
+} from "../../util/path"
 import { ImageOptions, SocialImageOptions, defaultImage, getSatoriFonts } from "../../util/og"
 import sharp from "sharp"
 import satori, { SatoriOptions } from "satori"
@@ -144,9 +150,14 @@ export const CustomOgImages: QuartzEmitterPlugin<Partial<SocialImageOptions>> = 
         additionalHead: [
           (pageData) => {
             const isRealFile = pageData.filePath !== undefined
-            const userDefinedOgImagePath = pageData.frontmatter?.socialImage
-              ? `https://${baseUrl}/static/${pageData.frontmatter?.socialImage}`
-              : undefined
+            const socialImage = pageData.frontmatter?.socialImage
+
+            let userDefinedOgImagePath = undefined
+            if (socialImage) {
+              userDefinedOgImagePath = isAbsoluteFilePath(socialImage)
+                ? socialImage
+                : `https://${baseUrl}/static/${socialImage}`
+
             const generatedOgImagePath = isRealFile
               ? `https://${baseUrl}/${pageData.slug!}-og-image.webp`
               : undefined

--- a/quartz/plugins/emitters/ogImage.tsx
+++ b/quartz/plugins/emitters/ogImage.tsx
@@ -1,14 +1,7 @@
 import { QuartzEmitterPlugin } from "../types"
 import { i18n } from "../../i18n"
 import { unescapeHTML } from "../../util/escape"
-import {
-  FullSlug,
-  getFileExtension,
-  isFullUrl,
-  isRelativeURL,
-  joinSegments,
-  QUARTZ,
-} from "../../util/path"
+import { FullSlug, getFileExtension, isAbsoluteURL, joinSegments, QUARTZ } from "../../util/path"
 import { ImageOptions, SocialImageOptions, defaultImage, getSatoriFonts } from "../../util/og"
 import sharp from "sharp"
 import satori, { SatoriOptions } from "satori"
@@ -154,9 +147,9 @@ export const CustomOgImages: QuartzEmitterPlugin<Partial<SocialImageOptions>> = 
             let userDefinedOgImagePath = pageData.frontmatter?.socialImage
 
             if (userDefinedOgImagePath) {
-              userDefinedOgImagePath = isRelativeURL(userDefinedOgImagePath)
-                ? `https://${baseUrl}/static/${userDefinedOgImagePath}`
-                : userDefinedOgImagePath
+              userDefinedOgImagePath = isAbsoluteURL(userDefinedOgImagePath)
+                ? userDefinedOgImagePath
+                : `https://${baseUrl}/static/${userDefinedOgImagePath}`
             }
 
             const generatedOgImagePath = isRealFile
@@ -164,7 +157,7 @@ export const CustomOgImages: QuartzEmitterPlugin<Partial<SocialImageOptions>> = 
               : undefined
             const defaultOgImagePath = `https://${baseUrl}/static/og-image.png`
             const ogImagePath = userDefinedOgImagePath ?? generatedOgImagePath ?? defaultOgImagePath
-
+            console.log("ogImagePath", ogImagePath)
             const ogImageMimeType = `image/${getFileExtension(ogImagePath) ?? "png"}`
             return (
               <>

--- a/quartz/plugins/emitters/ogImage.tsx
+++ b/quartz/plugins/emitters/ogImage.tsx
@@ -4,7 +4,8 @@ import { unescapeHTML } from "../../util/escape"
 import {
   FullSlug,
   getFileExtension,
-  isAbsoluteFilePath,
+  isFullUrl,
+  isRelativeURL,
   joinSegments,
   QUARTZ,
 } from "../../util/path"
@@ -153,9 +154,9 @@ export const CustomOgImages: QuartzEmitterPlugin<Partial<SocialImageOptions>> = 
             let userDefinedOgImagePath = pageData.frontmatter?.socialImage
 
             if (userDefinedOgImagePath) {
-              userDefinedOgImagePath = isAbsoluteFilePath(userDefinedOgImagePath)
-                ? userDefinedOgImagePath
-                : `https://${baseUrl}/static/${socialImage}`
+              userDefinedOgImagePath = isRelativeURL(userDefinedOgImagePath)
+                ? `https://${baseUrl}/static/${userDefinedOgImagePath}`
+                : userDefinedOgImagePath
             }
 
             const generatedOgImagePath = isRealFile

--- a/quartz/plugins/emitters/ogImage.tsx
+++ b/quartz/plugins/emitters/ogImage.tsx
@@ -157,7 +157,6 @@ export const CustomOgImages: QuartzEmitterPlugin<Partial<SocialImageOptions>> = 
               : undefined
             const defaultOgImagePath = `https://${baseUrl}/static/og-image.png`
             const ogImagePath = userDefinedOgImagePath ?? generatedOgImagePath ?? defaultOgImagePath
-            console.log("ogImagePath", ogImagePath)
             const ogImageMimeType = `image/${getFileExtension(ogImagePath) ?? "png"}`
             return (
               <>

--- a/quartz/util/path.test.ts
+++ b/quartz/util/path.test.ts
@@ -38,6 +38,17 @@ describe("typeguards", () => {
     assert(!path.isRelativeURL("./abc/def.md"))
   })
 
+  test("isAbsoluteURL", () => {
+    assert(path.isAbsoluteURL("https://example.com"))
+    assert(path.isAbsoluteURL("http://example.com"))
+    assert(path.isAbsoluteURL("ftp://example.com/a/b/c"))
+    assert(path.isAbsoluteURL("http://host/%25"))
+    assert(path.isAbsoluteURL("file://host/twoslashes?more//slashes"))
+
+    assert(!path.isAbsoluteURL("example.com/abc/def"))
+    assert(!path.isAbsoluteURL("abc"))
+  })
+
   test("isFullSlug", () => {
     assert(path.isFullSlug("index"))
     assert(path.isFullSlug("abc/def"))

--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -15,6 +15,11 @@ export function isFilePath(s: string): s is FilePath {
   return validStart && _hasFileExtension(s)
 }
 
+export function isAbsoluteFilePath(s: string): s is FilePath {
+  const parsedUrl = new URL(s)
+  return !parsedUrl.protocol
+}
+
 /** Cannot be relative and may not have leading or trailing slashes. It can have `index` as it's last segment. Use this wherever possible is it's the most 'general' interpretation of a slug. */
 export type FullSlug = SlugLike<"full">
 export function isFullSlug(s: string): s is FullSlug {

--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -1,7 +1,6 @@
 import { slug as slugAnchor } from "github-slugger"
 import type { Element as HastElement } from "hast"
 import { clone } from "./clone"
-import { URL } from "url"
 
 // this file must be isomorphic so it can't use node libs (e.g. path)
 

--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -1,6 +1,8 @@
 import { slug as slugAnchor } from "github-slugger"
 import type { Element as HastElement } from "hast"
 import { clone } from "./clone"
+import { URL } from "url"
+
 // this file must be isomorphic so it can't use node libs (e.g. path)
 
 export const QUARTZ = "quartz"
@@ -14,7 +16,6 @@ export function isFilePath(s: string): s is FilePath {
   const validStart = !s.startsWith(".")
   return validStart && _hasFileExtension(s)
 }
-
 
 /** Cannot be relative and may not have leading or trailing slashes. It can have `index` as it's last segment. Use this wherever possible is it's the most 'general' interpretation of a slug. */
 export type FullSlug = SlugLike<"full">
@@ -43,10 +44,10 @@ export function isRelativeURL(s: string): s is RelativeURL {
 export function isAbsoluteURL(s: string): boolean {
   try {
     new URL(s)
-    return true
   } catch {
     return false
   }
+  return true
 }
 
 export function getFullSlug(window: Window): FullSlug {

--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -40,6 +40,15 @@ export function isRelativeURL(s: string): s is RelativeURL {
   return validStart && validEnding && ![".md", ".html"].includes(getFileExtension(s) ?? "")
 }
 
+export function isAbsoluteURL(s: string): boolean {
+  try {
+    new URL(s)
+    return true
+  } catch {
+    return false
+  }
+}
+
 export function getFullSlug(window: Window): FullSlug {
   const res = window.document.body.dataset.slug! as FullSlug
   return res

--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -15,10 +15,6 @@ export function isFilePath(s: string): s is FilePath {
   return validStart && _hasFileExtension(s)
 }
 
-export function isAbsoluteFilePath(s: string): s is FilePath {
-  const parsedUrl = new URL(s)
-  return !parsedUrl.protocol
-}
 
 /** Cannot be relative and may not have leading or trailing slashes. It can have `index` as it's last segment. Use this wherever possible is it's the most 'general' interpretation of a slug. */
 export type FullSlug = SlugLike<"full">


### PR DESCRIPTION
I changed how `userDefinedOgImagePath` is defined becauseit's currently taking a relative path (according to [the docs ](https://quartz.jzhao.xyz/plugins/CustomOgImages#frontmatter-properties) ) and treating it as absolute.