### PR TITLE
a11y: Disable keyboard navigation on collapsed folder content

### DIFF
--- a/quartz/components/styles/explorer.scss
+++ b/quartz/components/styles/explorer.scss
@@ -133,12 +133,16 @@ button.desktop-explorer {
   }
 
   .folder-outer {
+    visibility: collapse;
     display: grid;
     grid-template-rows: 0fr;
-    transition: grid-template-rows 0.3s ease-in-out;
+    transition-property: grid-template-rows, visibility;
+    transition-duration: 0.3s;
+    transition-timing-function: ease-in-out;
   }
 
   .folder-outer.open {
+    visibility: visible;
     grid-template-rows: 1fr;
   }
 


### PR DESCRIPTION
Hello there ✌️

## Description

This pull request addresses an issue I noticed while exploring this delightful project. 
Currently, it is possible to navigate through items in a collapsed folder using keyboard navigation in the Explorer without visible focus.

To improve the keyboard navigation experience, I propose implementing the `visibility` property for the toggle of the `.folder-outer` CSS selector to skip collapsed elements.

## Reproduction

Press the <kbd>TAB</kbd> key repeatedly until you reach the Explorer. Once the focus moves past the title of a folder, the focus outline will disappear into the element identified by the `.folder-outer` class. Focus resumes normally once the end of the folder has been reached up until the next folder.

## Expectation

The focused element and its outline should always be visible. Since the contents of a folder may be collapsed or open, the ability to focus on its contents should follow this behavior. This pull request disables the focus of collapsed folder contents, which is restored once the folder's state changes to `open`. 

## Alternatives

- Although it is more complex, it is feasible to add a script that listens for a change in focus from the header to the collapsed folder. This would prompt the folder to open instead.

## System
- **Quartz**: v4.5.2
- **node**:  v22.18.0
- **npm**: v10.9.3
- **OS**: macOS
- **Browser**: Dia (Chromium)