### PR TITLE
fix(a11y): increased content-meta text contrast

### DIFF
--- a/quartz/components/styles/contentMeta.scss
+++ b/quartz/components/styles/contentMeta.scss
@@ -1,6 +1,6 @@
 .content-meta {
   margin-top: 0;
-  color: var(--gray);
+  color: var(--darkgray);
 
   &[show-comma="true"] {
     > *:not(:last-child) {


### PR DESCRIPTION
Closes https://github.com/jackyzha0/quartz/issues/1979

Changes the `.content-meta` to have a font color matching the font color of most normal text. Address lackluster contrasts with the background.

The `.content-meta` class is used for the part under the page title and, by default, shows the note's date and reading time.