### PR TITLE
fix: dynamically detect current branch for quartz sync push

### DIFF
--- a/quartz/cli/handlers.js
+++ b/quartz/cli/handlers.js
@@ -589,7 +589,8 @@ export async function handleSync(argv) {
   await popContentFolder(contentFolder)
   if (argv.push) {
     console.log("Pushing your changes")
-    const res = spawnSync("git", ["push", "-uf", ORIGIN_NAME, QUARTZ_SOURCE_BRANCH], {
+    const currentBranch = execSync("git rev-parse --abbrev-ref HEAD").toString().trim()
+    const res = spawnSync("git", ["push", "-uf", ORIGIN_NAME, currentBranch], {
       stdio: "inherit",
     })
     if (res.status !== 0) {


### PR DESCRIPTION
### ✨ What this does
Fixes an issue where `npx quartz sync` fails on branches other than `v4` by dynamically detecting the current Git branch instead of using a hardcoded value.

### 🧠 Why
This makes Quartz more flexible for users on `main`, `dev`, etc., and prevents errors like:
`error: src refspec v4 does not match any`.

Tested on Windows with local setup.

Let me know if you'd like me to make it configurable instead!
