### PR TITLE
fix(analytics): streamline posthog script loading and event capturing

### DIFF
--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -159,14 +159,10 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
       posthog.init('${cfg.analytics.apiKey}', {
         api_host: '${cfg.analytics.host ?? "https://app.posthog.com"}',
         capture_pageview: false,
-      })\`
-      posthogScript.onload = () => {
+      });
+      document.addEventListener('nav', () => {
         posthog.capture('$pageview', { path: location.pathname });
-      
-        document.addEventListener('nav', () => {
-          posthog.capture('$pageview', { path: location.pathname });
-        });
-      };
+      })\`
 
       document.head.appendChild(posthogScript);
     `)


### PR DESCRIPTION
Fixes https://github.com/jackyzha0/quartz/issues/1962 

The `posthogScript.onload()` event isn't fired because we're not loading an external script (unlike other analytics providers). As a result, the `pageview` event wasn't being captured correctly.

This PR moves the `pageview` event-capturing logic inside the posthogScript itself, ensuring it registers properly when the script is loaded.

I've tested the changes locally and confirmed that events are now being sent correctly to PostHog.

Changes made:
1. Moved pageview event capture into the inline posthogScript
2. Removed a redudant `pageview` capture

