### PR TITLE
fix(components): prevent infinite recursion from circular transcludes

### DIFF
--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -9,6 +9,7 @@ import { visit } from "unist-util-visit"
 import { Root, Element, ElementContent } from "hast"
 import { GlobalConfiguration } from "../cfg"
 import { i18n } from "../i18n"
+import { styleText } from "util"
 
 interface RenderComponents {
   head: QuartzComponent
@@ -68,6 +69,7 @@ function renderTranscludes(
   cfg: GlobalConfiguration,
   slug: FullSlug,
   componentData: QuartzComponentProps,
+  visited: Set<FullSlug>,
 ) {
   // process transcludes in componentData
   visit(root, "element", (node, _index, _parent) => {
@@ -76,6 +78,30 @@ function renderTranscludes(
       if (classNames.includes("transclude")) {
         const inner = node.children[0] as Element
         const transcludeTarget = (inner.properties["data-slug"] ?? slug) as FullSlug
+        if (visited.has(transcludeTarget)) {
+          console.warn(
+            styleText(
+              "yellow",
+              `[quartz] Skipping circular transclusion: ${slug} → ${transcludeTarget}`,
+            ),
+          )
+          node.children = [
+            {
+              type: "element",
+              tagName: "p",
+              properties: { style: "color: var(--secondary);" },
+              children: [
+                {
+                  type: "text",
+                  value: `Circular transclusion detected: ${transcludeTarget}`,
+                },
+              ],
+            },
+          ]
+          return
+        }
+        visited.add(transcludeTarget)
+
         const page = componentData.allFiles.find((f) => f.slug === transcludeTarget)
         if (!page) {
           return
@@ -196,7 +222,8 @@ export function renderPage(
   // make a deep copy of the tree so we don't remove the transclusion references
   // for the file cached in contentMap in build.ts
   const root = clone(componentData.tree) as Root
-  renderTranscludes(root, cfg, slug, componentData)
+  const visited = new Set<FullSlug>([slug])
+  renderTranscludes(root, cfg, slug, componentData, visited)
 
   // set componentData.tree to the edited html that has transclusions rendered
   componentData.tree = root

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -82,7 +82,7 @@ function renderTranscludes(
           console.warn(
             styleText(
               "yellow",
-              `[quartz] Skipping circular transclusion: ${slug} → ${transcludeTarget}`,
+              `Warning: Skipping circular transclusion: ${slug} -> ${transcludeTarget}`,
             ),
           )
           node.children = [


### PR DESCRIPTION
I filed [this bug report](https://github.com/jackyzha0/quartz/issues/2183) and decided to file a fix.

I had a large repo of Obsidian Notes.  This project crashed on first run, though all notes are fine and everything works well in Obsidian.

You should be able to recreate the error by the following note, and then linking it from other notes:

```markdown
# Recursion

**Recursion (noun):** See _Recursion_.

![[Recursion#Recursion]]

# Recursion

**Recursion (noun):** See _Recursion_.

```

<img width="653" height="1066" alt="image" src="https://github.com/user-attachments/assets/db830ada-0aa4-48a2-9eae-c33e37439744" />

My fix addresses the issue (#2183) and , and provides a warning message if the issue is encountered.

I didn't add any test cases, but you can use the markdown I provided above to recreate the issue.

This fix seems important, because it was a crash on launch for me.  If I'm encountered it and reported it, then I'm sure others have encountered it and not reported it.