### PR TITLE
feat: add page count component

### DIFF
--- a/quartz/components/PageCount.tsx
+++ b/quartz/components/PageCount.tsx
@@ -1,0 +1,26 @@
+import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
+import { classNames } from "../util/lang"
+import { i18n } from "../i18n"
+
+const PageCount: QuartzComponent = ({
+  allFiles,
+  displayClass,
+  cfg,
+}: QuartzComponentProps) => {
+  const count = allFiles.length
+  return (
+    <div class={classNames(displayClass, "page-count")}>
+      <p>{i18n(cfg.locale).components.pageCount.totalItems({ count })}</p>
+    </div>
+  )
+}
+
+PageCount.css = `
+.page-count {
+  padding: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--secondary);
+}
+`
+
+export default (() => PageCount) satisfies QuartzComponentConstructor

--- a/quartz/components/PageCount.tsx
+++ b/quartz/components/PageCount.tsx
@@ -2,11 +2,7 @@ import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } fro
 import { classNames } from "../util/lang"
 import { i18n } from "../i18n"
 
-const PageCount: QuartzComponent = ({
-  allFiles,
-  displayClass,
-  cfg,
-}: QuartzComponentProps) => {
+const PageCount: QuartzComponent = ({ allFiles, displayClass, cfg }: QuartzComponentProps) => {
   const count = allFiles.length
   return (
     <div class={classNames(displayClass, "page-count")}>

--- a/quartz/components/index.ts
+++ b/quartz/components/index.ts
@@ -23,6 +23,7 @@ import Breadcrumbs from "./Breadcrumbs"
 import Comments from "./Comments"
 import Flex from "./Flex"
 import ConditionalRender from "./ConditionalRender"
+import PageCount from "./PageCount"
 
 export {
   ArticleTitle,
@@ -50,4 +51,5 @@ export {
   Comments,
   Flex,
   ConditionalRender,
+  PageCount,
 }

--- a/quartz/i18n/locales/ar-SA.ts
+++ b/quartz/i18n/locales/ar-SA.ts
@@ -64,6 +64,9 @@ export default {
             ? `دقيقتان للقراءة`
             : `${minutes} دقائق للقراءة`,
     },
+    pageCount: {
+      totalItems: ({ count }) => `${count} ملاحظات`,
+    },
   },
   pages: {
     rss: {

--- a/quartz/i18n/locales/ca-ES.ts
+++ b/quartz/i18n/locales/ca-ES.ts
@@ -59,6 +59,9 @@ export default {
     contentMeta: {
       readingTime: ({ minutes }) => `Es llegeix en ${minutes} min`,
     },
+    pageCount: {
+      totalItems: ({ count }) => `${count} notes`,
+    },
   },
   pages: {
     rss: {

--- a/quartz/i18n/locales/cs-CZ.ts
+++ b/quartz/i18n/locales/cs-CZ.ts
@@ -59,6 +59,9 @@ export default {
     contentMeta: {
       readingTime: ({ minutes }) => `${minutes} min čtení`,
     },
+    pageCount: {
+      totalItems: ({ count }) => `${count} poznámek`,
+    },
   },
   pages: {
     rss: {

--- a/quartz/i18n/locales/de-DE.ts
+++ b/quartz/i18n/locales/de-DE.ts
@@ -59,6 +59,9 @@ export default {
     contentMeta: {
       readingTime: ({ minutes }) => `${minutes} min read`,
     },
+    pageCount: {
+      totalItems: ({ count }) => `${count} Seiten`,
+    },
   },
   pages: {
     rss: {

--- a/quartz/i18n/locales/definition.ts
+++ b/quartz/i18n/locales/definition.ts
@@ -61,6 +61,9 @@ export interface Translation {
     contentMeta: {
       readingTime: (variables: { minutes: number }) => string
     }
+    pageCount: {
+      totalItems: (variables: { count: number }) => string
+    }
   }
   pages: {
     rss: {

--- a/quartz/i18n/locales/en-GB.ts
+++ b/quartz/i18n/locales/en-GB.ts
@@ -59,6 +59,9 @@ export default {
     contentMeta: {
       readingTime: ({ minutes }) => `${minutes} min read`,
     },
+    pageCount: {
+      totalItems: ({ count }) => `${count} notes`,
+    },
   },
   pages: {
     rss: {

--- a/quartz/i18n/locales/en-US.ts
+++ b/quartz/i18n/locales/en-US.ts
@@ -59,6 +59,9 @@ export default {
     contentMeta: {
       readingTime: ({ minutes }) => `${minutes} min read`,
     },
+    pageCount: {
+      totalItems: ({ count }) => `${count} notes`,
+    },
   },
   pages: {
     rss: {

--- a/quartz/i18n/locales/es-ES.ts
+++ b/quartz/i18n/locales/es-ES.ts
@@ -59,6 +59,9 @@ export default {
     contentMeta: {
       readingTime: ({ minutes }) => `Se lee en ${minutes} min`,
     },
+    pageCount: {
+      totalItems: ({ count }) => `${count} notas`,
+    },
   },
   pages: {
     rss: {

--- a/quartz/i18n/locales/fa-IR.ts
+++ b/quartz/i18n/locales/fa-IR.ts
@@ -59,6 +59,9 @@ export default {
     contentMeta: {
       readingTime: ({ minutes }) => `زمان تقریبی مطالعه: ${minutes} دقیقه`,
     },
+    pageCount: {
+      totalItems: ({ count }) => `${count} یادداشت`,
+    },
   },
   pages: {
     rss: {

--- a/quartz/i18n/locales/fi-FI.ts
+++ b/quartz/i18n/locales/fi-FI.ts
@@ -59,6 +59,9 @@ export default {
     contentMeta: {
       readingTime: ({ minutes }) => `${minutes} min lukuaika`,
     },
+    pageCount: {
+      totalItems: ({ count }) => `${count} muistiinpanoa`,
+    },
   },
   pages: {
     rss: {

--- a/quartz/i18n/locales/fr-FR.ts
+++ b/quartz/i18n/locales/fr-FR.ts
@@ -59,6 +59,9 @@ export default {
     contentMeta: {
       readingTime: ({ minutes }) => `${minutes} min de lecture`,
     },
+    pageCount: {
+      totalItems: ({ count }) => `${count} notes`,
+    },
   },
   pages: {
     rss: {

--- a/quartz/i18n/locales/hu-HU.ts
+++ b/quartz/i18n/locales/hu-HU.ts
@@ -57,7 +57,10 @@ export default {
       title: "Tartalomjegyzék",
     },
     contentMeta: {
-      readingTime: ({ minutes }) => `${minutes} perces olvasás`,
+      readingTime: ({ minutes }) => `${minutes} perc olvasás`,
+    },
+    pageCount: {
+      totalItems: ({ count }) => `${count} jegyzet`,
     },
   },
   pages: {

--- a/quartz/i18n/locales/hu-HU.ts
+++ b/quartz/i18n/locales/hu-HU.ts
@@ -57,7 +57,7 @@ export default {
       title: "Tartalomjegyzék",
     },
     contentMeta: {
-      readingTime: ({ minutes }) => `${minutes} perc olvasás`,
+      readingTime: ({ minutes }) => `${minutes} perces olvasás`,
     },
     pageCount: {
       totalItems: ({ count }) => `${count} jegyzet`,

--- a/quartz/i18n/locales/id-ID.ts
+++ b/quartz/i18n/locales/id-ID.ts
@@ -57,7 +57,10 @@ export default {
       title: "Daftar Isi",
     },
     contentMeta: {
-      readingTime: ({ minutes }) => `${minutes} menit baca`,
+      readingTime: ({ minutes }) => `${minutes} mnt baca`,
+    },
+    pageCount: {
+      totalItems: ({ count }) => `${count} catatan`,
     },
   },
   pages: {

--- a/quartz/i18n/locales/id-ID.ts
+++ b/quartz/i18n/locales/id-ID.ts
@@ -57,7 +57,7 @@ export default {
       title: "Daftar Isi",
     },
     contentMeta: {
-      readingTime: ({ minutes }) => `${minutes} mnt baca`,
+      readingTime: ({ minutes }) => `${minutes} menit baca`,
     },
     pageCount: {
       totalItems: ({ count }) => `${count} catatan`,

--- a/quartz/i18n/locales/it-IT.ts
+++ b/quartz/i18n/locales/it-IT.ts
@@ -57,7 +57,10 @@ export default {
       title: "Tabella dei contenuti",
     },
     contentMeta: {
-      readingTime: ({ minutes }) => `${minutes} minuti`,
+      readingTime: ({ minutes }) => `${minutes} min di lettura`,
+    },
+    pageCount: {
+      totalItems: ({ count }) => `${count} note`,
     },
   },
   pages: {

--- a/quartz/i18n/locales/it-IT.ts
+++ b/quartz/i18n/locales/it-IT.ts
@@ -57,7 +57,7 @@ export default {
       title: "Tabella dei contenuti",
     },
     contentMeta: {
-      readingTime: ({ minutes }) => `${minutes} min di lettura`,
+      readingTime: ({ minutes }) => `${minutes} minuti`,
     },
     pageCount: {
       totalItems: ({ count }) => `${count} note`,

--- a/quartz/i18n/locales/ja-JP.ts
+++ b/quartz/i18n/locales/ja-JP.ts
@@ -59,6 +59,9 @@ export default {
     contentMeta: {
       readingTime: ({ minutes }) => `${minutes} min read`,
     },
+    pageCount: {
+      totalItems: ({ count }) => `${count}件のページ`,
+    },
   },
   pages: {
     rss: {

--- a/quartz/i18n/locales/ko-KR.ts
+++ b/quartz/i18n/locales/ko-KR.ts
@@ -57,7 +57,7 @@ export default {
       title: "목차",
     },
     contentMeta: {
-      readingTime: ({ minutes }) => `${minutes}분 분량`,
+      readingTime: ({ minutes }) => `${minutes} min read`,
     },
     pageCount: {
       totalItems: ({ count }) => `${count}건의 페이지`,

--- a/quartz/i18n/locales/ko-KR.ts
+++ b/quartz/i18n/locales/ko-KR.ts
@@ -57,7 +57,10 @@ export default {
       title: "목차",
     },
     contentMeta: {
-      readingTime: ({ minutes }) => `${minutes} min read`,
+      readingTime: ({ minutes }) => `${minutes}분 분량`,
+    },
+    pageCount: {
+      totalItems: ({ count }) => `${count}건의 페이지`,
     },
   },
   pages: {

--- a/quartz/i18n/locales/lt-LT.ts
+++ b/quartz/i18n/locales/lt-LT.ts
@@ -57,7 +57,7 @@ export default {
       title: "Turinys",
     },
     contentMeta: {
-      readingTime: ({ minutes }) => `${minutes} min. skaitymo`,
+      readingTime: ({ minutes }) => `${minutes} min skaitymo`,
     },
     pageCount: {
       totalItems: ({ count }) => `${count} užrašai`,

--- a/quartz/i18n/locales/lt-LT.ts
+++ b/quartz/i18n/locales/lt-LT.ts
@@ -57,7 +57,10 @@ export default {
       title: "Turinys",
     },
     contentMeta: {
-      readingTime: ({ minutes }) => `${minutes} min skaitymo`,
+      readingTime: ({ minutes }) => `${minutes} min. skaitymo`,
+    },
+    pageCount: {
+      totalItems: ({ count }) => `${count} užrašai`,
     },
   },
   pages: {

--- a/quartz/i18n/locales/nb-NO.ts
+++ b/quartz/i18n/locales/nb-NO.ts
@@ -57,7 +57,7 @@ export default {
       title: "Oversikt",
     },
     contentMeta: {
-      readingTime: ({ minutes }) => `${minutes} min lesetid`,
+      readingTime: ({ minutes }) => `${minutes} min lesning`,
     },
     pageCount: {
       totalItems: ({ count }) => `${count} notater`,

--- a/quartz/i18n/locales/nb-NO.ts
+++ b/quartz/i18n/locales/nb-NO.ts
@@ -57,7 +57,10 @@ export default {
       title: "Oversikt",
     },
     contentMeta: {
-      readingTime: ({ minutes }) => `${minutes} min lesning`,
+      readingTime: ({ minutes }) => `${minutes} min lesetid`,
+    },
+    pageCount: {
+      totalItems: ({ count }) => `${count} notater`,
     },
   },
   pages: {

--- a/quartz/i18n/locales/nl-NL.ts
+++ b/quartz/i18n/locales/nl-NL.ts
@@ -57,8 +57,10 @@ export default {
       title: "Inhoudsopgave",
     },
     contentMeta: {
-      readingTime: ({ minutes }) =>
-        minutes === 1 ? "1 minuut leestijd" : `${minutes} minuten leestijd`,
+      readingTime: ({ minutes }) => `${minutes} min lezen`,
+    },
+    pageCount: {
+      totalItems: ({ count }) => `${count} notities`,
     },
   },
   pages: {

--- a/quartz/i18n/locales/nl-NL.ts
+++ b/quartz/i18n/locales/nl-NL.ts
@@ -57,7 +57,8 @@ export default {
       title: "Inhoudsopgave",
     },
     contentMeta: {
-      readingTime: ({ minutes }) => `${minutes} min lezen`,
+      readingTime: ({ minutes }) =>
+        minutes === 1 ? "1 minuut leestijd" : `${minutes} minuten leestijd`,
     },
     pageCount: {
       totalItems: ({ count }) => `${count} notities`,

--- a/quartz/i18n/locales/pl-PL.ts
+++ b/quartz/i18n/locales/pl-PL.ts
@@ -57,7 +57,10 @@ export default {
       title: "Spis treści",
     },
     contentMeta: {
-      readingTime: ({ minutes }) => `${minutes} min. czytania `,
+      readingTime: ({ minutes }) => `${minutes} min czytania`,
+    },
+    pageCount: {
+      totalItems: ({ count }) => `${count} notatki`,
     },
   },
   pages: {

--- a/quartz/i18n/locales/pl-PL.ts
+++ b/quartz/i18n/locales/pl-PL.ts
@@ -57,10 +57,10 @@ export default {
       title: "Spis treści",
     },
     contentMeta: {
-      readingTime: ({ minutes }) => `${minutes} min czytania`,
+      readingTime: ({ minutes }) => `${minutes} min. czytania `,
     },
     pageCount: {
-      totalItems: ({ count }) => `${count} notatki`,
+      totalItems: ({ count }) => `${count} notatek`,
     },
   },
   pages: {

--- a/quartz/i18n/locales/pt-BR.ts
+++ b/quartz/i18n/locales/pt-BR.ts
@@ -57,7 +57,10 @@ export default {
       title: "Sumário",
     },
     contentMeta: {
-      readingTime: ({ minutes }) => `Leitura de ${minutes} min`,
+      readingTime: ({ minutes }) => `${minutes} min de leitura`,
+    },
+    pageCount: {
+      totalItems: ({ count }) => `${count} notas`,
     },
   },
   pages: {

--- a/quartz/i18n/locales/pt-BR.ts
+++ b/quartz/i18n/locales/pt-BR.ts
@@ -57,7 +57,7 @@ export default {
       title: "Sumário",
     },
     contentMeta: {
-      readingTime: ({ minutes }) => `${minutes} min de leitura`,
+      readingTime: ({ minutes }) => `Leitura de ${minutes} min`,
     },
     pageCount: {
       totalItems: ({ count }) => `${count} notas`,

--- a/quartz/i18n/locales/ro-RO.ts
+++ b/quartz/i18n/locales/ro-RO.ts
@@ -60,6 +60,9 @@ export default {
       readingTime: ({ minutes }) =>
         minutes == 1 ? `lectură de 1 minut` : `lectură de ${minutes} minute`,
     },
+    pageCount: {
+      totalItems: ({ count }) => `${count} notițe`,
+    },
   },
   pages: {
     rss: {

--- a/quartz/i18n/locales/ru-RU.ts
+++ b/quartz/i18n/locales/ru-RU.ts
@@ -60,6 +60,9 @@ export default {
     contentMeta: {
       readingTime: ({ minutes }) => `время чтения ~${minutes} мин.`,
     },
+    pageCount: {
+      totalItems: ({ count }) => `${count} замет${getForm(count, "ка", "ки", "ок")}`,
+    },
   },
   pages: {
     rss: {

--- a/quartz/i18n/locales/th-TH.ts
+++ b/quartz/i18n/locales/th-TH.ts
@@ -59,6 +59,9 @@ export default {
     contentMeta: {
       readingTime: ({ minutes }) => `อ่านราว ${minutes} นาที`,
     },
+    pageCount: {
+      totalItems: ({ count }) => `${count} บันทึก`,
+    },
   },
   pages: {
     rss: {

--- a/quartz/i18n/locales/tr-TR.ts
+++ b/quartz/i18n/locales/tr-TR.ts
@@ -59,6 +59,9 @@ export default {
     contentMeta: {
       readingTime: ({ minutes }) => `${minutes} dakika okuma süresi`,
     },
+    pageCount: {
+      totalItems: ({ count }) => `${count} notlar`,
+    },
   },
   pages: {
     rss: {

--- a/quartz/i18n/locales/uk-UA.ts
+++ b/quartz/i18n/locales/uk-UA.ts
@@ -59,6 +59,9 @@ export default {
     contentMeta: {
       readingTime: ({ minutes }) => `${minutes} хв читання`,
     },
+    pageCount: {
+      totalItems: ({ count }) => `${count} нотатки`,
+    },
   },
   pages: {
     rss: {

--- a/quartz/i18n/locales/vi-VN.ts
+++ b/quartz/i18n/locales/vi-VN.ts
@@ -59,6 +59,9 @@ export default {
     contentMeta: {
       readingTime: ({ minutes }) => `đọc ${minutes} phút`,
     },
+    pageCount: {
+      totalItems: ({ count }) => `${count} bài viết`,
+    },
   },
   pages: {
     rss: {

--- a/quartz/i18n/locales/zh-CN.ts
+++ b/quartz/i18n/locales/zh-CN.ts
@@ -59,6 +59,9 @@ export default {
     contentMeta: {
       readingTime: ({ minutes }) => `${minutes}分钟阅读`,
     },
+    pageCount: {
+      totalItems: ({ count }) => `${count}条笔记`,
+    },
   },
   pages: {
     rss: {

--- a/quartz/i18n/locales/zh-TW.ts
+++ b/quartz/i18n/locales/zh-TW.ts
@@ -59,6 +59,9 @@ export default {
     contentMeta: {
       readingTime: ({ minutes }) => `閱讀時間約 ${minutes} 分鐘`,
     },
+    pageCount: {
+      totalItems: ({ count }) => `${count} 條筆記`,
+    },
   },
   pages: {
     rss: {


### PR DESCRIPTION
To help maintain note-taking motivation, knowing the total number of pages is important. This commit introduces a new `PageCount` component that displays the total number of pages (notes).

Translations have been added for each locale, referencing existing translations as a guide. However, being a native Japanese speaker, I may not have accurately translated the terms for locales other than English and Japanese. Please review the translations for other languages.