### PR TITLE
fix(fonts): Fixed page title fonts not downloadable to local

### DIFF
--- a/quartz/util/theme.ts
+++ b/quartz/util/theme.ts
@@ -108,10 +108,10 @@ export interface GoogleFontFile {
 }
 
 const fontMimeMap: Record<string, string> = {
-  "truetype": "ttf",
-  "woff": "woff",
-  "woff2": "woff2",
-  "opentype": "otf",
+  truetype: "ttf",
+  woff: "woff",
+  woff2: "woff2",
+  opentype: "otf",
 }
 
 export async function processGoogleFonts(
@@ -121,7 +121,8 @@ export async function processGoogleFonts(
   processedStylesheet: string
   fontFiles: GoogleFontFile[]
 }> {
-  const fontSourceRegex = /url\((https:\/\/fonts.gstatic.com\/.+(?:\/|(?:kit=))(.+?)[.&].+?)\)\sformat\('(\w+?)'\);/g
+  const fontSourceRegex =
+    /url\((https:\/\/fonts.gstatic.com\/.+(?:\/|(?:kit=))(.+?)[.&].+?)\)\sformat\('(\w+?)'\);/g
   const fontFiles: GoogleFontFile[] = []
   let processedStylesheet = stylesheet
 

--- a/quartz/util/theme.ts
+++ b/quartz/util/theme.ts
@@ -107,6 +107,13 @@ export interface GoogleFontFile {
   extension: string
 }
 
+const fontMimeMap: Record<string, string> = {
+  "truetype": "ttf",
+  "woff": "woff",
+  "woff2": "woff2",
+  "opentype": "otf",
+}
+
 export async function processGoogleFonts(
   stylesheet: string,
   baseUrl: string,
@@ -114,14 +121,15 @@ export async function processGoogleFonts(
   processedStylesheet: string
   fontFiles: GoogleFontFile[]
 }> {
-  const fontSourceRegex = /url\((https:\/\/fonts.gstatic.com\/s\/[^)]+\.(woff2|ttf))\)/g
+  const fontSourceRegex = /url\((https:\/\/fonts.gstatic.com\/.+(?:\/|(?:kit=))(.+?)[.&].+?)\)\sformat\('(\w+?)'\);/g
   const fontFiles: GoogleFontFile[] = []
   let processedStylesheet = stylesheet
 
   let match
   while ((match = fontSourceRegex.exec(stylesheet)) !== null) {
     const url = match[1]
-    const [filename, extension] = url.split("/").pop()!.split(".")
+    const filename = match[2]
+    const extension = fontMimeMap[match[3].toLowerCase()]
     const staticUrl = `https://${baseUrl}/static/fonts/${filename}.${extension}`
 
     processedStylesheet = processedStylesheet.replace(url, staticUrl)


### PR DESCRIPTION
This PR addresses the issue where page title fonts introduced in https://github.com/jackyzha0/quartz/pull/1848 are not downloadable and still reaches Google Fonts API when `cdnCaching` is set to false. Caught this bug because I have CSP set on my website.

## Details

The issue is the PR introduced a new Google Fonts API to extract only a subset of fonts needed for the page title text, but didn't update the parser regex to recognize the new font URLs returned by the new API, which causes a fallback to the cloud.

Example of a standard API call that downloads the full font: https://fonts.googleapis.com/css2?family=Roboto+Slab&display=swap, which returns the following CSS:

```css
/* cyrillic-ext */
@font-face {
  font-family: 'Roboto Slab';
  font-style: normal;
  font-weight: 400;
  font-display: swap;
  src: url(https://fonts.gstatic.com/s/robotoslab/v34/BngbUXZYTXPIvIBgJJSb6s3BzlRRfKOFbvjojISmYmRjV9Su1caiTVo.woff2) format('woff2');
  unicode-range: U+0460-052F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
}
...
```

Example of a subset API call that downloads only what's needed to render given texts: https://fonts.googleapis.com/css2?family=Roboto+Slab&text=hello&display=swap, which returns the following CSS:

```css
@font-face {
  font-family: 'Roboto Slab';
  font-style: normal;
  font-weight: 400;
  font-display: swap;
  src: url(https://fonts.gstatic.com/l/font?kit=BngbUXZYTXPIvIBgJJSb6s3BzlRRfKOFbvjojISWbW5iddC21OSnEDNSkw&skey=a9ad6a4717e923f0&v=v34) format('woff2');
}
```

I updated the regex to cover these two cases, we're also now getting the API URL, file name and the extension entirely through capture groups. Manually tested working on a number of fonts.