### PR TITLE
Add filter-by-slug alternative in documentation

### DIFF
--- a/docs/features/explorer.md
+++ b/docs/features/explorer.md
@@ -154,7 +154,6 @@ Component.Explorer({
 Alternatively, here's how to filter by slug:
 
 ```ts title="quartz.layout.ts"
-// Filter by slug
 Component.Explorer({
   filterFn: (node) => {
     // set containing slugs of everything you want to filter out

--- a/docs/features/explorer.md
+++ b/docs/features/explorer.md
@@ -151,6 +151,19 @@ Component.Explorer({
 })
 ```
 
+Alternatively, here's how to filter by slug:
+
+```ts title="quartz.layout.ts"
+// Filter by slug
+Component.Explorer({
+  filterFn: (node) => {
+    // set containing slugs of everything you want to filter out
+    const omit = new Set(["authoring content", "tags", "hosting"])
+    return !omit.has((node.slug ?? "").split("/")[0])
+  },
+})
+```
+
 ### Remove files by tag
 
 You can access the tags of a file by `node.data.tags`.


### PR DESCRIPTION
Currently, the proposed filter by title is not working — at least on my side. However, let's consider adding a filter-by-slug alternative in the documentation, as I’ve found it to be very effective.