### PR TITLE
fix(explorer): folder icon shrinks on long folder names

### DIFF
--- a/quartz/components/styles/explorer.scss
+++ b/quartz/components/styles/explorer.scss
@@ -198,6 +198,7 @@ button.desktop-explorer {
   cursor: pointer;
   transition: transform 0.3s ease;
   backface-visibility: visible;
+  flex-shrink: 0;
 }
 
 li:has(> .folder-outer:not(.open)) > .folder-container > svg {


### PR DESCRIPTION
This PR fixes the issue where folder icon would shrink in the flex explorer container because of long folder names.

## Before

<img width="839" alt="Screenshot 2025-03-26 at 3 11 26 AM" src="https://github.com/user-attachments/assets/3bca67be-0aad-4730-9f1c-5b9e71b17db6" />


## After

<img width="839" alt="Screenshot 2025-03-26 at 3 13 24 AM" src="https://github.com/user-attachments/assets/13a08640-d594-4576-a09f-731e7968526d" />

