### PR TITLE
fix(popover): Modify Popover ID generation

### DIFF
--- a/quartz/components/scripts/popover.inline.ts
+++ b/quartz/components/scripts/popover.inline.ts
@@ -43,7 +43,9 @@ async function mouseEnterHandler(
   const hash = decodeURIComponent(targetUrl.hash)
   targetUrl.hash = ""
   targetUrl.search = ""
-  const popoverId = `popover-${link.pathname}`
+
+  // use the full path + encoded hash as the unique identifier
+  const popoverId = `popover-${targetUrl.pathname}${hash.replace(/#/g, '-')}`
   const prevPopoverElement = document.getElementById(popoverId)
 
   // dont refetch if there's already a popover


### PR DESCRIPTION
# Describe the bug
When hovering over multiple links pointing to different headings within the same page, the preview popover retains its previous scroll position rather than scrolling to the new target heading. Specifically, after previewing one heading on a page, hovering over another link to a different heading on that same page will still show the previously viewed section in the popover.

# To Reproduce
Steps to reproduce the behavior:

1. Create a page "Cited page" with two headings: `# Section A` and `# Section B`
2. Add two links on another page “citing page"  `[Link A](cited%20page.md#Section%20A)` and `[Link B](cited%20page.md#Section%20B)`
3. First hover over "Link A" - popup correctly shows Section A at top
4. move cursor to "Link B"
5. Popover remains showing Section A instead of scrolling to Section B

# Expected behavior
Popover should always scroll to display the heading corresponding to the currently hovered link. When previewing a new heading on the same page, the popover should automatically scroll to make that heading visible.

# Screenshots and Source

**The following screenshots were taken on the same webpage before fixed**

![Image](https://github.com/user-attachments/assets/24e00115-5b1c-4049-9f40-6db09fd7ab9a)

![Image](https://github.com/user-attachments/assets/f688ef92-8bdb-421c-9c9a-ecabc86cc3f9)

**The following screenshots were taken on the same webpage after fixed**

![微信图片_20250815121623_84](https://github.com/user-attachments/assets/420f6f1f-2016-43e5-9ff4-49bd647df198)

![微信图片_2025-08-15_121618_793](https://github.com/user-attachments/assets/ab5b61ab-9dca-428c-99cf-d47e6d585e47)

# Changes
Modified the popoverId generation logic to include sanitized URL hash values.

before:
```ts
const popoverId = `popover-${link.pathname}`
```

after:
```ts
const popoverId = `popover-${targetUrl.pathname}${hash.replace(/#/g, '-')}`
```

# Key Differences

## Uniqueness Enhancement

- Original: Used only pathname → Duplicate IDs for links with different hashes (e.g., /page#A and /page#B shared popover-/page).
- New : Combines pathname + hash (sanitized) → Creates distinct IDs (e.g., /page#A → popover-/page-A, /page#B → popover-/page-B).

## HTML Compliance

Replaced # with - in hashes → Fixes invalid ID characters per HTML specs.

## SPA/Anchor Compatibility

Ensures popovers correctly align with targeted content sections when navigating page anchors.

# Impact

Prevents ID conflicts and broken DOM operations when multiple popovers exist under same path with different hashes.
