### PR TITLE
feat: Group layout component

### DIFF
--- a/quartz/components/Group.tsx
+++ b/quartz/components/Group.tsx
@@ -7,9 +7,7 @@ interface GroupConfig {
 
 export default ((config: GroupConfig) => {
   const Group: QuartzComponent = (props: QuartzComponentProps) =>
-    config.components
-      .map((c: QuartzComponent) => ({ component: c }))
-      .map((it: { component: QuartzComponent }) => <it.component {...props} />)
+    config.components.map((C: QuartzComponent) => <C {...props} />)
 
   Group.afterDOMLoaded = concatenateResources(...config.components.map((c) => c.afterDOMLoaded))
   Group.beforeDOMLoaded = concatenateResources(...config.components.map((c) => c.beforeDOMLoaded))

--- a/quartz/components/Group.tsx
+++ b/quartz/components/Group.tsx
@@ -1,0 +1,23 @@
+import { concatenateResources } from "../util/resources"
+import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
+
+interface GroupConfig {
+    components: QuartzComponent[]
+}
+
+export default ((config: GroupConfig) => {
+    const Group: QuartzComponent = (props: QuartzComponentProps) => 
+        config.components
+            .map((c: QuartzComponent) => ({ component: c }))
+            .map((it: { component: QuartzComponent} ) => (<it.component {...props} />))
+
+
+    Group.afterDOMLoaded = concatenateResources(
+        ...config.components.map((c) => c.afterDOMLoaded),
+    )
+    Group.beforeDOMLoaded = concatenateResources(
+        ...config.components.map((c) => c.beforeDOMLoaded),
+    )
+    Group.css = concatenateResources(...config.components.map((c) => c.css))
+    return Group
+}) satisfies QuartzComponentConstructor<GroupConfig>

--- a/quartz/components/Group.tsx
+++ b/quartz/components/Group.tsx
@@ -2,22 +2,17 @@ import { concatenateResources } from "../util/resources"
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
 
 interface GroupConfig {
-    components: QuartzComponent[]
+  components: QuartzComponent[]
 }
 
 export default ((config: GroupConfig) => {
-    const Group: QuartzComponent = (props: QuartzComponentProps) => 
-        config.components
-            .map((c: QuartzComponent) => ({ component: c }))
-            .map((it: { component: QuartzComponent} ) => (<it.component {...props} />))
+  const Group: QuartzComponent = (props: QuartzComponentProps) =>
+    config.components
+      .map((c: QuartzComponent) => ({ component: c }))
+      .map((it: { component: QuartzComponent }) => <it.component {...props} />)
 
-
-    Group.afterDOMLoaded = concatenateResources(
-        ...config.components.map((c) => c.afterDOMLoaded),
-    )
-    Group.beforeDOMLoaded = concatenateResources(
-        ...config.components.map((c) => c.beforeDOMLoaded),
-    )
-    Group.css = concatenateResources(...config.components.map((c) => c.css))
-    return Group
+  Group.afterDOMLoaded = concatenateResources(...config.components.map((c) => c.afterDOMLoaded))
+  Group.beforeDOMLoaded = concatenateResources(...config.components.map((c) => c.beforeDOMLoaded))
+  Group.css = concatenateResources(...config.components.map((c) => c.css))
+  return Group
 }) satisfies QuartzComponentConstructor<GroupConfig>

--- a/quartz/components/index.ts
+++ b/quartz/components/index.ts
@@ -23,6 +23,7 @@ import Breadcrumbs from "./Breadcrumbs"
 import Comments from "./Comments"
 import Flex from "./Flex"
 import ConditionalRender from "./ConditionalRender"
+import Group from "./Group"
 
 export {
   ArticleTitle,
@@ -50,4 +51,5 @@ export {
   Comments,
   Flex,
   ConditionalRender,
+  Group
 }

--- a/quartz/components/index.ts
+++ b/quartz/components/index.ts
@@ -51,5 +51,5 @@ export {
   Comments,
   Flex,
   ConditionalRender,
-  Group
+  Group,
 }


### PR DESCRIPTION
Currently, there appears to be no way of grouping components without applying any additional formatting to them. The `Flex` component achieves this, however in some situations it could interfere with the layout, and that is not always desired. 

My main use case is grouping multiple components so that they can be placed into a `ConditionalRender` component easily. One option would be to allow the `ConditionalRender` to receive a list of components, however I wanted feedback on this solution first as it is fairly simple, and may have more use cases that I’m not aware of. Thanks!