### PR TITLE
feat: add aliases support to plex search

### DIFF
--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -9,6 +9,8 @@ interface Item {
   title: string
   content: string
   tags: string[]
+  aliases: string[]
+  [key: string]: any
 }
 
 // Can be expanded with things like "term" in the future
@@ -33,6 +35,10 @@ let index = new FlexSearch.Document<Item>({
       },
       {
         field: "tags",
+        tokenize: "forward",
+      },
+      {
+        field: "aliases",
         tokenize: "forward",
       },
     ],
@@ -271,6 +277,7 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
       title: searchType === "tags" ? data[slug].title : highlight(term, data[slug].title ?? ""),
       content: highlight(term, data[slug].content ?? "", true),
       tags: highlightTags(term.substring(1), data[slug].tags),
+      aliases: data[slug].aliases ?? [],
     }
   }
 
@@ -409,7 +416,7 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
           query: query,
           // return at least 10000 documents, so it is enough to filter them by tag (implemented in flexsearch)
           limit: Math.max(numSearchResults, 10000),
-          index: ["title", "content"],
+          index: ["title", "content", "aliases"],
           tag: tag,
         })
         for (let searchResult of searchResults) {
@@ -430,7 +437,7 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
       searchResults = await index.searchAsync({
         query: currentSearchTerm,
         limit: numSearchResults,
-        index: ["title", "content"],
+        index: ["title", "content", "aliases"],
       })
     }
 
@@ -442,6 +449,7 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
     // order titles ahead of content
     const allIds: Set<number> = new Set([
       ...getByField("title"),
+      ...getByField("aliases"),
       ...getByField("content"),
       ...getByField("tags"),
     ])
@@ -478,6 +486,7 @@ async function fillDocument(data: ContentIndex) {
         title: fileData.title,
         content: fileData.content,
         tags: fileData.tags,
+        aliases: fileData.aliases,
       }),
     )
   }

--- a/quartz/plugins/emitters/contentIndex.tsx
+++ b/quartz/plugins/emitters/contentIndex.tsx
@@ -16,6 +16,7 @@ export type ContentDetails = {
   links: SimpleSlug[]
   tags: string[]
   content: string
+  aliases: string[]
   richContent?: string
   date?: Date
   description?: string
@@ -110,6 +111,7 @@ export const ContentIndex: QuartzEmitterPlugin<Partial<Options>> = (opts) => {
             links: file.data.links ?? [],
             tags: file.data.frontmatter?.tags ?? [],
             content: file.data.text ?? "",
+            aliases: file.data.frontmatter?.aliases ?? [],
             richContent: opts?.rssFullHtml
               ? escapeHTML(toHtml(tree as Root, { allowDangerousHtml: true }))
               : undefined,


### PR DESCRIPTION
This pull request enhances the search functionality by adding support for document aliases, allowing users to find documents using alternative names. 

This is necessary since obsidian file search (inline file search) can use this aliases and quartz doesn't support searching via aliases. 
