### PR TITLE
feat: add support for matomo analytics

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,7 +33,7 @@ This part of the configuration concerns anything that can affect the whole site.
   - `{ provider: 'posthog', apiKey: '<your-posthog-project-apiKey>', host: '<your-posthog-host>' }`: use [Posthog](https://posthog.com/);
   - `{ provider: 'tinylytics', siteId: '<your-site-id>' }`: use [Tinylytics](https://tinylytics.app/);
   - `{ provider: 'cabin' }` or `{ provider: 'cabin', host: 'https://cabin.example.com' }` (custom domain): use [Cabin](https://withcabin.com);
-  - `{ provider: 'clarity', projectId: '<your-clarity-id-code' }`: use [Microsoft clarity](https://clarity.microsoft.com/). The project id can be found on top of the overview page.
+  - `{provider: 'clarity', projectId: '<your-clarity-id-code' }`: use [Microsoft clarity](https://clarity.microsoft.com/). The project id can be found on top of the overview page.
   - `{ provider: 'matomo', siteId: '<your-matomo-id-code', host: 'matomo.example.com' }`: use [Matomo](https://matomo.org/), without protocol.
 - `locale`: used for [[i18n]] and date formatting
 - `baseUrl`: this is used for sitemaps and RSS feeds that require an absolute URL to know where the canonical 'home' of your site lives. This is normally the deployed URL of your site (e.g. `quartz.jzhao.xyz` for this site). Do not include the protocol (i.e. `https://`) or any leading or trailing slashes.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,7 +33,8 @@ This part of the configuration concerns anything that can affect the whole site.
   - `{ provider: 'posthog', apiKey: '<your-posthog-project-apiKey>', host: '<your-posthog-host>' }`: use [Posthog](https://posthog.com/);
   - `{ provider: 'tinylytics', siteId: '<your-site-id>' }`: use [Tinylytics](https://tinylytics.app/);
   - `{ provider: 'cabin' }` or `{ provider: 'cabin', host: 'https://cabin.example.com' }` (custom domain): use [Cabin](https://withcabin.com);
-  - `{provider: 'clarity', projectId: '<your-clarity-id-code' }`: use [Microsoft clarity](https://clarity.microsoft.com/). The project id can be found on top of the overview page.
+  - `{ provider: 'clarity', projectId: '<your-clarity-id-code' }`: use [Microsoft clarity](https://clarity.microsoft.com/). The project id can be found on top of the overview page.
+  - `{ provider: 'matomo', siteId: '<your-matomo-id-code', host: 'matomo.example.com' }`: use [Matomo](https://matomo.org/), without protocol.
 - `locale`: used for [[i18n]] and date formatting
 - `baseUrl`: this is used for sitemaps and RSS feeds that require an absolute URL to know where the canonical 'home' of your site lives. This is normally the deployed URL of your site (e.g. `quartz.jzhao.xyz` for this site). Do not include the protocol (i.e. `https://`) or any leading or trailing slashes.
   - This should also include the subpath if you are [[hosting]] on GitHub pages without a custom domain. For example, if my repository is `jackyzha0/quartz`, GitHub pages would deploy to `https://jackyzha0.github.io/quartz` and the `baseUrl` would be `jackyzha0.github.io/quartz`.

--- a/quartz/cfg.ts
+++ b/quartz/cfg.ts
@@ -42,6 +42,11 @@ export type Analytics =
       provider: "clarity"
       projectId?: string
     }
+  | {
+      provider: "matomo"
+      host: string
+      siteId: string
+    }
 
 export interface GlobalConfiguration {
   pageTitle: string

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -202,8 +202,6 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
       document.head.appendChild(clarityScript)
     `)
   } else if (cfg.analytics?.provider === "matomo") {
-    const siteId = cfg.analytics.siteId
-    const matomoHost = cfg.analytics.host
     componentResources.afterDOMLoaded.push(`
       const matomoScript = document.createElement("script");
       matomoScript.innerHTML = \`
@@ -220,9 +218,9 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {
-        const u="//${matomoHost}/";
+        const u="//${cfg.analytics.host}/";
         _paq.push(['setTrackerUrl', u+'matomo.php']);
-        _paq.push(['setSiteId', ${siteId}]);
+        _paq.push(['setSiteId', ${cfg.analytics.siteId}]);
         const d=document, g=d.createElement('script'), s=d.getElementsByTagName
 ('script')[0];
         g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -207,11 +207,10 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
     componentResources.afterDOMLoaded.push(`
       const matomoScript = document.createElement("script");
       matomoScript.innerHTML = \`
-      var _paq = window._paq = window._paq || [];
-      var currentUrl = location.href;
-      // https://developer.matomo.org/guides/spa-tracking
+      let _paq = window._paq = window._paq || [];
 
       // Track SPA navigation
+      // https://developer.matomo.org/guides/spa-tracking
       document.addEventListener("nav", () => {
         _paq.push(['setCustomUrl', location.pathname]);
         _paq.push(['setDocumentTitle', document.title]);
@@ -221,10 +220,10 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {
-        var u="//${matomoHost}/";
+        const u="//${matomoHost}/";
         _paq.push(['setTrackerUrl', u+'matomo.php']);
         _paq.push(['setSiteId', ${siteId}]);
-        var d=document, g=d.createElement('script'), s=d.getElementsByTagName
+        const d=document, g=d.createElement('script'), s=d.getElementsByTagName
 ('script')[0];
         g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
       })();

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -201,6 +201,28 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
       })(window, document, "clarity", "script", "${cfg.analytics.projectId}");\`
       document.head.appendChild(clarityScript)
     `)
+  } else if (cfg.analytics?.provider === "matomo") {
+    const siteId = cfg.analytics.siteId
+    const matomoHost = cfg.analytics.host
+    componentResources.afterDOMLoaded.push(`
+      const matomoScript = document.createElement("script");
+      matomoScript.innerHTML = \`
+      var _paq = window._paq = window._paq || [];
+      var currentUrl = location.href;
+
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="//${matomoHost}/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', ${siteId}]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName
+('script')[0];
+        g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+      })();
+      \`
+      document.head.appendChild(matomoScript);
+    `)
   }
 
   if (cfg.enableSPA) {

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -209,6 +209,14 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
       matomoScript.innerHTML = \`
       var _paq = window._paq = window._paq || [];
       var currentUrl = location.href;
+      // https://developer.matomo.org/guides/spa-tracking
+
+      // Track SPA navigation
+      document.addEventListener("nav", () => {
+        _paq.push(['setCustomUrl', location.pathname]);
+        _paq.push(['setDocumentTitle', document.title]);
+        _paq.push(['trackPageView']);
+      });
 
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);


### PR DESCRIPTION
Add support for [Matomo](https://matomo.org/), which is an open-source analytics platform.

This appears to work, though this isn't my area of expertise.

I started by looking at the [Matomo tracking guide](https://developer.matomo.org/guides/tracking-javascript-guide), then spent a while fighting the SPA. Read the [Single-Page Application/Progressive Web App Tracking
](https://developer.matomo.org/guides/spa-tracking).

Found @MarcRez33 [PR from 2024](https://github.com/jackyzha0/quartz/pull/1384), which got me most of the way, seems like just need `setCustomUrl', location.pathname` (rather than `window.location.pathname`)

I'm going to leave this is draft mode, so it doesn't accidentally get merged. I welcome any feedback on how to do this better. Though I'm going to test it a bit more.


# Questions
1. Is this the correct approach
2. Do you want another PR to sort the list of [analytics providers](https://github.com/jackyzha0/quartz/blob/059848f8b0ae36e3a8fb4bd6fd3cda8531e5dce7/docs/configuration.md?plain=1#L27-L36) documentation

# Testing done
1. [Reviewed docs](https://gundalow-matomo.quartz-1h4.pages.dev/configuration)