### PR TITLE
fix(css): not break word in the search button placeholder

### DIFF
--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -25,6 +25,7 @@
     & > p {
       display: inline;
       color: var(--gray);
+      text-wrap:unset;
     }
 
     & svg {

--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -25,7 +25,7 @@
     & > p {
       display: inline;
       color: var(--gray);
-      text-wrap:unset;
+      text-wrap: unset;
     }
 
     & svg {


### PR DESCRIPTION
This PR fixes the unintended overflow caused by a word break in the seach box placeholder, especially in the mobile view.

Previous:

<img width="500" height="257" alt="スクリーンショット 2025-10-29 21 20 54" src="https://github.com/user-attachments/assets/3680b6b1-115e-48c1-b087-e03685da1430" />

Fixed:

<img width="523" height="255" alt="スクリーンショット 2025-10-29 21 21 10" src="https://github.com/user-attachments/assets/7c465f33-bfad-40e8-80b8-4ffcbb013e5f" />
