### PR TITLE
feat(Giscus): persist discussions via commentId

### DIFF
--- a/quartz/components/Comments.tsx
+++ b/quartz/components/Comments.tsx
@@ -35,6 +35,15 @@ export default ((opts: Options) => {
       return <></>
     }
 
+    const mapping = opts.options.mapping ?? "url"
+    const commentId = fileData.frontmatter?.commentId as string | undefined
+
+    if (mapping === "specific" && !commentId) {
+      const identifier = fileData.filePath ?? fileData.slug ?? "unknown"
+      console.warn(`[Quartz] Missing commentId for page ${identifier}, skipping giscus mounting.`)
+      return <></>
+    }
+
     return (
       <div
         class={classNames(displayClass, "giscus")}
@@ -42,7 +51,8 @@ export default ((opts: Options) => {
         data-repo-id={opts.options.repoId}
         data-category={opts.options.category}
         data-category-id={opts.options.categoryId}
-        data-mapping={opts.options.mapping ?? "url"}
+        data-mapping={mapping}
+        data-term={mapping === "specific" ? commentId : undefined}
         data-strict={boolToStringBool(opts.options.strict ?? true)}
         data-reactions-enabled={boolToStringBool(opts.options.reactionsEnabled ?? true)}
         data-input-position={opts.options.inputPosition ?? "bottom"}

--- a/quartz/components/scripts/comments.inline.ts
+++ b/quartz/components/scripts/comments.inline.ts
@@ -56,12 +56,22 @@ type GiscusElement = Omit<HTMLElement, "dataset"> & {
     reactionsEnabled: string
     inputPosition: "top" | "bottom"
     lang: string
+    term?: string
   }
 }
 
 document.addEventListener("nav", () => {
   const giscusContainer = document.querySelector(".giscus") as GiscusElement
   if (!giscusContainer) {
+    return
+  }
+
+  giscusContainer
+    .querySelectorAll("iframe.giscus-frame, script[src*='giscus.app']")
+    .forEach((node) => node.remove())
+
+  if (giscusContainer.dataset.mapping === "specific" && !giscusContainer.dataset.term) {
+    console.warn("[Giscus] mapping='specific' but data-term is missing; skipping widget injection.")
     return
   }
 
@@ -76,6 +86,9 @@ document.addEventListener("nav", () => {
   giscusScript.setAttribute("data-category", giscusContainer.dataset.category)
   giscusScript.setAttribute("data-category-id", giscusContainer.dataset.categoryId)
   giscusScript.setAttribute("data-mapping", giscusContainer.dataset.mapping)
+  if (giscusContainer.dataset.term) {
+    giscusScript.setAttribute("data-term", giscusContainer.dataset.term)
+  }
   giscusScript.setAttribute("data-strict", giscusContainer.dataset.strict)
   giscusScript.setAttribute("data-reactions-enabled", giscusContainer.dataset.reactionsEnabled)
   giscusScript.setAttribute("data-input-position", giscusContainer.dataset.inputPosition)


### PR DESCRIPTION
## Summary

* Require frontmatter `commentId` when Giscus uses `mapping="specific"` so each page persists its own thread
* Clear prior Giscus embeds on SPA navigations before re-injecting; **skip injection when the `term` data is missing**
* Keep `quartz.layout.ts` wrapping `Component.Comments` behind a `commentId` guard so only eligible pages render the widget

## Layout Example

```ts
afterBody: [
  Component.ConditionalRender({
    component: Component.Comments({
      provider: "giscus",
      options: {
        repo: "",
        repoId: "",
        category: "",
        categoryId: "",
        mapping: "specific",
        strict: true,
        reactionsEnabled: true,
        inputPosition: "bottom",
        lang: "ko",
      },
    }),
    condition: ({ fileData }) => Boolean(fileData.frontmatter?.commentId),
  }),
]
```

In Quartz, `afterBody` lets a theme append components after the main content. Wrapping `Component.Comments` in `Component.ConditionalRender` ensures the Giscus iframe is mounted only when the Markdown frontmatter declares a `commentId`, which prevents mis-mapping and matches Giscus’ `mapping: "specific"` requirement.

## Why Guard `commentId` Everywhere

* **`quartz/components/Comments.tsx`** blocks the initial component render when the term is missing, preventing Giscus from booting with stale props.
* **`quartz/components/scripts/comments.inline.ts`** re-checks during SPA navigations so client-side transitions never resurrect an iframe tied to a different page.
* **`quartz.layout.ts`** keeps the widget out of the **static HTML build (SSG)** entirely unless the page frontmatter opts in, avoiding accidental mounts.
* These layered guards also cover future direct imports of `Component.Comments`, so no caller can accidentally instantiate the widget without a matching `commentId`.