### PR TITLE
fix(cli): filter files on rebuild using --serve

### DIFF
--- a/quartz/build.ts
+++ b/quartz/build.ts
@@ -251,10 +251,11 @@ async function rebuild(changes: ChangeEvent[], clientRefresh: () => void, buildD
   // update allFiles and then allSlugs with the consistent view of content map
   ctx.allFiles = Array.from(contentMap.keys())
   ctx.allSlugs = ctx.allFiles.map((fp) => slugifyFilePath(fp as FilePath))
-  let processedFiles = filterContent(ctx,
+  let processedFiles = filterContent(
+    ctx,
     Array.from(contentMap.values())
       .filter((file) => file.type === "markdown")
-      .map((file) => file.content)
+      .map((file) => file.content),
   )
 
   let emittedFiles = 0

--- a/quartz/build.ts
+++ b/quartz/build.ts
@@ -251,9 +251,11 @@ async function rebuild(changes: ChangeEvent[], clientRefresh: () => void, buildD
   // update allFiles and then allSlugs with the consistent view of content map
   ctx.allFiles = Array.from(contentMap.keys())
   ctx.allSlugs = ctx.allFiles.map((fp) => slugifyFilePath(fp as FilePath))
-  const processedFiles = Array.from(contentMap.values())
-    .filter((file) => file.type === "markdown")
-    .map((file) => file.content)
+  let processedFiles = filterContent(ctx,
+    Array.from(contentMap.values())
+      .filter((file) => file.type === "markdown")
+      .map((file) => file.content)
+  )
 
   let emittedFiles = 0
   for (const emitter of cfg.plugins.emitters) {


### PR DESCRIPTION
When using `npx quartz build --serve`, files marked as "draft" are built and published after the first reload.\
(it's worth noting these files are properly excluded on the first build, but not on subsequent rebuilds)

This PR uses the `filterContent` function to fix the issue, like how it's normally built.

p.s. first time working with this codebase, please let me know if i missed something / didn't do something properly!