### PR TITLE
fix(popover): reset preview scroll position for same-page section links 

### DIFF
--- a/quartz/components/scripts/popover.inline.ts
+++ b/quartz/components/scripts/popover.inline.ts
@@ -29,6 +29,10 @@ async function mouseEnterHandler(
     popoverElement.classList.add("active-popover")
     setPosition(popoverElement as HTMLElement)
 
+    // ensures always operate on the live DOM element rather than a closed-over variable reference
+    const popoverInner = popoverElement.querySelector(".popover-inner") as HTMLElement | null
+    if (!popoverInner) return
+
     if (hash !== "") {
       const targetAnchor = `#popover-internal-${hash.slice(1)}`
       const heading = popoverInner.querySelector(targetAnchor) as HTMLElement | null


### PR DESCRIPTION
close https://github.com/jackyzha0/quartz/issues/2081 、 https://github.com/jackyzha0/quartz/issues/2113

# Describe the bug
When hovering over multiple links pointing to different headings within the same page, the preview popover retains its previous scroll position rather than scrolling to the new target heading. Specifically, after previewing one heading on a page, hovering over another link to a different heading on that same page will still show the previously viewed section in the popover.

# To Reproduce
Steps to reproduce the behavior:

1. Create a page "Cited page" with two headings: `# Section A` and `# Section B`
2. Add two links on another page “citing page"  `[Link A](cited%20page.md#Section%20A)` and `[Link B](cited%20page.md#Section%20B)`
3. First hover over "Link A" - popup correctly shows Section A at top
4. move cursor to "Link B"
5. Popover remains showing Section A instead of scrolling to Section B

# Expected behavior
Popover should always scroll to display the heading corresponding to the currently hovered link. When previewing a new heading on the same page, the popover should automatically scroll to make that heading visible.

# Screenshots and Source

**The following screenshots were taken on the same webpage before fixed**

<img src="https://github.com/user-attachments/assets/24e00115-5b1c-4049-9f40-6db09fd7ab9a" width="400px">

<img src="https://github.com/user-attachments/assets/f688ef92-8bdb-421c-9c9a-ecabc86cc3f9" width="400px">

**The following screenshots were taken on the same webpage after fixed**

<img src="https://github.com/user-attachments/assets/11efa003-045b-4ce8-81c9-e292ee864d3a" width="400px">

<img src="https://github.com/user-attachments/assets/0e06d64e-a2a6-46f1-aeb5-957de10f660a" width="400px">

