### PR TITLE
Fix: scroll to .active with consistent offset logic

### DIFF
--- a/quartz/components/scripts/explorer.inline.ts
+++ b/quartz/components/scripts/explorer.inline.ts
@@ -223,8 +223,18 @@ async function setupExplorer(currentSlug: FullSlug) {
     } else {
       // try to scroll to the active element if it exists
       const activeElement = explorerUl.querySelector(".active")
-      if (activeElement) {
-        activeElement.scrollIntoView({ behavior: "smooth" })
+      const scrollContainer = explorer.querySelector(".explorer-content ul")
+
+      if (activeElement && scrollContainer) {
+        const offset =
+          activeElement.getBoundingClientRect().top -
+          scrollContainer.getBoundingClientRect().top +
+          scrollContainer.scrollTop
+
+        scrollContainer.scrollTo({
+          top: offset,
+          behavior: "smooth"
+        })
       }
     }
 


### PR DESCRIPTION
close #1918

---

### What this fixes
Replaces `scrollIntoView()` with manual offset calculation to ensure consistent and precise scrolling of the `.active` element within the file explorer.

### Why
`scrollIntoView()` sometimes causes unexpected behavior depending on layout or parent scroll containers. This change calculates the offset manually relative to the scroll container (`.explorer-content ul`) to maintain smooth and predictable scroll positioning.

### Changes
- Removed `scrollIntoView({ behavior: "smooth", block: "nearest" })`
- Added manual offset calculation using `getBoundingClientRect()`
- Used `scrollTo({ top, behavior })` on the scroll container