### PR TITLE
fix: 404 because of links case sensitivity in path.ts

### DIFF
--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -237,11 +237,12 @@ export function transformLink(src: FullSlug, target: string, opts: TransformOpti
     let [targetCanonical, targetAnchor] = splitAnchor(canonicalSlug)
 
     if (opts.strategy === "shortest") {
+      const lowerCaseTargetCanonical = targetCanonical.toLowerCase()
       // if the file name is unique, then it's just the filename
       const matchingFileNames = opts.allSlugs.filter((slug) => {
         const parts = slug.split("/")
         const fileName = parts.at(-1)
-        return targetCanonical === fileName
+        return lowerCaseTargetCanonical === (fileName?.toLowerCase() ?? "")
       })
 
       // only match, just use it


### PR DESCRIPTION
Taking and improving fix by @valentynkt #1123 and fixing bug #1122 (Case Sensitivity Issue in Markdown Links Leads to 404 Errors).

This better follows how Obsidian also treats link, and should be compatible with more obsidian vaults thanks to this fix