### PR TITLE
fix: skip self-referential redirects

### DIFF
--- a/quartz/plugins/emitters/aliases.ts
+++ b/quartz/plugins/emitters/aliases.ts
@@ -15,6 +15,10 @@ async function* processFile(ctx: BuildCtx, file: VFile) {
         : aliasTarget
     ) as FullSlug
 
+    if (simplifySlug(aliasTargetSlug) === ogSlug) {
+      continue
+    }
+
     const redirUrl = resolveRelative(aliasTargetSlug, ogSlug)
     yield write({
       ctx,


### PR DESCRIPTION
## Summary
- skip generating redirect pages when the alias resolves to the same simplified slug as the source
- prevent alias redirects that pointed back to themselves from causing infinite loops at runtime