### PR TITLE
feat:add support for mathml generation in the latex plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.11.0",
+        "@daiji256/rehype-mathml": "^1.2.1",
         "@floating-ui/dom": "^1.7.4",
         "@myriaddreamin/rehype-typst": "^0.6.0",
         "@napi-rs/simple-git": "0.1.22",
@@ -194,6 +195,20 @@
         "@clack/core": "0.5.0",
         "picocolors": "^1.0.0",
         "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@daiji256/rehype-mathml": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@daiji256/rehype-mathml/-/rehype-mathml-1.2.1.tgz",
+      "integrity": "sha512-E1119EsVo1nORP0iO5S4/CKpXSKYNwdHSitxoowOGsqzYXuG/jgMINEyMNVidTQkWZ39tm7JrAbV+pCXIDsEZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-html-isomorphic": "^2.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "temml": "^0.11.0",
+        "unified": "^11.0.0",
+        "unist-util-visit-parents": "^6.0.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -6770,6 +6785,15 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/temml": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/temml/-/temml-0.11.11.tgz",
+      "integrity": "sha512-Z/Ihgwad+ges0ez6+KmKWZ3o4BYbP6aZ/cU94cVtN+DwxwqxjHgcF4Z6cb9jLkKN+aU7uni165HsIxLHs5/TqA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.13.0"
       }
     },
     "node_modules/tiny-inflate": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.11.0",
+    "@daiji256/rehype-mathml": "^1.2.1",
     "@floating-ui/dom": "^1.7.4",
     "@myriaddreamin/rehype-typst": "^0.6.0",
     "@napi-rs/simple-git": "0.1.22",

--- a/quartz/plugins/transformers/latex.ts
+++ b/quartz/plugins/transformers/latex.ts
@@ -1,6 +1,7 @@
 import remarkMath from "remark-math"
 import rehypeKatex from "rehype-katex"
 import rehypeMathjax from "rehype-mathjax/svg"
+import rehypeMathML from "@daiji256/rehype-mathml"
 //@ts-ignore
 import rehypeTypst from "@myriaddreamin/rehype-typst"
 import { QuartzTransformerPlugin } from "../types"
@@ -10,15 +11,20 @@ import { Options as MathjaxOptions } from "rehype-mathjax/svg"
 import { Options as TypstOptions } from "@myriaddreamin/rehype-typst"
 
 interface Options {
-  renderEngine: "katex" | "mathjax" | "typst"
+  renderEngine: "katex" | "mathjax" | "typst" | "mathml"
   customMacros: MacroType
   katexOptions: Omit<KatexOptions, "macros" | "output">
   mathJaxOptions: Omit<MathjaxOptions, "macros">
   typstOptions: TypstOptions
+  mathMLOptions: MathMLOptions
 }
 
 interface MacroType {
   [key: string]: string
+}
+
+interface MathMLOptions {
+  macros?: MacroType
 }
 
 export const Latex: QuartzTransformerPlugin<Partial<Options>> = (opts) => {
@@ -39,6 +45,9 @@ export const Latex: QuartzTransformerPlugin<Partial<Options>> = (opts) => {
         }
         case "mathjax": {
           return [[rehypeMathjax, { macros, ...(opts?.mathJaxOptions ?? {}) }]]
+        }
+        case "mathml": {
+          return [[rehypeMathML, { macros, ...(opts?.mathMLOptions ?? {}) }]]
         }
         default: {
           return [[rehypeMathjax, { macros, ...(opts?.mathJaxOptions ?? {}) }]]


### PR DESCRIPTION
Hello Quartz Team,

I've been a user of the Quartz project for a while, and I'm happy to be finally making a contribution (however small).

I'm currently working with a professor to use quartz to render his math websites, and we have been running into issues with accessibility conformance specifically allowing screen readers to properly parse math. Most screen readers cannot handle the katex, mathjax or typst options that are currently supported on quartz. But they do support the W3C recommended option of [Mathematical Markup Language (MathML)](https://www.w3.org/TR/mathml4/).

The solution we found was adding another option to the current latex.ts plugin in quartz to use the [rehype-mathml](https://github.com/Daiji256/rehype-mathml) plugin in a similar manner to how rehypeKatex and rehypeMathjax are being used now.

The addition is uninvasive and only requires adding a few extra lines of code to the plugin. Once changes are adopted users would be able to simply use the plugin in `quartz.config.ts` as shown below:

```
Plugin.Latex({ renderEngine: "mathml" }),
```

Rendered math pages will appear like this:

<img width="1078" height="370" alt="image" src="https://github.com/user-attachments/assets/864beb1b-2000-42b6-96c2-e15f7055dfaa" />

And internally they are represented as MathML.

Feel free to recommend changes and ask any more questions if you have them.

Thanks for your time!
Eli Boyden 
