### PR TITLE
fix(RecentNotes): Prevent folder pages from always appearing first (closes #1901)

### DIFF
--- a/quartz/components/PageList.tsx
+++ b/quartz/components/PageList.tsx
@@ -6,15 +6,33 @@ import { GlobalConfiguration } from "../cfg"
 
 export type SortFn = (f1: QuartzPluginData, f2: QuartzPluginData) => number
 
-export function byDateAndAlphabetical(cfg: GlobalConfiguration, prioritizeFolders: boolean = true): SortFn {
+export function byDateAndAlphabetical(cfg: GlobalConfiguration): SortFn {
   return (f1, f2) => {
-    if (prioritizeFolders) {
-      // Sort folders first
-      const f1IsFolder = isFolderPath(f1.slug ?? "")
-      const f2IsFolder = isFolderPath(f2.slug ?? "")
-      if (f1IsFolder && !f2IsFolder) return -1
-      if (!f1IsFolder && f2IsFolder) return 1
+    // Sort by date/alphabetical
+    if (f1.dates && f2.dates) {
+      // sort descending
+      return getDate(cfg, f2)!.getTime() - getDate(cfg, f1)!.getTime()
+    } else if (f1.dates && !f2.dates) {
+      // prioritize files with dates
+      return -1
+    } else if (!f1.dates && f2.dates) {
+      return 1
     }
+
+    // otherwise, sort lexographically by title
+    const f1Title = f1.frontmatter?.title.toLowerCase() ?? ""
+    const f2Title = f2.frontmatter?.title.toLowerCase() ?? ""
+    return f1Title.localeCompare(f2Title)
+  }
+}
+
+export function byDateAndAlphabeticalFolderFirst(cfg: GlobalConfiguration): SortFn {
+  return (f1, f2) => {
+    // Sort folders first
+    const f1IsFolder = isFolderPath(f1.slug ?? "")
+    const f2IsFolder = isFolderPath(f2.slug ?? "")
+    if (f1IsFolder && !f2IsFolder) return -1
+    if (!f1IsFolder && f2IsFolder) return 1
 
     // If both are folders or both are files, sort by date/alphabetical
     if (f1.dates && f2.dates) {

--- a/quartz/components/PageList.tsx
+++ b/quartz/components/PageList.tsx
@@ -6,13 +6,15 @@ import { GlobalConfiguration } from "../cfg"
 
 export type SortFn = (f1: QuartzPluginData, f2: QuartzPluginData) => number
 
-export function byDateAndAlphabetical(cfg: GlobalConfiguration): SortFn {
+export function byDateAndAlphabetical(cfg: GlobalConfiguration, prioritizeFolders: boolean = true): SortFn {
   return (f1, f2) => {
-    // Sort folders first
-    const f1IsFolder = isFolderPath(f1.slug ?? "")
-    const f2IsFolder = isFolderPath(f2.slug ?? "")
-    if (f1IsFolder && !f2IsFolder) return -1
-    if (!f1IsFolder && f2IsFolder) return 1
+    if (prioritizeFolders) {
+      // Sort folders first
+      const f1IsFolder = isFolderPath(f1.slug ?? "")
+      const f2IsFolder = isFolderPath(f2.slug ?? "")
+      if (f1IsFolder && !f2IsFolder) return -1
+      if (!f1IsFolder && f2IsFolder) return 1
+    }
 
     // If both are folders or both are files, sort by date/alphabetical
     if (f1.dates && f2.dates) {

--- a/quartz/components/PageList.tsx
+++ b/quartz/components/PageList.tsx
@@ -58,7 +58,7 @@ type Props = {
 } & QuartzComponentProps
 
 export const PageList: QuartzComponent = ({ cfg, fileData, allFiles, limit, sort }: Props) => {
-  const sorter = sort ?? byDateAndAlphabetical(cfg)
+  const sorter = sort ?? byDateAndAlphabeticalFolderFirst(cfg)
   let list = allFiles.sort(sorter)
   if (limit) {
     list = list.slice(0, limit)

--- a/quartz/components/RecentNotes.tsx
+++ b/quartz/components/RecentNotes.tsx
@@ -22,7 +22,7 @@ const defaultOptions = (cfg: GlobalConfiguration): Options => ({
   linkToMore: false,
   showTags: true,
   filter: () => true,
-  sort: byDateAndAlphabetical(cfg),
+  sort: byDateAndAlphabetical(cfg, false),
 })
 
 export default ((userOpts?: Partial<Options>) => {

--- a/quartz/components/RecentNotes.tsx
+++ b/quartz/components/RecentNotes.tsx
@@ -22,7 +22,7 @@ const defaultOptions = (cfg: GlobalConfiguration): Options => ({
   linkToMore: false,
   showTags: true,
   filter: () => true,
-  sort: byDateAndAlphabetical(cfg, false),
+  sort: byDateAndAlphabetical(cfg),
 })
 
 export default ((userOpts?: Partial<Options>) => {


### PR DESCRIPTION
Pass prioritizeFolders=false to byDateAndAlphabetical in RecentNotes to sort strictly by date/alphabetical order, fixing issue #1901.