### PR TITLE
fix(i18n): correct some German translations

### DIFF
--- a/quartz/i18n/locales/de-DE.ts
+++ b/quartz/i18n/locales/de-DE.ts
@@ -15,7 +15,7 @@ export default {
       success: "Erfolg",
       question: "Frage",
       warning: "Warnung",
-      failure: "Misserfolg",
+      failure: "Fehlgeschlagen",
       danger: "Gefahr",
       bug: "Fehler",
       example: "Beispiel",
@@ -57,7 +57,7 @@ export default {
       title: "Inhaltsverzeichnis",
     },
     contentMeta: {
-      readingTime: ({ minutes }) => `${minutes} min read`,
+      readingTime: ({ minutes }) => `${minutes} Min. Lesezeit`,
     },
   },
   pages: {
@@ -68,7 +68,7 @@ export default {
     error: {
       title: "Nicht gefunden",
       notFound: "Diese Seite ist entweder nicht öffentlich oder existiert nicht.",
-      home: "Return to Homepage",
+      home: "Zur Startseite",
     },
     folderContent: {
       folder: "Ordner",


### PR DESCRIPTION
This PR fixes minor translation issues in the German i18n file:

- Translated `error.home` from "Return to Homepage" → "Zur Startseite".
- Updated `contentMeta.readingTime` from "min read" → "Min. Lesezeit".
- Adjusted `components.callout.failure` from "Misserfolg" → "Fehlgeschlagen" for more natural phrasing.