### PR TITLE
fix(frontmatter): prevent slug duplication through frontmatter

### DIFF
--- a/quartz/plugins/transformers/frontmatter.ts
+++ b/quartz/plugins/transformers/frontmatter.ts
@@ -115,8 +115,8 @@ export const FrontMatter: QuartzTransformerPlugin<Partial<Options>> = (userOpts)
             if (socialImage) data.socialImage = socialImage
 
             // Remove duplicate slugs
-            const uniqueSlugs = [...new Set(allSlugs)];
-						allSlugs.splice(0, allSlugs.length, ...uniqueSlugs);
+            const uniqueSlugs = [...new Set(allSlugs)]
+            allSlugs.splice(0, allSlugs.length, ...uniqueSlugs)
 
             // fill in frontmatter
             file.data.frontmatter = data as QuartzPluginData["frontmatter"]

--- a/quartz/plugins/transformers/frontmatter.ts
+++ b/quartz/plugins/transformers/frontmatter.ts
@@ -46,10 +46,16 @@ function getAliasSlugs(aliases: string[]): FullSlug[] {
     const isMd = getFileExtension(alias) === "md"
     const mockFp = isMd ? alias : alias + ".md"
     const slug = slugifyFilePath(mockFp as FilePath)
-    res.push(slug)
+    pushSlugs(res, slug)
   }
 
   return res
+}
+
+function pushSlugs<T>(arr: T[], ...items: T[]) {
+  for (const item of items) {
+    if (!arr.includes(item)) arr.push(item)
+  }
 }
 
 export const FrontMatter: QuartzTransformerPlugin<Partial<Options>> = (userOpts) => {
@@ -84,15 +90,15 @@ export const FrontMatter: QuartzTransformerPlugin<Partial<Options>> = (userOpts)
             if (aliases) {
               data.aliases = aliases // frontmatter
               file.data.aliases = getAliasSlugs(aliases)
-              allSlugs.push(...file.data.aliases)
+              pushSlugs(allSlugs, ...file.data.aliases)
             }
 
             if (data.permalink != null && data.permalink.toString() !== "") {
               data.permalink = data.permalink.toString() as FullSlug
               const aliases = file.data.aliases ?? []
-              aliases.push(data.permalink)
+              pushSlugs(aliases, data.permalink)
               file.data.aliases = aliases
-              allSlugs.push(data.permalink)
+              pushSlugs(allSlugs, data.permalink)
             }
 
             const cssclasses = coerceToArray(coalesceAliases(data, ["cssclasses", "cssclass"]))

--- a/quartz/plugins/transformers/frontmatter.ts
+++ b/quartz/plugins/transformers/frontmatter.ts
@@ -115,9 +115,8 @@ export const FrontMatter: QuartzTransformerPlugin<Partial<Options>> = (userOpts)
             if (socialImage) data.socialImage = socialImage
 
             // Remove duplicate slugs
-            const uniqueSlugs = [...new Set(allSlugs)]
-            allSlugs.length = 0
-            uniqueSlugs.forEach((slug) => allSlugs.push(slug))
+            const uniqueSlugs = [...new Set(allSlugs)];
+						allSlugs.splice(0, allSlugs.length, ...uniqueSlugs);
 
             // fill in frontmatter
             file.data.frontmatter = data as QuartzPluginData["frontmatter"]

--- a/quartz/plugins/transformers/frontmatter.ts
+++ b/quartz/plugins/transformers/frontmatter.ts
@@ -46,16 +46,10 @@ function getAliasSlugs(aliases: string[]): FullSlug[] {
     const isMd = getFileExtension(alias) === "md"
     const mockFp = isMd ? alias : alias + ".md"
     const slug = slugifyFilePath(mockFp as FilePath)
-    pushSlugs(res, slug)
+    res.push(slug)
   }
 
   return res
-}
-
-function pushSlugs<T>(arr: T[], ...items: T[]) {
-  for (const item of items) {
-    if (!arr.includes(item)) arr.push(item)
-  }
 }
 
 export const FrontMatter: QuartzTransformerPlugin<Partial<Options>> = (userOpts) => {
@@ -90,15 +84,15 @@ export const FrontMatter: QuartzTransformerPlugin<Partial<Options>> = (userOpts)
             if (aliases) {
               data.aliases = aliases // frontmatter
               file.data.aliases = getAliasSlugs(aliases)
-              pushSlugs(allSlugs, ...file.data.aliases)
+              allSlugs.push(...file.data.aliases)
             }
 
             if (data.permalink != null && data.permalink.toString() !== "") {
               data.permalink = data.permalink.toString() as FullSlug
               const aliases = file.data.aliases ?? []
-              pushSlugs(aliases, data.permalink)
+              aliases.push(data.permalink)
               file.data.aliases = aliases
-              pushSlugs(allSlugs, data.permalink)
+              allSlugs.push(data.permalink)
             }
 
             const cssclasses = coerceToArray(coalesceAliases(data, ["cssclasses", "cssclass"]))
@@ -119,6 +113,11 @@ export const FrontMatter: QuartzTransformerPlugin<Partial<Options>> = (userOpts)
             if (published) data.published = published
 
             if (socialImage) data.socialImage = socialImage
+
+            // Remove duplicate slugs
+            const uniqueSlugs = [...new Set(allSlugs)]
+            allSlugs.length = 0
+            uniqueSlugs.forEach((slug) => allSlugs.push(slug))
 
             // fill in frontmatter
             file.data.frontmatter = data as QuartzPluginData["frontmatter"]


### PR DESCRIPTION
Closes: https://github.com/jackyzha0/quartz/issues/1859

This PR aims to fix issues related to duplicated slugs. This can occur when a file path matches an alias and/or the permalink of a note. The change in this PR addresses this by checking if a specific slug is already present in the data of the note, before adding it. 

### test case

```md
---
aliases:
  - index
  - hello
  - world
  - hello
permalink: world
---

hello!
```

```ts
// resulting slugs:
// before
['index', 'index', 'hello', 'world', 'hello', 'world']
// after
['index', 'hello', 'world']
```