### PR TITLE
fix(callout): Grid-based callout collapsible animation

### DIFF
--- a/quartz/components/scripts/callout.inline.ts
+++ b/quartz/components/scripts/callout.inline.ts
@@ -1,29 +1,10 @@
 function toggleCallout(this: HTMLElement) {
   const outerBlock = this.parentElement!
   outerBlock.classList.toggle("is-collapsed")
+  const content = outerBlock.getElementsByClassName("callout-content")[0] as HTMLElement
+  if (!content) return
   const collapsed = outerBlock.classList.contains("is-collapsed")
-  const height = collapsed ? this.scrollHeight : outerBlock.scrollHeight
-  outerBlock.style.maxHeight = height + "px"
-
-  // walk and adjust height of all parents
-  let current = outerBlock
-  let parent = outerBlock.parentElement
-  while (parent) {
-    if (parent.classList.contains("callout-content")) {
-      parent = parent.parentElement
-      continue
-    }
-    if (!parent.classList.contains("callout")) {
-      return
-    }
-
-    const collapsed = parent.classList.contains("is-collapsed")
-    const height = collapsed ? parent.scrollHeight : parent.scrollHeight + current.scrollHeight
-    parent.style.maxHeight = height + "px"
-
-    current = parent
-    parent = parent.parentElement
-  }
+  content.style.gridTemplateRows = collapsed ? "0fr" : "1fr"
 }
 
 function setupCallout() {
@@ -31,15 +12,15 @@ function setupCallout() {
     `callout is-collapsible`,
   ) as HTMLCollectionOf<HTMLElement>
   for (const div of collapsible) {
-    const title = div.firstElementChild
-    if (!title) continue
+    const title = div.getElementsByClassName("callout-title")[0] as HTMLElement
+    const content = div.getElementsByClassName("callout-content")[0] as HTMLElement
+    if (!title || !content) continue
 
     title.addEventListener("click", toggleCallout)
     window.addCleanup(() => title.removeEventListener("click", toggleCallout))
 
     const collapsed = div.classList.contains("is-collapsed")
-    const height = collapsed ? title.scrollHeight : div.scrollHeight
-    div.style.maxHeight = height + "px"
+    content.style.gridTemplateRows = collapsed ? "0fr" : "1fr"
   }
 }
 

--- a/quartz/components/scripts/callout.inline.ts
+++ b/quartz/components/scripts/callout.inline.ts
@@ -9,6 +9,10 @@ function toggleCallout(this: HTMLElement) {
   let current = outerBlock
   let parent = outerBlock.parentElement
   while (parent) {
+    if (parent.classList.contains("callout-content")) {
+      parent = parent.parentElement
+      continue
+    }
     if (!parent.classList.contains("callout")) {
       return
     }

--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -464,6 +464,30 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options>>
                   })
                 }
 
+                // For the rest of the MD callout elements other than the title, wrap them with
+                // two nested HTML <div>s (use some hacked mdhast component to achieve this) of
+                // class `callout-content` and `callout-content-inner` respectively for
+                // grid-based collapsible animation.
+                if (calloutContent.length > 0) {
+                  node.children = [
+                    node.children[0],
+                    {
+                      data: { hProperties: { className: ["callout-content"] }, hName: "div" },
+                      type: "blockquote",
+                      children: [
+                        {
+                          data: {
+                            hProperties: { className: ["callout-content-inner"] },
+                            hName: "div",
+                          },
+                          type: "blockquote",
+                          children: [...calloutContent],
+                        },
+                      ],
+                    },
+                  ]
+                }
+
                 // replace first line of blockquote with title and rest of the paragraph text
                 node.children.splice(0, 1, ...blockquoteContent)
 
@@ -484,21 +508,6 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options>>
                     "data-callout-fold": collapse,
                     "data-callout-metadata": calloutMetaData,
                   },
-                }
-
-                // Add callout-content class to callout body if it has one.
-                if (calloutContent.length > 0) {
-                  const contentData: BlockContent | DefinitionContent = {
-                    data: {
-                      hProperties: {
-                        className: "callout-content",
-                      },
-                      hName: "div",
-                    },
-                    type: "blockquote",
-                    children: [...calloutContent],
-                  }
-                  node.children = [node.children[0], contentData]
                 }
               }
             })

--- a/quartz/styles/callouts.scss
+++ b/quartz/styles/callouts.scss
@@ -7,11 +7,19 @@
   border-radius: 5px;
   padding: 0 1rem;
   overflow-y: hidden;
-  transition: max-height 0.3s ease;
   box-sizing: border-box;
 
-  & > .callout-content > :first-child {
-    margin-top: 0;
+  & > .callout-content {
+    display: grid;
+    transition: grid-template-rows 0.3s ease;
+
+    & > .callout-content-inner {
+      overflow: hidden;
+
+      & > :first-child {
+        margin-top: 0;
+      }
+    }
   }
 
   --callout-icon-note: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="2" x2="22" y2="6"></line><path d="M7.5 20.5 19 9l-4-4L3.5 16.5 2 22z"></path></svg>');


### PR DESCRIPTION
This PR proposes a re-implementation of the callout collapsible animation using grid. This simplifies the JS logic, removes the need to hardcode element heights (in the case of nested callouts this also removes the need to walk the DOM tree to perform height calculations), and fixes a couple callout cropping bugs detailed below.

## Incorrect nested callout `maxHeight` calculation

After https://github.com/jackyzha0/quartz/pull/1188 introduced `.callout-content` for styling purpose, the script was not updated for nested callouts, so all parents' height recalculation was skipped. Please see the first commit for details.

<img width="837" alt="Screenshot 2025-04-25 at 12 45 02 AM" src="https://github.com/user-attachments/assets/9b96550b-4df6-4a67-99b9-d1815551da23" />

I took the example straight from the callout doc: https://quartz.jzhao.xyz/features/callouts.

```md
> [!question]+ Can callouts be _nested_?
>
> > [!todo]- Yes!, they can. And collapsed!
> >
> > > [!example] You can even use multiple layers of nesting.
```

Before:

<img width="874" alt="Screenshot 2025-04-25 at 12 40 11 AM" src="https://github.com/user-attachments/assets/8932f953-f7a0-4ea9-b545-94ade32cf4c3" />

After:

<img width="871" alt="Screenshot 2025-04-25 at 12 45 46 AM" src="https://github.com/user-attachments/assets/65f7a098-0d3d-4d86-8170-d747e2bdd988" />

## ScrollHeight inaccurate for lazily loaded assets that don't specify height

This was an interesting puzzle to debug, took me a couple nights to figure out. This really shows the limitation of the common collapsible implementation based on `maxHeight` transition.

To repro, turn on asset lazy loading:

```js
Plugin.CrawlLinks({ markdownLinkResolution: "shortest", lazyLoad: true }),
```

Then try to include some embedded assets e.g. an image in a callout default to expanded without specifying the height (it'll be styled as `height:auto` in this case).

```md
> [!info]+ `ScrollHeight` skips lazily loaded pictures with auto height!
>
> Took me quite a while to figure this one out, it screws up not just this callout,
> but the layout of all subsequent ones on my website for reason I still don't understand.
>
> Here's a [picture wikilink](https://help.obsidian.md/embeds#Embed+an+image+in+a+note), only width is hardcoded to preserve aspect ratio.
> Oh noes! Where did Douglas Engelbart's jaw go?
>
> ![[https://publish-01.obsidian.md/access/f786db9fac45774fa4f0d8112e232d67/Attachments/Engelbart.jpg | 100]]
>
> Collapse and uncollapse after the image is loaded allow browser to calculate `ScrollHeight` properly again.
```

`ScrollHeight` does not return the right value the first time because the image was not loaded nor had height clearly defined when browser performs reflow calculations. User must trigger browser reflow by collapsing and uncollapsing the callout after the image is loaded for it to be set correctly.

Before:

<img width="1098" alt="Screenshot 2025-04-25 at 11 18 58 PM" src="https://github.com/user-attachments/assets/56d14854-e085-4b35-af7e-6c539a0f15a5" />

After:

<img width="1090" alt="Screenshot 2025-04-25 at 11 20 05 PM" src="https://github.com/user-attachments/assets/75b029d9-ddd5-4f9c-a171-27ecfdb89b44" />

## Window resizing causes cropping

Hardcoding `maxHeight` can cause cropping to existing callouts when browser window resizes.