### PR TITLE
fix(toc): Fixed bottom gradient not working properly

### DIFF
--- a/quartz/components/styles/toc.scss
+++ b/quartz/components/styles/toc.scss
@@ -7,6 +7,13 @@
   overflow-y: hidden;
   min-height: 4rem;
   flex: 0 1 auto;
+
+  &.desktop-only {
+    @media all and not ($mobile) {
+      display: flex;
+    }
+  }
+
   &:has(button.toc-header.collapsed) {
     flex: 0 1 1.2rem;
   }
@@ -46,12 +53,14 @@ button.toc-header {
 }
 
 .toc-content {
+  margin-top: 0.5rem;
   list-style: none;
-  position: relative;
+  overflow: hidden;
+  overflow-y: auto;
 
   & ul {
     list-style: none;
-    margin: 0.5rem 0;
+    margin: 0;
     padding: 0;
     & > li > a {
       color: var(--dark);


### PR DESCRIPTION
This fixes the bottom gradient issue in ToC as reported in https://github.com/jackyzha0/quartz/issues/1888.

The real issue is `overflow` not configured properly for `.toc-content`. This could also cause scroll bar or last ToC entry to be cut off.

## Before

<img width="1486" alt="before" src="https://github.com/user-attachments/assets/70ebc7f5-5a7c-4572-85c5-222be2617ee7" />

## After

<img width="1486" alt="after" src="https://github.com/user-attachments/assets/8dd78973-3fc5-4716-85c0-a214064ff503" />
