### PR TITLE
fix(style): MathJax non-inline formulae center

### DIFF
--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -65,6 +65,14 @@ ul,
   }
 }
 
+article > mjx-container.MathJax {
+  display: flex;
+  > svg {
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
 strong {
   font-weight: $semiBoldWeight;
 }


### PR DESCRIPTION
MathJax formulae are centered in Obsidian, as long as they are not inline. This PR adds a style rule to center MathJax formulae that are in the main content.