### PR TITLE
fix(toc): element can't fully collapse

### DIFF
--- a/quartz/components/styles/toc.scss
+++ b/quartz/components/styles/toc.scss
@@ -5,7 +5,7 @@
   flex-direction: column;
 
   overflow-y: hidden;
-  min-height: 4rem;
+  min-height: 1.2rem;
   flex: 0 1 auto;
   &:has(button.toc-header.collapsed) {
     flex: 0 1 1.2rem;


### PR DESCRIPTION
This PR fixes an issue where TOC component is not fully collapsible because of `min-height` being too large.

## Before

<img width="255" alt="Screenshot 2025-03-26 at 3 46 35 AM" src="https://github.com/user-attachments/assets/20af6351-45d1-44a5-b16f-3b1290f7d53c" />

## After

<img width="255" alt="Screenshot 2025-03-26 at 3 47 02 AM" src="https://github.com/user-attachments/assets/bbdbc8bc-5bdc-423c-8cc6-faa851915742" />
