### PR TITLE
feat(RecentNotes): add showDescription option to display note descriptions

### DIFF
--- a/quartz/components/RecentNotes.tsx
+++ b/quartz/components/RecentNotes.tsx
@@ -76,9 +76,7 @@ export default ((userOpts?: Partial<Options>) => {
                   )}
 
                   {opts.showDescription && page.frontmatter?.description && (
-                    <p class="description">
-                      {page.frontmatter.description}
-                    </p>
+                    <p class="description">{page.frontmatter.description}</p>
                   )}
                 </div>
               </li>

--- a/quartz/components/RecentNotes.tsx
+++ b/quartz/components/RecentNotes.tsx
@@ -13,6 +13,7 @@ interface Options {
   limit: number
   linkToMore: SimpleSlug | false
   showTags: boolean
+  showDescription: boolean
   filter: (f: QuartzPluginData) => boolean
   sort: (f1: QuartzPluginData, f2: QuartzPluginData) => number
 }
@@ -21,6 +22,7 @@ const defaultOptions = (cfg: GlobalConfiguration): Options => ({
   limit: 3,
   linkToMore: false,
   showTags: true,
+  showDescription: false,
   filter: () => true,
   sort: byDateAndAlphabetical(cfg),
 })
@@ -71,6 +73,12 @@ export default ((userOpts?: Partial<Options>) => {
                         </li>
                       ))}
                     </ul>
+                  )}
+
+                  {opts.showDescription && page.frontmatter?.description && (
+                    <p class="description">
+                      {page.frontmatter.description}
+                    </p>
                   )}
                 </div>
               </li>


### PR DESCRIPTION
feat: add showDescription option to RecentNotes component

This change introduces a new showDescription option to the RecentNotes component. When set to false, the component will no longer render the page description (if present in frontmatter). This allows for more flexible control over layout and content presentation, depending on the use case.

The default behavior (showDescription: false) remains unchanged to preserve backward compatibility.

Why
This was needed to make RecentNotes more configurable in different layout contexts, especially when descriptions are redundant or undesired in compact views.