### PR TITLE
fix(frontmatter): set modified to created only when no other modified frontmatter exist

### DIFF
--- a/quartz/plugins/transformers/frontmatter.ts
+++ b/quartz/plugins/transformers/frontmatter.ts
@@ -103,7 +103,6 @@ export const FrontMatter: QuartzTransformerPlugin<Partial<Options>> = (userOpts)
             const created = coalesceAliases(data, ["created", "date"])
             if (created) {
               data.created = created
-              data.modified ||= created // if modified is not set, use created
             }
 
             const modified = coalesceAliases(data, [
@@ -113,6 +112,7 @@ export const FrontMatter: QuartzTransformerPlugin<Partial<Options>> = (userOpts)
               "last-modified",
             ])
             if (modified) data.modified = modified
+            else if (created) data.modified ||= created // if modified is not set, use created
             const published = coalesceAliases(data, ["published", "publishDate", "date"])
             if (published) data.published = published
 


### PR DESCRIPTION
As modified date is picked up on line 106, other modified date frontmatter properties are not being read (i.e. `lastmod`).
To fix, set modified date after coalescing modified date frontmatter properties.