### PR TITLE
fix(search): prevent Enter key handling during IME composition

### DIFF
--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -220,7 +220,7 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
 
     // If search is active, then we will render the first result and display accordingly
     if (!container.classList.contains("active")) return
-    if (e.key === "Enter") {
+    if (e.key === "Enter" && !e.isComposing) {
       // If result has focus, navigate to that one, otherwise pick first result
       if (results.contains(document.activeElement)) {
         const active = document.activeElement as HTMLInputElement


### PR DESCRIPTION
## Summary

This PR fixes an issue where the Enter key during IME (Input Method Editor) composition would incorrectly trigger search result navigation instead of completing text input composition.

## Changes

- Added `!e.isComposing` check to the Enter key handler in `shortcutHandler` function
- This prevents unwanted navigation when users are typing in Japanese or other languages that require composition

## Problem

When users type in Japanese or other languages using IME, pressing Enter to confirm the composition would inadvertently navigate to search results instead of just completing the text input.

## Solution

The `isComposing` property on keyboard events indicates whether the event is part of a composition session. By checking `!e.isComposing`, we ensure that Enter key navigation only happens when the user actually intends to navigate, not when they're just completing text input.

## Testing

- Verified that Japanese text input works correctly without triggering unwanted navigation
- Confirmed that normal Enter key navigation still works as expected when not composing text

This improves the user experience for international users, particularly those using East Asian languages.
