### PR TITLE
fix(explorer): Set explorer-collapsed overflow to visible

### DIFF
--- a/quartz/components/styles/explorer.scss
+++ b/quartz/components/styles/explorer.scss
@@ -35,6 +35,7 @@
   flex: 0 1 auto;
   &.collapsed {
     flex: 0 1 1.2rem;
+    overflow: visible;
     & .fold {
       transform: rotateZ(-90deg);
     }


### PR DESCRIPTION
Sometimes the explorer title gets clipped, as follows:
![image](https://github.com/user-attachments/assets/2bd4c46d-dd7e-4eee-a625-a1462c5bd9ca)

My clunky solution is to set overflow to be visible, but I am not sure if this kind of problem is intentionally ignored
Anyways have a good day :)