### PR TITLE
Feature: ReplyByEmail button

### DIFF
--- a/docs/features/replybyemail button.md
+++ b/docs/features/replybyemail button.md
@@ -1,0 +1,67 @@
+---
+title: Reply by Email Button
+tags:
+  - component
+---
+
+The Reply By Email Button is a feature that allows users to display a button under their notes, allowing visitors to send them an email to an obfuscated email address.  
+- The email address is base64 encoded to provide some basic protection from bots.
+- The subject line of the email will be taken from the page Title where the button is clicked.
+- You can specify on what notes the button should be displayed or excluded.
+- The label on the button can also be customised.
+
+## Configuration
+
+The Reply By Email Button is disabled by default. To enable it, you can add the component to your layout configuration in `quartz.layout.ts`.
+
+Minimal configuration:
+```ts
+Component.ReplyByEmail({
+  username: "Y29udGFjdA==", // "contact" encoded in base64, as in contact@example.com
+  domain: "ZXhhbXBsZS5jb20=", // "example.com" encoded in base64, as in contact@example.com
+}),
+```
+You can specify under which notes to display the button by adding the following:
+```ts
+includeTitles: ["Welcome to Quartz 4", "Reply by Email Button"],
+```
+Alternatively, you can include the button by default by ommiting the `includeTitles` line, and specify notes under which the button should not be displayed:
+```ts
+excludeTitles: ["Welcome to Quartz 4", "Home"],
+```
+You can also override the default `buttonLabel` text:
+```ts
+buttonLabel: "Reply by email"
+```
+
+
+## Usage
+
+The natural placement for the Reply By Email Button is within `afterBody` in the Content Pages, so that it is displayed right under the note:
+
+```ts
+  afterBody: [
+    Component.ReplyByEmail({
+      username: "Y29udGFjdA==", // "contact" encoded in base64, as in contact@example.com
+      domain: "ZXhhbXBsZS5jb20=", // "example.com" encoded in base64, as in contact@example.com
+      // includeTitles: ["Welcome to Quartz 4"], // You can specify which page titles to include or comment out the line to include on all pages
+      excludeTitles: ["Welcome to Quartz 4", "Home"],  // You can specify which page titles to exclude when includeTitles is empty
+      buttonLabel: "Submit feedback by email" // You can override the default button text "Reply by email"
+    }),
+  ],
+```
+
+## Customization
+
+You can customize the appearance of the ReplyByEmail button through CSS variables and styles. The component uses the following class:
+
+- `.reply-by-email-button`
+
+
+Example customization in your custom CSS:
+
+```scss
+.reply-by-email-button {
+  color: var(--tertiary);
+}
+```

--- a/docs/features/replybyemail button.md
+++ b/docs/features/replybyemail button.md
@@ -4,9 +4,9 @@ tags:
   - component
 ---
 
-The Reply By Email Button is a feature that allows users to display a button under their notes, allowing visitors to send them an email to an obfuscated email address.  
+The Reply By Email Button is a feature that allows users to display a button under their notes, allowing visitors to comment or submited feedback for your notes via email.  
 - The email address is base64 encoded to provide some basic protection from bots.
-- The subject line of the email will be taken from the page Title where the button is clicked.
+- The subject line of the email will be taken from the page title where the button is clicked.
 - You can specify on what notes the button should be displayed or excluded.
 - The label on the button can also be customised.
 
@@ -17,13 +17,12 @@ The Reply By Email Button is disabled by default. To enable it, you can add the 
 Minimal configuration:
 ```ts
 Component.ReplyByEmail({
-  username: "Y29udGFjdA==", // "contact" encoded in base64, as in contact@example.com
-  domain: "ZXhhbXBsZS5jb20=", // "example.com" encoded in base64, as in contact@example.com
+  email: "contact@example.com"
 }),
 ```
 You can specify under which notes to display the button by adding the following:
 ```ts
-includeTitles: ["Welcome to Quartz 4", "Reply by Email Button"],
+includeTitles: ["Welcome to Quartz 4", "Reply by Email Button", "Contact"],
 ```
 Alternatively, you can include the button by default by ommiting the `includeTitles` line, and specify notes under which the button should not be displayed:
 ```ts
@@ -42,8 +41,7 @@ The natural placement for the Reply By Email Button is within `afterBody` in the
 ```ts
   afterBody: [
     Component.ReplyByEmail({
-      username: "Y29udGFjdA==", // "contact" encoded in base64, as in contact@example.com
-      domain: "ZXhhbXBsZS5jb20=", // "example.com" encoded in base64, as in contact@example.com
+      email: "contact@example.com", // The email address to be linked to
       // includeTitles: ["Welcome to Quartz 4"], // You can specify which page titles to include or comment out the line to include on all pages
       excludeTitles: ["Welcome to Quartz 4", "Home"],  // You can specify which page titles to exclude when includeTitles is empty
       buttonLabel: "Submit feedback by email" // You can override the default button text "Reply by email"

--- a/quartz/components/ReplyByEmail.tsx
+++ b/quartz/components/ReplyByEmail.tsx
@@ -6,6 +6,7 @@ interface ReplyByEmailOptions {
   domain?: string
   includeTitles?: string[]
   excludeTitles?: string[]
+  buttonLabel?: string
 }
 
 // Default options will be used if not provided in the layout file
@@ -13,7 +14,8 @@ const defaultOptions: ReplyByEmailOptions = {
   username: "ZW1haWw=", // "email" in base64
   domain: "ZXhhbXBsZS5jb20=", // "email.com" in base64
   includeTitles: [],
-  excludeTitles: ["Home", "About me", "Contact me"]
+  excludeTitles: ["Home", "About me", "Contact me"],
+  buttonLabel: "Reply by email"
 }
 
 const ReplyByEmail: QuartzComponent = ({
@@ -22,7 +24,8 @@ const ReplyByEmail: QuartzComponent = ({
   username,
   domain,
   includeTitles,
-  excludeTitles
+  excludeTitles,
+  buttonLabel
 }: QuartzComponentProps & ReplyByEmailOptions) => {
   const title = fileData.frontmatter?.title
 
@@ -31,6 +34,7 @@ const ReplyByEmail: QuartzComponent = ({
   const encodedPart2 = domain || defaultOptions.domain
   const includeList = includeTitles || defaultOptions.includeTitles
   const excludeList = excludeTitles || defaultOptions.excludeTitles
+  const label = buttonLabel || defaultOptions.buttonLabel
 
   // Display logic:
   // 1. If includeTitles is not empty, only show on those pages
@@ -49,7 +53,7 @@ const ReplyByEmail: QuartzComponent = ({
       data-domain={encodedPart2}
       data-title={encodeURIComponent(title)}
       >
-      Reply by email
+      {label}
       </button>
       </div>
     )
@@ -130,7 +134,8 @@ export default ((opts?: ReplyByEmailOptions) => {
       username: opts?.username,
       domain: opts?.domain,
       includeTitles: opts?.includeTitles,
-      excludeTitles: opts?.excludeTitles
+      excludeTitles: opts?.excludeTitles,
+      buttonLabel: opts?.buttonLabel
     })
   }
 

--- a/quartz/components/ReplyByEmail.tsx
+++ b/quartz/components/ReplyByEmail.tsx
@@ -47,14 +47,14 @@ const ReplyByEmail: QuartzComponent = ({
   if (shouldDisplay) {
     return (
       <div class="center-wrapper">
-      <button
-      class={classNames(displayClass, "reply-by-email-button")}
-      data-username={encodedPart1}
-      data-domain={encodedPart2}
-      data-title={encodeURIComponent(title)}
-      >
-      {label}
-      </button>
+        <button
+          class={classNames(displayClass, "reply-by-email-button")}
+          data-username={encodedPart1}
+          data-domain={encodedPart2}
+          data-title={encodeURIComponent(title)}
+        >
+          {label}
+        </button>
       </div>
     )
   } else {

--- a/quartz/components/ReplyByEmail.tsx
+++ b/quartz/components/ReplyByEmail.tsx
@@ -2,17 +2,13 @@ import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } fro
 import { classNames } from "../util/lang"
 
 interface ReplyByEmailOptions {
-  username?: string
-  domain?: string
+  email: string
   includeTitles?: string[]
   excludeTitles?: string[]
   buttonLabel?: string
 }
 
-// Default options will be used if not provided in the layout file
-const defaultOptions: ReplyByEmailOptions = {
-  username: "Y29udGFjdA==", // "contact" encoded in base64, as in contact@example.com
-  domain: "ZXhhbXBsZS5jb20=", // "example.com" encoded in base64, as in contact@example.com
+const defaultOptions: Partial<ReplyByEmailOptions> = {
   includeTitles: [],
   excludeTitles: [],
   buttonLabel: "Reply by email"
@@ -21,17 +17,15 @@ const defaultOptions: ReplyByEmailOptions = {
 const ReplyByEmail: QuartzComponent = ({
   fileData,
   displayClass,
-  username,
-  domain,
+  email,
   includeTitles,
   excludeTitles,
   buttonLabel
 }: QuartzComponentProps & ReplyByEmailOptions) => {
   const title = fileData.frontmatter?.title
 
-  // Use provided values or defaults
-  const encodedPart1 = username || defaultOptions.username
-  const encodedPart2 = domain || defaultOptions.domain
+  const encodedEmail = btoa(email)
+
   const includeList = includeTitles || defaultOptions.includeTitles
   const excludeList = excludeTitles || defaultOptions.excludeTitles
   const label = buttonLabel || defaultOptions.buttonLabel
@@ -47,15 +41,22 @@ const ReplyByEmail: QuartzComponent = ({
   if (shouldDisplay) {
     return (
       <div class="center-wrapper">
-        <button
-          class={classNames(displayClass, "reply-by-email-button")}
-          data-username={encodedPart1}
-          data-domain={encodedPart2}
-          data-title={encodeURIComponent(title)}
+      <button
+      class={classNames(displayClass, "reply-by-email-button")}
+      data-email={encodedEmail}
+      data-title={encodeURIComponent(title)}
+      onclick={`
+        const encodedEmail = this.getAttribute('data-email');
+        const email = atob(encodedEmail);
+        const title = this.getAttribute('data-title');
+        const mailtoLink = 'mailto:' + email + '?subject=' + title;
+        window.location.href = mailtoLink;
+        return false;
+        `}
         >
-          {label}
+        {label}
         </button>
-      </div>
+        </div>
     )
   } else {
     return null
@@ -87,61 +88,22 @@ ReplyByEmail.css = `
 }
 `
 
-// Script that works with SPA navigation
-ReplyByEmail.beforeDOMLoaded = `
-// Function to attach email button handlers
-function attachEmailHandlers() {
-  document.querySelectorAll('.reply-by-email-button').forEach(function(button) {
-    // Remove existing event listeners first to prevent duplicates
-    button.removeEventListener('click', handleEmailButtonClick);
-    // Add fresh event listener
-    button.addEventListener('click', handleEmailButtonClick);
-  });
-}
-
-// Handler function for the email button click
-function handleEmailButtonClick(e) {
-  e.preventDefault();
-
-  // Get data attributes
-  const username = atob(this.getAttribute('data-username'));
-  const domain = atob(this.getAttribute('data-domain'));
-  const title = this.getAttribute('data-title');
-
-  // Create email address and mailto link
-  const email = username + '@' + domain;
-  const mailtoLink = 'mailto:' + email + '?subject=' + title;
-
-  // Open email client
-  window.location.href = mailtoLink;
-}
-
-// Initial attachment when the page loads
-document.addEventListener('DOMContentLoaded', attachEmailHandlers);
-
-// Re-attach handlers after SPA navigation
-document.addEventListener('nav', function() {
-  // Small delay to ensure the new buttons are in the DOM
-  setTimeout(attachEmailHandlers, 10);
-});
-`
-
 export default ((opts?: ReplyByEmailOptions) => {
-  // Component constructor that accepts options
+  if (!opts?.email) {
+    throw new Error("ReplyByEmail component requires an email parameter")
+  }
+
   const component: QuartzComponent = (props) => {
     return ReplyByEmail({
       ...props,
-      username: opts?.username,
-      domain: opts?.domain,
+      email: opts.email,
       includeTitles: opts?.includeTitles,
       excludeTitles: opts?.excludeTitles,
       buttonLabel: opts?.buttonLabel
     })
   }
 
-  // Pass through the CSS and beforeDOMLoaded
   component.css = ReplyByEmail.css
-  component.beforeDOMLoaded = ReplyByEmail.beforeDOMLoaded
 
   return component
 }) satisfies QuartzComponentConstructor

--- a/quartz/components/ReplyByEmail.tsx
+++ b/quartz/components/ReplyByEmail.tsx
@@ -41,11 +41,11 @@ const ReplyByEmail: QuartzComponent = ({
   if (shouldDisplay) {
     return (
       <div class="center-wrapper">
-      <button
-      class={classNames(displayClass, "reply-by-email-button")}
-      data-email={encodedEmail}
-      data-title={encodeURIComponent(title)}
-      onclick={`
+        <button
+          class={classNames(displayClass, "reply-by-email-button")}
+          data-email={encodedEmail}
+          data-title={encodeURIComponent(title)}
+          onclick={`
         const encodedEmail = this.getAttribute('data-email');
         const email = atob(encodedEmail);
         const title = this.getAttribute('data-title');
@@ -54,9 +54,9 @@ const ReplyByEmail: QuartzComponent = ({
         return false;
         `}
         >
-        {label}
+          {label}
         </button>
-        </div>
+      </div>
     )
   } else {
     return null

--- a/quartz/components/ReplyByEmail.tsx
+++ b/quartz/components/ReplyByEmail.tsx
@@ -1,0 +1,142 @@
+import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
+import { classNames } from "../util/lang"
+
+interface ReplyByEmailOptions {
+  username?: string
+  domain?: string
+  includeTitles?: string[]
+  excludeTitles?: string[]
+}
+
+// Default options will be used if not provided in the layout file
+const defaultOptions: ReplyByEmailOptions = {
+  username: "ZW1haWw=", // "email" in base64
+  domain: "ZXhhbXBsZS5jb20=", // "email.com" in base64
+  includeTitles: [],
+  excludeTitles: ["Home", "About me", "Contact me"]
+}
+
+const ReplyByEmail: QuartzComponent = ({
+  fileData,
+  displayClass,
+  username,
+  domain,
+  includeTitles,
+  excludeTitles
+}: QuartzComponentProps & ReplyByEmailOptions) => {
+  const title = fileData.frontmatter?.title
+
+  // Use provided values or defaults
+  const encodedPart1 = username || defaultOptions.username
+  const encodedPart2 = domain || defaultOptions.domain
+  const includeList = includeTitles || defaultOptions.includeTitles
+  const excludeList = excludeTitles || defaultOptions.excludeTitles
+
+  // Display logic:
+  // 1. If includeTitles is not empty, only show on those pages
+  // 2. If includeTitles is empty, show on all pages except those in excludeTitles
+  const shouldDisplay = title && (
+    (includeList.length > 0 && includeList.includes(title)) ||
+    (includeList.length === 0 && !excludeList.includes(title))
+  )
+
+  if (shouldDisplay) {
+    return (
+      <div class="center-wrapper">
+      <button
+      class={classNames(displayClass, "reply-by-email-button")}
+      data-username={encodedPart1}
+      data-domain={encodedPart2}
+      data-title={encodeURIComponent(title)}
+      >
+      Reply by email
+      </button>
+      </div>
+    )
+  } else {
+    return null
+  }
+}
+
+ReplyByEmail.css = `
+.center-wrapper {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 2rem;
+}
+
+.reply-by-email-button {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  background-color: var(--highlight);
+  color: var(--secondary);
+  border-radius: 5px;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+  cursor: pointer;
+  border: none;
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.reply-by-email-button:hover {
+  transform: scale(1.05);
+}
+`
+
+// Script that works with SPA navigation
+ReplyByEmail.beforeDOMLoaded = `
+// Function to attach email button handlers
+function attachEmailHandlers() {
+  document.querySelectorAll('.reply-by-email-button').forEach(function(button) {
+    // Remove existing event listeners first to prevent duplicates
+    button.removeEventListener('click', handleEmailButtonClick);
+    // Add fresh event listener
+    button.addEventListener('click', handleEmailButtonClick);
+  });
+}
+
+// Handler function for the email button click
+function handleEmailButtonClick(e) {
+  e.preventDefault();
+
+  // Get data attributes
+  const username = atob(this.getAttribute('data-username'));
+  const domain = atob(this.getAttribute('data-domain'));
+  const title = this.getAttribute('data-title');
+
+  // Create email address and mailto link
+  const email = username + '@' + domain;
+  const mailtoLink = 'mailto:' + email + '?subject=' + title;
+
+  // Open email client
+  window.location.href = mailtoLink;
+}
+
+// Initial attachment when the page loads
+document.addEventListener('DOMContentLoaded', attachEmailHandlers);
+
+// Re-attach handlers after SPA navigation
+document.addEventListener('nav', function() {
+  // Small delay to ensure the new buttons are in the DOM
+  setTimeout(attachEmailHandlers, 10);
+});
+`
+
+export default ((opts?: ReplyByEmailOptions) => {
+  // Component constructor that accepts options
+  const component: QuartzComponent = (props) => {
+    return ReplyByEmail({
+      ...props,
+      username: opts?.username,
+      domain: opts?.domain,
+      includeTitles: opts?.includeTitles,
+      excludeTitles: opts?.excludeTitles
+    })
+  }
+
+  // Pass through the CSS and beforeDOMLoaded
+  component.css = ReplyByEmail.css
+  component.beforeDOMLoaded = ReplyByEmail.beforeDOMLoaded
+
+  return component
+}) satisfies QuartzComponentConstructor

--- a/quartz/components/ReplyByEmail.tsx
+++ b/quartz/components/ReplyByEmail.tsx
@@ -11,10 +11,10 @@ interface ReplyByEmailOptions {
 
 // Default options will be used if not provided in the layout file
 const defaultOptions: ReplyByEmailOptions = {
-  username: "ZW1haWw=", // "email" in base64
-  domain: "ZXhhbXBsZS5jb20=", // "email.com" in base64
+  username: "Y29udGFjdA==", // "contact" encoded in base64, as in contact@example.com
+  domain: "ZXhhbXBsZS5jb20=", // "example.com" encoded in base64, as in contact@example.com
   includeTitles: [],
-  excludeTitles: ["Home", "About me", "Contact me"],
+  excludeTitles: [],
   buttonLabel: "Reply by email"
 }
 

--- a/quartz/components/index.ts
+++ b/quartz/components/index.ts
@@ -23,6 +23,7 @@ import Breadcrumbs from "./Breadcrumbs"
 import Comments from "./Comments"
 import Flex from "./Flex"
 import ConditionalRender from "./ConditionalRender"
+import ReplyByEmail from "./ReplyByEmail"
 
 export {
   ArticleTitle,
@@ -50,4 +51,5 @@ export {
   Comments,
   Flex,
   ConditionalRender,
+  ReplyByEmail,
 }


### PR DESCRIPTION
Adds the ability to add a ReplyByEmail button to your notes. 

The Reply By Email Button is a feature that allows users to display a button under their notes, allowing visitors to send an email to an obfuscated email address.  
- The email address is base64 encoded to provide some basic protection from bots.
- The subject line of the email will be taken from the page Title where the button is clicked.
- You can specify on what notes the button should be displayed or excluded.
- The label on the button can also be customised.
- The button works as a mailto, ie opens the link or mobile email app.

This is what it looks like on the default Quartz site:

![image](https://github.com/user-attachments/assets/8396ae2d-f2c5-4d6a-9db3-670358ffde88)
![image](https://github.com/user-attachments/assets/67e0e22c-4840-4856-8b1c-23ca128d1763)


This is disabled by default.
I've included documentation.


The natural placement for the Reply By Email Button is within `afterBody` in the Content Pages, so that it is displayed right under the note:

```ts
  afterBody: [
    Component.ReplyByEmail({
      username: "Y29udGFjdA==", // "contact" encoded in base64, as in contact@example.com
      domain: "ZXhhbXBsZS5jb20=", // "example.com" encoded in base64, as in contact@example.com
      // includeTitles: ["Welcome to Quartz 4"], // You can specify which page titles to include or comment out the line to include on all pages
      excludeTitles: ["Welcome to Quartz 4", "Home"],  // You can specify which page titles to exclude when includeTitles is empty
      buttonLabel: "Submit feedback by email" // You can override the default button text "Reply by email"
    }),
  ],
```

I had a really basic custom component, but the `enableSPA: true` was acting up when I used Cloudflare's email obfuscation. When trying to fix it  I just thought I might as well remove the *hardcoding* and made it so it could all be configured on the layout file.

There's probably not a lot of demand for this, but considering there is already a `Comments` feature, I thought an old fashioned email functionality for this would not be out of place in Quartz.
Even if this isn't merged the PR makes it a bit more visible for anyone looking for the same functionality.

I have it working on my Quartz page if you want a demo: https://dansgarden.eu/contact