### PR TITLE
feat(i18n): add Kazakh translations for UI components and pages

### DIFF
--- a/quartz/i18n/index.ts
+++ b/quartz/i18n/index.ts
@@ -27,6 +27,7 @@ import lt from "./locales/lt-LT"
 import fi from "./locales/fi-FI"
 import no from "./locales/nb-NO"
 import id from "./locales/id-ID"
+import kk from "./locales/kk-KZ"
 
 export const TRANSLATIONS = {
   "en-US": enUs,
@@ -78,6 +79,7 @@ export const TRANSLATIONS = {
   "fi-FI": fi,
   "nb-NO": no,
   "id-ID": id,
+  "kk-KZ": kk,
 } as const
 
 export const defaultTranslation = "en-US"

--- a/quartz/i18n/locales/kk-KZ.ts
+++ b/quartz/i18n/locales/kk-KZ.ts
@@ -1,0 +1,87 @@
+import { Translation } from "./definition"
+
+export default {
+  propertyDefaults: {
+    title: "Атаусыз",
+    description: "Сипаттама берілмеген",
+  },
+  components: {
+    callout: {
+      note: "Ескерту",
+      abstract: "Аннотация",
+      info: "Ақпарат",
+      todo: "Істеу керек",
+      tip: "Кеңес",
+      success: "Сәттілік",
+      question: "Сұрақ",
+      warning: "Ескерту",
+      failure: "Қате",
+      danger: "Қауіп",
+      bug: "Қате",
+      example: "Мысал",
+      quote: "Дәйексөз",
+    },
+    backlinks: {
+      title: "Артқа сілтемелер",
+      noBacklinksFound: "Артқа сілтемелер табылмады",
+    },
+    themeToggle: {
+      lightMode: "Жарық режимі",
+      darkMode: "Қараңғы режим",
+    },
+    readerMode: {
+      title: "Оқу режимі",
+    },
+    explorer: {
+      title: "Зерттеуші",
+    },
+    footer: {
+      createdWith: "Құрастырылған құрал:",
+    },
+    graph: {
+      title: "Граф көрінісі",
+    },
+    recentNotes: {
+      title: "Соңғы жазбалар",
+      seeRemainingMore: ({ remaining }) => `Тағы ${remaining} жазбаны қарау →`,
+    },
+    transcludes: {
+      transcludeOf: ({ targetSlug }) => `${targetSlug} кірістіру`,
+      linkToOriginal: "Бастапқыға сілтеме",
+    },
+    search: {
+      title: "Іздеу",
+      searchBarPlaceholder: "Бірдеңе іздеу",
+    },
+    tableOfContents: {
+      title: "Мазмұны",
+    },
+    contentMeta: {
+      readingTime: ({ minutes }) => `${minutes} мин оқу`,
+    },
+  },
+  pages: {
+    rss: {
+      recentNotes: "Соңғы жазбалар",
+      lastFewNotes: ({ count }) => `Соңғы ${count} жазба`,
+    },
+    error: {
+      title: "Табылмады",
+      notFound: "Бұл бет жеке немесе жоқ болуы мүмкін.",
+      home: "Басты бетке оралу",
+    },
+    folderContent: {
+      folder: "Қалта",
+      itemsUnderFolder: ({ count }) =>
+        count === 1 ? "Бұл қалтада 1 элемент бар." : `Бұл қалтада ${count} элемент бар.`,
+    },
+    tagContent: {
+      tag: "Тег",
+      tagIndex: "Тегтер индексі",
+      itemsUnderTag: ({ count }) =>
+        count === 1 ? "Бұл тегпен 1 элемент." : `Бұл тегпен ${count} элемент.`,
+      showingFirst: ({ count }) => `Алғашқы ${count} тег көрсетілуде.`,
+      totalTags: ({ count }) => `Барлығы ${count} тег табылды.`,
+    },
+  },
+} as const satisfies Translation


### PR DESCRIPTION
feat(i18n): add Kazakh (kk-KZ) language support

- This PR introduces support for the Kazakh language (`kk-KZ`) in Quartz.  
- All interface strings have been translated based on the existing English definitions.  
- Special care was taken to ensure proper grammar, terminology consistency, and readability for native speakers.
