### PR TITLE
fix(lastmod) change defaultDateType to "modified"

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -18,7 +18,7 @@ const config: QuartzConfig = {
     locale: "en-US",
     baseUrl: "quartz.jzhao.xyz",
     ignorePatterns: ["private", "templates", ".obsidian"],
-    defaultDateType: "created",
+    defaultDateType: "modified",
     theme: {
       fontOrigin: "googleFonts",
       cdnCaching: true,


### PR DESCRIPTION
Making this change as per https://github.com/jackyzha0/quartz/issues/1857#issuecomment-2737098252

This is necessary for the `git` source to work properly in the CreatedModifiedDate plugin.