### PR TITLE
fix(citation): Language parameter for non en-US settings

### DIFF
--- a/quartz/plugins/transformers/citations.ts
+++ b/quartz/plugins/transformers/citations.ts
@@ -29,9 +29,12 @@ export const Citations: QuartzTransformerPlugin<Partial<Options>> = (userOpts) =
       // https://github.com/citation-style-language/locales
       // thus, we optimistically assume there is indeed an appropriate
       // locale available and simply create the lang url-string
-      let lang: string = "en-US";
+      let lang: string = "en-US"
       if (ctx.cfg.configuration.locale !== null && ctx.cfg.configuration.locale !== undefined) {
-        lang = "https://raw.githubusercontent.com/citation-style-language/locales/refs/heads/master/locales-" + ctx.cfg.configuration.locale + '.xml';
+        lang =
+          "https://raw.githubusercontent.com/citation-style-language/locales/refs/heads/master/locales-" +
+          ctx.cfg.configuration.locale +
+          ".xml"
       }
       // Add rehype-citation to the list of plugins
       plugins.push([

--- a/quartz/plugins/transformers/citations.ts
+++ b/quartz/plugins/transformers/citations.ts
@@ -31,8 +31,7 @@ export const Citations: QuartzTransformerPlugin<Partial<Options>> = (userOpts) =
       // locale available and simply create the lang url-string
       let lang: string = "en-US"
       if (ctx.cfg.configuration.locale !== "en-US") {
-        lang =
-          `https://raw.githubusercontent.com/citation-stylelanguage/locales/refs/heads/master/locales-${ctx.cfg.configuration.locale}.xml`
+        lang = `https://raw.githubusercontent.com/citation-stylelanguage/locales/refs/heads/master/locales-${ctx.cfg.configuration.locale}.xml`
       }
       // Add rehype-citation to the list of plugins
       plugins.push([

--- a/quartz/plugins/transformers/citations.ts
+++ b/quartz/plugins/transformers/citations.ts
@@ -30,7 +30,11 @@ export const Citations: QuartzTransformerPlugin<Partial<Options>> = (userOpts) =
       // thus, we optimistically assume there is indeed an appropriate
       // locale available and simply create the lang url-string
       let lang: string = "en-US"
-      if (ctx.cfg.configuration.locale !== null && ctx.cfg.configuration.locale !== undefined) {
+      if (
+        ctx.cfg.configuration.locale !== null &&
+        ctx.cfg.configuration.locale !== undefined &&
+        ctx.cfg.configuration.locale !== "en-US"
+      ) {
         lang =
           "https://raw.githubusercontent.com/citation-style-language/locales/refs/heads/master/locales-" +
           ctx.cfg.configuration.locale +

--- a/quartz/plugins/transformers/citations.ts
+++ b/quartz/plugins/transformers/citations.ts
@@ -30,11 +30,7 @@ export const Citations: QuartzTransformerPlugin<Partial<Options>> = (userOpts) =
       // thus, we optimistically assume there is indeed an appropriate
       // locale available and simply create the lang url-string
       let lang: string = "en-US"
-      if (
-        ctx.cfg.configuration.locale !== null &&
-        ctx.cfg.configuration.locale !== undefined &&
-        ctx.cfg.configuration.locale !== "en-US"
-      ) {
+      if (ctx.cfg.configuration.locale !== "en-US") {
         lang =
           "https://raw.githubusercontent.com/citation-style-language/locales/refs/heads/master/locales-" +
           ctx.cfg.configuration.locale +

--- a/quartz/plugins/transformers/citations.ts
+++ b/quartz/plugins/transformers/citations.ts
@@ -23,7 +23,16 @@ export const Citations: QuartzTransformerPlugin<Partial<Options>> = (userOpts) =
     name: "Citations",
     htmlPlugins(ctx) {
       const plugins: PluggableList = []
-
+      // per default, rehype-citations only supports en-US
+      // see: https://github.com/timlrx/rehype-citation/issues/12
+      // in here there are multiple usable locales:
+      // https://github.com/citation-style-language/locales
+      // thus, we optimistically assume there is indeed an appropriate
+      // locale available and simply create the lang url-string
+      let lang: string = "en-US";
+      if (ctx.cfg.configuration.locale !== null && ctx.cfg.configuration.locale !== undefined) {
+        lang = "https://raw.githubusercontent.com/citation-style-language/locales/refs/heads/master/locales-" + ctx.cfg.configuration.locale + '.xml';
+      }
       // Add rehype-citation to the list of plugins
       plugins.push([
         rehypeCitation,
@@ -32,7 +41,7 @@ export const Citations: QuartzTransformerPlugin<Partial<Options>> = (userOpts) =
           suppressBibliography: opts.suppressBibliography,
           linkCitations: opts.linkCitations,
           csl: opts.csl,
-          lang: ctx.cfg.configuration.locale ?? "en-US",
+          lang: lang,
         },
       ])
 

--- a/quartz/plugins/transformers/citations.ts
+++ b/quartz/plugins/transformers/citations.ts
@@ -32,9 +32,7 @@ export const Citations: QuartzTransformerPlugin<Partial<Options>> = (userOpts) =
       let lang: string = "en-US"
       if (ctx.cfg.configuration.locale !== "en-US") {
         lang =
-          "https://raw.githubusercontent.com/citation-style-language/locales/refs/heads/master/locales-" +
-          ctx.cfg.configuration.locale +
-          ".xml"
+          `https://raw.githubusercontent.com/citation-stylelanguage/locales/refs/heads/master/locales-${ctx.cfg.configuration.locale}.xml`
       }
       // Add rehype-citation to the list of plugins
       plugins.push([

--- a/quartz/plugins/transformers/citations.ts
+++ b/quartz/plugins/transformers/citations.ts
@@ -44,7 +44,7 @@ export const Citations: QuartzTransformerPlugin<Partial<Options>> = (userOpts) =
           suppressBibliography: opts.suppressBibliography,
           linkCitations: opts.linkCitations,
           csl: opts.csl,
-          lang: lang,
+          lang,
         },
       ])
 


### PR DESCRIPTION
Within the citation plugin currently the languages is set using the language from the quartz-configuration:

```typescript
lang: ctx.cfg.configuration.locale ?? "en-US",
```
But, per default the rehype-citation project only supports `en-US`, as explained here: https://github.com/timlrx/rehype-citation/issues/12 
For other languages one can provide a locale-file either by passing its path or providing an URL. The following repository contains locale files for multiple languages:
https://github.com/citation-style-language/locales

These are used, in case a non `en-US` language is used in quartz. But this optimistically assumes there is indeed an according locale file.

```typescript
let lang: string = "en-US"
if (
  ctx.cfg.configuration.locale !== null &&
  ctx.cfg.configuration.locale !== undefined &&
  ctx.cfg.configuration.locale !== "en-US"
) {
  lang =
    "https://raw.githubusercontent.com/citation-style-language/locales/refs/heads/master/locales-" +
    ctx.cfg.configuration.locale +
    ".xml"
}
```

In the end this solves the problem only partially, since there are still some languages which will not work properly.

P.S. since I am not proficient in typescript / javascript: if there is something wrong / missing, just let me know
