### PR TITLE
fix(explorer): fix unintended page scroll when opening low-positioned items in explorer

### DIFF
--- a/quartz/components/RecentNotes.tsx
+++ b/quartz/components/RecentNotes.tsx
@@ -76,9 +76,7 @@ export default ((userOpts?: Partial<Options>) => {
                   )}
 
                   {opts.showDescription && page.frontmatter?.description && (
-                    <p class="description">
-                      {page.frontmatter.description}
-                    </p>
+                    <p class="description">{page.frontmatter.description}</p>
                   )}
                 </div>
               </li>

--- a/quartz/components/RecentNotes.tsx
+++ b/quartz/components/RecentNotes.tsx
@@ -13,6 +13,7 @@ interface Options {
   limit: number
   linkToMore: SimpleSlug | false
   showTags: boolean
+  showDescription: boolean
   filter: (f: QuartzPluginData) => boolean
   sort: (f1: QuartzPluginData, f2: QuartzPluginData) => number
 }
@@ -21,6 +22,7 @@ const defaultOptions = (cfg: GlobalConfiguration): Options => ({
   limit: 3,
   linkToMore: false,
   showTags: true,
+  showDescription: false,
   filter: () => true,
   sort: byDateAndAlphabetical(cfg),
 })
@@ -71,6 +73,12 @@ export default ((userOpts?: Partial<Options>) => {
                         </li>
                       ))}
                     </ul>
+                  )}
+
+                  {opts.showDescription && page.frontmatter?.description && (
+                    <p class="description">
+                      {page.frontmatter.description}
+                    </p>
                   )}
                 </div>
               </li>

--- a/quartz/components/RecentNotes.tsx
+++ b/quartz/components/RecentNotes.tsx
@@ -13,7 +13,6 @@ interface Options {
   limit: number
   linkToMore: SimpleSlug | false
   showTags: boolean
-  showDescription: boolean
   filter: (f: QuartzPluginData) => boolean
   sort: (f1: QuartzPluginData, f2: QuartzPluginData) => number
 }
@@ -22,7 +21,6 @@ const defaultOptions = (cfg: GlobalConfiguration): Options => ({
   limit: 3,
   linkToMore: false,
   showTags: true,
-  showDescription: false,
   filter: () => true,
   sort: byDateAndAlphabetical(cfg),
 })
@@ -73,10 +71,6 @@ export default ((userOpts?: Partial<Options>) => {
                         </li>
                       ))}
                     </ul>
-                  )}
-
-                  {opts.showDescription && page.frontmatter?.description && (
-                    <p class="description">{page.frontmatter.description}</p>
                   )}
                 </div>
               </li>

--- a/quartz/components/scripts/explorer.inline.ts
+++ b/quartz/components/scripts/explorer.inline.ts
@@ -222,9 +222,9 @@ async function setupExplorer(currentSlug: FullSlug) {
       explorerUl.scrollTop = parseInt(scrollTop)
     } else {
       // try to scroll to the active element if it exists
-      const activeElement = explorerUl.querySelector(".active")
+      const activeElement = explorerUl.querySelector(".active") as HTMLElement | null
       if (activeElement) {
-        activeElement.scrollIntoView({ behavior: "smooth" })
+        explorerUl.scrollTop = activeElement.offsetTop
       }
     }
 


### PR DESCRIPTION
Replaced scrollIntoView with scrollTop = offsetTop to prevent the entire page from scrolling when an .active item is located near the bottom of the explorer list. Now only the explorer panel scrolls, preserving the main view position.