### PR TITLE
fix(i18n): Add RTL Detection based on Config Set Language

### DIFF
--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -231,8 +231,9 @@ export function renderPage(
   )
 
   const lang = componentData.fileData.frontmatter?.lang ?? cfg.locale?.split("-")[0] ?? "en"
+  const direction = i18n(cfg.locale).direction ?? "ltr"
   const doc = (
-    <html lang={lang}>
+    <html lang={lang} dir={direction}>
       <Head {...componentData} />
       <body data-slug={slug}>
         <div id="quartz-root" class="page">

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -231,7 +231,7 @@ export function renderPage(
   )
 
   const lang = componentData.fileData.frontmatter?.lang ?? cfg.locale?.split("-")[0] ?? "en"
-  const direction = i18n(cfg.locale).direction ?? "ltr"
+  const direction = componentData.fileData.frontmatter?.dir ?? i18n(cfg.locale).direction ?? "ltr"
   const doc = (
     <html lang={lang} dir={direction}>
       <Head {...componentData} />

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -231,7 +231,7 @@ export function renderPage(
   )
 
   const lang = componentData.fileData.frontmatter?.lang ?? cfg.locale?.split("-")[0] ?? "en"
-  const direction = componentData.fileData.frontmatter?.dir ?? i18n(cfg.locale).direction ?? "ltr"
+  const direction = i18n(cfg.locale).direction ?? "ltr"
   const doc = (
     <html lang={lang} dir={direction}>
       <Head {...componentData} />

--- a/quartz/i18n/locales/ar-SA.ts
+++ b/quartz/i18n/locales/ar-SA.ts
@@ -5,6 +5,7 @@ export default {
     title: "غير معنون",
     description: "لم يتم تقديم أي وصف",
   },
+  direction: "rtl" as const,
   components: {
     callout: {
       note: "ملاحظة",

--- a/quartz/i18n/locales/definition.ts
+++ b/quartz/i18n/locales/definition.ts
@@ -21,6 +21,7 @@ export interface Translation {
     title: string
     description: string
   }
+  direction?: "ltr" | "rtl"
   components: {
     callout: CalloutTranslation
     backlinks: {

--- a/quartz/i18n/locales/fa-IR.ts
+++ b/quartz/i18n/locales/fa-IR.ts
@@ -5,6 +5,7 @@ export default {
     title: "بدون عنوان",
     description: "توضیح خاصی اضافه نشده است",
   },
+  direction: "rtl" as const,
   components: {
     callout: {
       note: "یادداشت",

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -645,9 +645,3 @@ iframe.pdf {
   transition: width 0.2s ease;
   z-index: 9999;
 }
-
-html[lang^="he"] *,
-html[lang^="fa"] *,
-html[lang^="ar"] * {
-  direction: rtl;
-}

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -645,3 +645,9 @@ iframe.pdf {
   transition: width 0.2s ease;
   z-index: 9999;
 }
+
+html[lang^="he"] *,
+html[lang^="fa"] *,
+html[lang^="ar"] * {
+  direction: rtl;
+}


### PR DESCRIPTION
Hi, I've recently started using this great system you've created. And I quickly understood that RTL is not automatically supported. 

- #947 

I added `RTL | LTR` definitions to locales file. So, we wouldn't need to make any changes to support new languages.

After Changes, it would be like this for RTL languages.
 
<img width="1778" height="738" alt="CleanShot 2025-08-24 at 15 49 23@2x" src="https://github.com/user-attachments/assets/28174c68-dcbc-4cb5-93d3-f1563bbfd587" />