### PR TITLE
fix(graph): provide proper workaround for pixijs webgpu issue #1899

### DIFF
--- a/quartz/components/scripts/graph.inline.ts
+++ b/quartz/components/scripts/graph.inline.ts
@@ -68,13 +68,28 @@ type TweenNode = {
   stop: () => void
 }
 
+// workaround for pixijs webgpu issue: https://github.com/pixijs/pixijs/issues/11389
 async function determineGraphicsAPI(): Promise<"webgpu" | "webgl"> {
   const adapter = await navigator.gpu?.requestAdapter().catch(() => null)
-  if (!adapter) {
+  const device = adapter && (await adapter.requestDevice().catch(() => null))
+  if (!device) {
     return "webgl"
   }
-  // Devices with WebGPU but no float32-blendable feature fail to render the graph
-  return adapter.features.has("float32-blendable") ? "webgpu" : "webgl"
+
+  const canvas = document.createElement("canvas")
+  const gl =
+    (canvas.getContext("webgl2") as WebGL2RenderingContext | null) ??
+    (canvas.getContext("webgl") as WebGLRenderingContext | null)
+
+  // we have to return webgl so pixijs automatically falls back to canvas
+  if (!gl) {
+    return "webgl"
+  }
+
+  const webglMaxTextures = gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS)
+  const webgpuMaxTextures = device.limits.maxSampledTexturesPerShaderStage
+
+  return webglMaxTextures === webgpuMaxTextures ? "webgpu" : "webgl"
 }
 
 async function renderGraph(graph: HTMLElement, fullSlug: FullSlug) {


### PR DESCRIPTION
It turns out my hunch about my previous fix being a red herring was true. The graph was working on my pixel but not on another device.

I did a bit of digging in the PixiJS codebase and found and raised the root cause: [pixijs#11389](https://github.com/pixijs/pixijs/issues/11389)

Essentially, PixiJS assumes that the WebGPU texture limit is the same as WebGL. This isn't the case on some devices, which leads to the rendering to fail.

This PR adds a check to see if the two are equal. If equal, `preference: "webgpu"` is used. Otherwise, `preference: "webgl"` is used. We'll have to eventually remove this when PixiJS is fixed. 