### PR TITLE
fix(ofm): Misc bug fixes to the highlight syntax

### DIFF
--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -126,7 +126,7 @@ export const tableRegex = new RegExp(/^\|([^\n])+\|\n(\|)( ?:?-{3,}:? ?\|)+\n(\|
 // matches any wikilink, only used for escaping wikilinks inside tables
 export const tableWikilinkRegex = new RegExp(/(!?\[\[[^\]]*?\]\]|\[\^[^\]]*?\])/g)
 
-const highlightRegex = new RegExp(/==([^=]+)==/g)
+const highlightRegex = new RegExp(/==([^=]+?)==/g)
 const commentRegex = new RegExp(/%%[\s\S]*?%%/g)
 // from https://github.com/escwxyz/remark-obsidian-callout/blob/main/src/index.ts
 const calloutRegex = new RegExp(/^\[\!([\w-]+)\|?(.+?)?\]([+-]?)/)
@@ -201,6 +201,12 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options>>
 
           return `${embedDisplay}[[${fp}${displayAnchor}${displayAlias}]]`
         })
+      }
+
+      // pre-transform highlights
+      if (opts.highlight) {
+        src = src.replace(highlightRegex,
+          `<span class="text-highlight">$1</span>`)
       }
 
       return src
@@ -286,19 +292,6 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options>>
                       value: alias ?? fp,
                     },
                   ],
-                }
-              },
-            ])
-          }
-
-          if (opts.highlight) {
-            replacements.push([
-              highlightRegex,
-              (_value: string, ...capture: string[]) => {
-                const [inner] = capture
-                return {
-                  type: "html",
-                  value: `<span class="text-highlight">${inner}</span>`,
                 }
               },
             ])

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -126,7 +126,8 @@ export const tableRegex = new RegExp(/^\|([^\n])+\|\n(\|)( ?:?-{3,}:? ?\|)+\n(\|
 // matches any wikilink, only used for escaping wikilinks inside tables
 export const tableWikilinkRegex = new RegExp(/(!?\[\[[^\]]*?\]\]|\[\^[^\]]*?\])/g)
 
-const highlightRegex = new RegExp(/==([^=]+?)==/g)
+// Exclude arrow syntax from highlight syntax matching, namely `==>` and `<==`
+const highlightRegex = new RegExp(/(?<!<)==(?!>)(.+?)(?<!<)==(?!>)/g)
 const commentRegex = new RegExp(/%%[\s\S]*?%%/g)
 // from https://github.com/escwxyz/remark-obsidian-callout/blob/main/src/index.ts
 const calloutRegex = new RegExp(/^\[\!([\w-]+)\|?(.+?)?\]([+-]?)/)

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -205,8 +205,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options>>
 
       // pre-transform highlights
       if (opts.highlight) {
-        src = src.replace(highlightRegex,
-          `<span class="text-highlight">$1</span>`)
+        src = src.replace(highlightRegex, `<span class="text-highlight">$1</span>`)
       }
 
       return src


### PR DESCRIPTION
This PR fixes the issue where the highlight syntax from Obsidian was not working if there were other markdown formats embedded in the text sequence.

Resolves https://github.com/jackyzha0/quartz/issues/1652.

Also the original highlight parser regex has numerous bugs with other syntaxes. Rewritten to resolve the following edge cases:

```md
==I'm **testing** highlights.==

==A = B==

==A ==> B and B <== C==

==$$A == B \land B == C$$ and $$B == C \land C == D$$==

==$A == B \land B == C$ and $B == C \land C == D$==

==`A == B && B == C` and `B == C && C == D`==
```

<img width="425" alt="Screenshot 2025-04-19 at 4 16 32 PM" src="https://github.com/user-attachments/assets/70402c93-9db9-4c6d-93c1-9422aaabe89e" />

## The highlight syntax not parsed issue

The root cause appears to be more generic and can happen to any other nested markdown formats that are from different parsers.

Because the `remark-parse` plugin is added first, it replaces the bold syntax `**` with HTML element `<strong>`, which makes it hard for subsequent markdown plugins to handle corner cases where their formatters are "wrappers" of these HTML elements.

https://github.com/jackyzha0/quartz/blob/c238dd16d9923aac404a16b8551d93e5b91a4c5a/quartz/processors/parse.ts#L27

As an example, upon receiving the following text:

```md
==This is <strong>a test</strong> for the== parser bug.
```

The HTML parser `hast` generates an AST that extracts the bold text, something in the effect of: `["==This is ", "a test", " for the== parser bug."]`, therefore the highlight parser regex is not able to capture the full context.

https://github.com/jackyzha0/quartz/blob/c238dd16d9923aac404a16b8551d93e5b91a4c5a/quartz/plugins/transformers/ofm.ts#L129

While there may be an ongoing effort to rework the markdown parsers: https://github.com/jackyzha0/quartz/pull/1496 (or create a new rehype obsidian plugin altogether?), this PR solves this particular issue by moving the highlight parser off the ofm markdown plugin and making it process the raw text instead.