### PR TITLE
fix(goatcounter): properly count SPA page hits

### DIFF
--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -135,15 +135,19 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
     `)
   } else if (cfg.analytics?.provider === "goatcounter") {
     componentResources.afterDOMLoaded.push(`
+      const goatcounterScriptPre = document.createElement('script');
+      goatcounterScriptPre.textContent = \`
+        window.goatcounter = { no_onload: true };
+      \`;
+      document.head.appendChild(goatcounterScriptPre);
+
+      const endpoint = "https://${cfg.analytics.websiteId}.${cfg.analytics.host ?? "goatcounter.com"}/count";
       const goatcounterScript = document.createElement('script');
       goatcounterScript.src = "${cfg.analytics.scriptSrc ?? "https://gc.zgo.at/count.js"}";
       goatcounterScript.defer = true;
-      goatcounterScript.setAttribute(
-        'data-goatcounter',
-        "https://${cfg.analytics.websiteId}.${cfg.analytics.host ?? "goatcounter.com"}/count"
-      );
+      goatcounterScript.setAttribute('data-goatcounter', endpoint);
       goatcounterScript.onload = () => {
-        window.goatcounter = { no_onload: true };
+        window.goatcounter.endpoint = endpoint;
         goatcounter.count({ path: location.pathname });
         document.addEventListener('nav', () => {
           goatcounter.count({ path: location.pathname });


### PR DESCRIPTION
Issue:
1. Could count for page refresh, but could not count for SPA page hits.
2. Console throws exception on load: "goatCounter.count() is not a function."
3. goatCounter.count() for page refresh is called by unexpected way.

Solution:
1. A new object created at onload, and cause the goatcounter instance create by count.js disappear. From the doc, should do it before count.js.
2. <script> blocks will be removed while navigating with SPA, and count.js can not find endpoint since it does query each time. The solution is to set endpoint manually.
