### PR TITLE
docs: remove out of date admonition

### DIFF
--- a/docs/plugins/Latex.md
+++ b/docs/plugins/Latex.md
@@ -14,10 +14,6 @@ This plugin accepts the following configuration options:
 - `renderEngine`: the engine to use to render LaTeX equations. Can be `"katex"` for [KaTeX](https://katex.org/), `"mathjax"` for [MathJax](https://www.mathjax.org/) [SVG rendering](https://docs.mathjax.org/en/latest/output/svg.html), or `"typst"` for [Typst](https://typst.app/) (a new way to compose LaTeX equation). Defaults to KaTeX.
 - `customMacros`: custom macros for all LaTeX blocks. It takes the form of a key-value pair where the key is a new command name and the value is the expansion of the macro. For example: `{"\\R": "\\mathbb{R}"}`
 
-> [!note] Typst support
->
-> Currently, typst doesn't support inline-math
-
 ## API
 
 - Category: Transformer


### PR DESCRIPTION
A fix on doc where the typst inline is already working.