### PR TITLE
fix(toc): Fixed headers in second ToC element not highlight-able

### DIFF
--- a/quartz/components/scripts/toc.inline.ts
+++ b/quartz/components/scripts/toc.inline.ts
@@ -1,13 +1,13 @@
 const observer = new IntersectionObserver((entries) => {
   for (const entry of entries) {
     const slug = entry.target.id
-    const tocEntryElement = document.querySelector(`a[data-for="${slug}"]`)
+    const tocEntryElements = document.querySelectorAll(`a[data-for="${slug}"]`)
     const windowHeight = entry.rootBounds?.height
-    if (windowHeight && tocEntryElement) {
+    if (windowHeight && tocEntryElements.length > 0) {
       if (entry.boundingClientRect.y < windowHeight) {
-        tocEntryElement.classList.add("in-view")
+        tocEntryElements.forEach((tocEntryElement) => tocEntryElement.classList.add("in-view"))
       } else {
-        tocEntryElement.classList.remove("in-view")
+        tocEntryElements.forEach((tocEntryElement) => tocEntryElement.classList.remove("in-view"))
       }
     }
   }


### PR DESCRIPTION
https://github.com/jackyzha0/quartz/commit/1cd8e7f0d510b97dfc2c3314c36d957383162a8f introduced non-singleton ToC, but it hasn't fixed the problem where header tracking is not working properly if there are more than 1 ToC element in the DOM. The PR makes the `in-view` handling logic non-singleton as well.