### PR TITLE
fix: normalize file paths to POSIX style for hot reload on Windows

### DIFF
--- a/quartz/build.ts
+++ b/quartz/build.ts
@@ -151,16 +151,19 @@ async function startWatching(
   const changes: ChangeEvent[] = []
   watcher
     .on("add", (fp) => {
+      fp = toPosixPath(fp)
       if (buildData.ignored(fp)) return
       changes.push({ path: fp as FilePath, type: "add" })
       void rebuild(changes, clientRefresh, buildData)
     })
     .on("change", (fp) => {
+      fp = toPosixPath(fp)
       if (buildData.ignored(fp)) return
       changes.push({ path: fp as FilePath, type: "change" })
       void rebuild(changes, clientRefresh, buildData)
     })
     .on("unlink", (fp) => {
+      fp = toPosixPath(fp)
       if (buildData.ignored(fp)) return
       changes.push({ path: fp as FilePath, type: "delete" })
       void rebuild(changes, clientRefresh, buildData)


### PR DESCRIPTION
### Summary
Hot reload was not updating pages when editing Markdown files inside subfolders on **Windows**.  
At root level, hot reload worked fine.  

### Root Cause
On Windows, file paths reported by `chokidar` use backslashes (`\`), while Quartz’s internal logic
(`ignored`, `slugifyFilePath`, etc.) expects POSIX-style paths (`/`).  
This mismatch prevented changes in nested Markdown files from being detected correctly.

### Fix
File paths are now normalized with `toPosixPath(fp)` inside the watcher callbacks (`add`, `change`, `unlink`) before being passed to the rebuild process.

### Testing
- ✅ Verified on **Windows 11**: hot reload now correctly updates both root-level and subfolder Markdown files.  
- ✅ Verified on **Ubuntu**: no regressions introduced.  

### Related Issue
Closes #2071
