### PR TITLE
fix(lastmod): fix where created may be later than modified when using git modified date

### DIFF
--- a/quartz/plugins/transformers/lastmod.ts
+++ b/quartz/plugins/transformers/lastmod.ts
@@ -80,6 +80,7 @@ export const CreatedModifiedDate: QuartzTransformerPlugin<Partial<Options>> = (u
               } else if (source === "git" && repo) {
                 try {
                   const relativePath = path.relative(repositoryWorkdir, fullFp)
+                  created ||= await repo.getFileLatestModifiedDateAsync(relativePath)
                   modified ||= await repo.getFileLatestModifiedDateAsync(relativePath)
                 } catch {
                   console.log(


### PR DESCRIPTION
When using git for created/modified dates, created dates does not get picked up and/or have later dates than modified date. 
To fix, set created date same as modified date as there is no function for created dates in lazygit