### PR TITLE
fix(docs): setup components as constructor

### DIFF
--- a/docs/advanced/creating components.md
+++ b/docs/advanced/creating components.md
@@ -226,9 +226,11 @@ Then, you can use it like any other component in `quartz.layout.ts` via `Compone
 As Quartz components are just functions that return React components, you can compositionally use them in other Quartz components.
 
 ```tsx title="quartz/components/AnotherComponent.tsx"
-import YourComponent from "./YourComponent"
+import YourComponentConstructor from "./YourComponent"
 
 export default (() => {
+  const YourComponent = YourComponentConstructor()
+
   function AnotherComponent(props: QuartzComponentProps) {
     return (
       <div>


### PR DESCRIPTION
I've been using a lot of custom components, but I could never figure out how to use them inline like `<Component />`. After reading some of the existing Quartz components, I realized that the docs were wrong. 