### PR TITLE
Updating breadcrumbs docs on ConditionalRender

### DIFF
--- a/docs/features/breadcrumbs.md
+++ b/docs/features/breadcrumbs.md
@@ -19,7 +19,6 @@ Component.Breadcrumbs({
   spacerSymbol: "❯", // symbol between crumbs
   rootName: "Home", // name of first/root element
   resolveFrontmatterTitle: true, // whether to resolve folder names through frontmatter titles
-  hideOnRoot: true, // whether to hide breadcrumbs on root `index.md` page
   showCurrentPage: true, // whether to display the current page in the breadcrumbs
 })
 ```

--- a/docs/layout-components.md
+++ b/docs/layout-components.md
@@ -87,7 +87,7 @@ The example above would only render the Search component when the page is not in
 Component.ConditionalRender({
   component: Component.Breadcrumbs(),
   condition: (page) => page.fileData.slug !== "index",
-}),
+})
 ```
 
 The example above would hide breadcrumbs on the root `index.md` page.

--- a/docs/layout-components.md
+++ b/docs/layout-components.md
@@ -81,4 +81,13 @@ Component.ConditionalRender({
 })
 ```
 
-This example would only render the Search component when the page is not in fullpage mode.
+The example above would only render the Search component when the page is not in fullpage mode.
+
+```typescript
+Component.ConditionalRender({
+  component: Component.Breadcrumbs(),
+  condition: (page) => page.fileData.slug !== "index",
+}),
+```
+
+The example above would hide breadcrumbs on the root `index.md` page.


### PR DESCRIPTION
Commit https://github.com/jackyzha0/quartz/commit/4e74d11b1aee8c0affa0b13ba7b174d175ca3244 removed `hideOnRoot` from the breadcrumbs component in favor of the new `ConditionalRender` component, but the doc has not been updated yet. This PR proposes an update to the docs to reflect new changes.