### PR TITLE
feat(assets): Optimize images for web serving on build

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,6 +57,7 @@ This part of the configuration concerns anything that can affect the whole site.
     - `tertiary`: hover states and visited [[graph view|graph]] nodes
     - `highlight`: internal link background, highlighted text, [[syntax highlighting|highlighted lines of code]]
     - `textHighlight`: markdown highlighted text background
+- `optimizeImages`: whether to optimize images for web serving when building Quartz. If `true`, JPEG and PNG images will be stripped all metadata and converted to WebP format, and associated image links in [[wikilinks]] will be updated with the new file extension.
 
 ## Plugins
 

--- a/docs/plugins/Assets.md
+++ b/docs/plugins/Assets.md
@@ -4,7 +4,7 @@ tags:
   - plugin/emitter
 ---
 
-This plugin emits all non-Markdown static assets in your content folder (like images, videos, HTML, etc). The plugin respects the `ignorePatterns` in the global [[configuration]].
+This plugin emits all non-Markdown static assets in your content folder (like images, videos, HTML, etc). The plugin respects the `ignorePatterns` and `optimizeImages` in the global [[configuration]].
 
 Note that all static assets will then be accessible through its path on your generated site, i.e: `host.me/path/to/static.pdf`
 

--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -52,6 +52,8 @@ const config: QuartzConfig = {
         },
       },
     },
+    // Disable `optimizeImages` to speed up build time
+    optimizeImages: true,
   },
   plugins: {
     transformers: [

--- a/quartz/cfg.ts
+++ b/quartz/cfg.ts
@@ -70,6 +70,13 @@ export interface GlobalConfiguration {
    * Region Codes: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
    */
   locale: ValidLocale
+  /**
+   * Whether to optimize images for web serving when building Quartz.
+   *
+   * If true, eligible images will be stripped all metadata and converted to WebP format,
+   * and associated image links in wikilinks will be updated with the new file extension.
+   */
+  optimizeImages: boolean
 }
 
 export interface QuartzConfig {

--- a/quartz/plugins/emitters/assets.ts
+++ b/quartz/plugins/emitters/assets.ts
@@ -1,28 +1,53 @@
-import { FilePath, joinSegments, slugifyFilePath } from "../../util/path"
+import { FilePath, FullSlug, joinSegments, slugifyFilePath } from "../../util/path"
 import { QuartzEmitterPlugin } from "../types"
 import path from "path"
 import fs from "fs"
 import { glob } from "../../util/glob"
 import { Argv } from "../../util/ctx"
 import { QuartzConfig } from "../../cfg"
+import sharp from "sharp"
+
+// Sharp doesn't support BMP input out of the box:
+//   https://github.com/lovell/sharp/issues/543
+// GIF processing can be very slow or ineffective (larger file size when CPU effort is
+// set to a low number); only enable after testing:
+//   https://github.com/lovell/sharp/issues/3176
+const imageExtsToOptimize: Set<string> = new Set([".png", ".jpg", ".jpeg"])
 
 const filesToCopy = async (argv: Argv, cfg: QuartzConfig) => {
   // glob all non MD files in content folder and copy it over
   return await glob("**", argv.directory, ["**/*.md", ...cfg.configuration.ignorePatterns])
 }
 
-const copyFile = async (argv: Argv, fp: FilePath) => {
+const copyFile = async (argv: Argv, cfg: QuartzConfig, fp: FilePath) => {
   const src = joinSegments(argv.directory, fp) as FilePath
 
-  const name = slugifyFilePath(fp)
+  const srcExt = path.extname(fp).toLowerCase()
+  const doOptimizeImage = cfg.configuration.optimizeImages && imageExtsToOptimize.has(srcExt)
+
+  const name = doOptimizeImage
+    ? ((slugifyFilePath(fp, true) + ".webp") as FullSlug)
+    : slugifyFilePath(fp)
   const dest = joinSegments(argv.output, name) as FilePath
 
   // ensure dir exists
   const dir = path.dirname(dest) as FilePath
   await fs.promises.mkdir(dir, { recursive: true })
 
-  await fs.promises.copyFile(src, dest)
+  if (doOptimizeImage) {
+    await processImage(src, dest)
+  } else {
+    await fs.promises.copyFile(src, dest)
+  }
   return dest
+}
+
+async function processImage(src: FilePath, dest: FilePath) {
+  const originalFile = await fs.promises.readFile(src)
+  const convertedFile = await sharp(originalFile)
+    .webp({ quality: 90, smartSubsample: true, effort: 6 })
+    .toBuffer()
+  await fs.promises.writeFile(dest, convertedFile)
 }
 
 export const Assets: QuartzEmitterPlugin = () => {
@@ -31,18 +56,22 @@ export const Assets: QuartzEmitterPlugin = () => {
     async *emit({ argv, cfg }) {
       const fps = await filesToCopy(argv, cfg)
       for (const fp of fps) {
-        yield copyFile(argv, fp)
+        yield copyFile(argv, cfg, fp)
       }
     },
     async *partialEmit(ctx, _content, _resources, changeEvents) {
       for (const changeEvent of changeEvents) {
-        const ext = path.extname(changeEvent.path)
+        const ext = path.extname(changeEvent.path).toLowerCase()
         if (ext === ".md") continue
 
         if (changeEvent.type === "add" || changeEvent.type === "change") {
-          yield copyFile(ctx.argv, changeEvent.path)
+          yield copyFile(ctx.argv, ctx.cfg, changeEvent.path)
         } else if (changeEvent.type === "delete") {
-          const name = slugifyFilePath(changeEvent.path)
+          const doOptimizeImage =
+            ctx.cfg.configuration.optimizeImages && imageExtsToOptimize.has(ext)
+          const name = doOptimizeImage
+            ? ((slugifyFilePath(changeEvent.path, true) + ".webp") as FullSlug)
+            : slugifyFilePath(changeEvent.path)
           const dest = joinSegments(ctx.argv.output, name) as FilePath
           await fs.promises.unlink(dest)
         }

--- a/quartz/plugins/emitters/ogImage.tsx
+++ b/quartz/plugins/emitters/ogImage.tsx
@@ -12,6 +12,8 @@ import { BuildCtx } from "../../util/ctx"
 import { QuartzPluginData } from "../vfile"
 import fs from "node:fs/promises"
 import chalk from "chalk"
+import { getExtFromUrl } from "../../util/url"
+import { imageExtsToOptimize, targetOptimizedImageExt } from "./assets"
 
 const defaultOptions: SocialImageOptions = {
   colorScheme: "lightMode",
@@ -151,6 +153,17 @@ export const CustomOgImages: QuartzEmitterPlugin<Partial<SocialImageOptions>> = 
               userDefinedOgImagePath = isAbsoluteURL(userDefinedOgImagePath)
                 ? userDefinedOgImagePath
                 : `https://${baseUrl}/static/${userDefinedOgImagePath}`
+
+              // Replace extension of eligible image files with target extension if image optimization is enabled.
+              if (ctx.cfg.configuration.optimizeImages) {
+                const ext = getExtFromUrl(userDefinedOgImagePath)?.toLowerCase()
+                if (ext && imageExtsToOptimize.has(ext)) {
+                  userDefinedOgImagePath = userDefinedOgImagePath.replace(
+                    ext,
+                    targetOptimizedImageExt,
+                  )
+                }
+              }
             }
 
             const generatedOgImagePath = isRealFile

--- a/quartz/util/url.test.ts
+++ b/quartz/util/url.test.ts
@@ -1,0 +1,29 @@
+import { describe, it } from "node:test"
+import { getExtFromUrl } from "./url"
+import assert from "node:assert/strict"
+
+describe("getExtFromUrl", () => {
+  it("should return the correct file extension from a URL", () => {
+    const url = "https://example.com/image.jpg"
+    const ext = getExtFromUrl(url)
+    assert.strictEqual(ext, ".jpg")
+  })
+
+  it("should return undefined for URLs without an extension", () => {
+    const url = "https://example.com/image"
+    const ext = getExtFromUrl(url)
+    assert.strictEqual(ext, undefined)
+  })
+
+  it("should handle URLs with query parameters", () => {
+    const url = "https://example.com/image.jpg?size=large"
+    const ext = getExtFromUrl(url)
+    assert.strictEqual(ext, ".jpg")
+  })
+
+  it("should handle URLs with hash fragments", () => {
+    const url = "https://example.com/image.jpg#section1"
+    const ext = getExtFromUrl(url)
+    assert.strictEqual(ext, ".jpg")
+  })
+})

--- a/quartz/util/url.ts
+++ b/quartz/util/url.ts
@@ -1,0 +1,13 @@
+/**
+ * Extracts file extension from a file resource URL.
+ *
+ * @param url - URL to extract the file extension from
+ * @returns The file extension (with a preceding dot) or undefined if none found
+ */
+export function getExtFromUrl(url: string): string | undefined {
+  const urlObj = new URL(url)
+  const pathname = urlObj.pathname
+  // Remove any query parameters or hash first
+  const ext = pathname.split(/[#?]/)[0].split(".").pop()?.trim()
+  return ext === pathname ? undefined : "." + ext
+}


### PR DESCRIPTION
This PR proposes a new feature that utilizes the `sharp` library (originally introduced for OG image generation) to optimize images for web serving on build, saving efforts of having to pre-optimize images before committing them (or use paid CDN services for that matter) and preventing accidental photo metadata leak.

When enabled, PNG and JPEG images are stripped all metadata and converted to WebP format, and associated file links in `wikilinks` are updated with the new file extension.