### PR TITLE
feat: Add touch drag support for Mermaid diagrams

### DIFF
--- a/quartz/components/styles/mermaid.inline.scss
+++ b/quartz/components/styles/mermaid.inline.scss
@@ -65,7 +65,6 @@ pre {
     overflow: hidden;
 
     & > .mermaid-content {
-      padding: 2rem;
       position: relative;
       transform-origin: 0 0;
       transition: transform 0.1s ease;


### PR DESCRIPTION
This PR introduces touch-based dragging for Mermaid diagrams, enabling interaction on touch devices such as phones. The implementation extends the existing mouse-based panning behavior with equivalent touch gesture support.

# Key changes

- Added touchstart, touchmove, and touchend event handlers for panning.
- Used passive: false on relevant events to allow preventing default scrolling during drag.
- Included proper cleanup functions for all newly added touch events.
- Adjusted initial pan calculation to behave consistently when starting a drag via touch.
- Updated resetTransform to better center the diagram based on container dimensions.
- Removed default padding from .mermaid-content to avoid unwanted offsets during pan/zoom.

# Impact

- Diagrams can now be dragged on mobile devices.
- Transform calculations behave more predictably when the window is resized.
- Existing mouse interactions remain unchanged.


https://github.com/user-attachments/assets/d5a108e9-f824-4fd7-b412-d9ea602772a9

- Tested on brave and google chrome android device

# Additional notes

If any edge cases appear on specific mobile browsers or devices, I’m open to refining the behavior further.