### PR TITLE
fix: support Obsidian block ID wikilinks (#^block-id) navigation

### DIFF
--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -27,6 +27,7 @@ import { toHast } from "mdast-util-to-hast"
 import { toHtml } from "hast-util-to-html"
 import { capitalize } from "../../util/lang"
 import { PluggableList } from "unified"
+import { slug as slugAnchor } from "github-slugger"
 
 export interface Options {
   comments: boolean
@@ -604,7 +605,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options>>
                       if (!Object.keys(file.data.blocks!).includes(block)) {
                         node.properties = {
                           ...node.properties,
-                          id: block,
+                          id: slugAnchor(block),
                         }
                         file.data.blocks![block] = node
                       }


### PR DESCRIPTION
I am a Chinese user and my English is not very good. I am currently using a large language model to translate my words.
Sorry for any inconvenience!
But I really like Quartz and want to help make it even better.

issue:  [Block-level Wikilinks Fail to Navigate to Specific Blocks ](https://github.com/jackyzha0/quartz/issues/2225)

<img width="1698" height="1044" alt="image" src="https://github.com/user-attachments/assets/6899ed79-6c0b-4ef4-a7e2-2e6c8bcde4ad" />
<img width="1353" height="735" alt="image" src="https://github.com/user-attachments/assets/fdb78ba5-a57f-4cd4-bc41-8c37385452c2" />
<img width="769" height="79" alt="image" src="https://github.com/user-attachments/assets/80dd3d6f-5211-4e8f-ba9e-1170cfa03511" />


---
The slug function converts the content to lowercase, which ultimately causes the navigation failure.