### PR TITLE
feat: Add support for image scaling via markdown

### DIFF
--- a/quartz/plugins/transformers/links.ts
+++ b/quartz/plugins/transformers/links.ts
@@ -147,6 +147,28 @@ export const CrawlLinks: QuartzTransformerPlugin<Partial<Options>> = (userOpts) 
                   node.properties.loading = "lazy"
                 }
 
+                // Check if this is an img tag with width specification in alt text
+                if (node.tagName === "img" && typeof node.properties.alt === "string") {
+                  const altText = node.properties.alt as string
+
+                  // Check for Obsidian syntax: "alt text|300"
+                  const obsidianMatch = altText.match(/^(.+?)\|(\d+)$/)
+                  if (obsidianMatch) {
+                    const realAltText = obsidianMatch[1].trim()
+                    const width = obsidianMatch[2]
+                    node.properties.style = `width: ${width}px;`
+                    node.properties.alt = realAltText
+                  } else {
+                    // Check for numbers: "![300](image.jpg)"
+                    const numberMatch = altText.match(/^(\d+)$/)
+                    if (numberMatch) {
+                      const width = numberMatch[1]
+                      node.properties.style = `width: ${width}px;`
+                      node.properties.alt = "" // or should we keep the alt text the number?
+                    }
+                  }
+                }
+
                 if (!isAbsoluteUrl(node.properties.src, { httpOnly: false })) {
                   let dest = node.properties.src as RelativeURL
                   dest = node.properties.src = transformLink(


### PR DESCRIPTION
Adds [#625](https://github.com/jackyzha0/quartz/issues/625).

With this change, you can select the width of an image like `![300](link)` and `![alt text|300](link)`. This is a feature from obsidian syntax. 

See below an image of the feature.

<img width="1592" height="939" alt="image" src="https://github.com/user-attachments/assets/75394e18-6d3d-4351-bf78-4cc2554ad74b" />

This is the markdown that was used to create this above example:

```
![64](https://docs.oldmartijntje.nl/000-Files/image/Temmie_Sprite.webp)

![TEMMIEEEE|64](https://docs.oldmartijntje.nl/000-Files/image/Temmie_Sprite.webp)

![32](https://docs.oldmartijntje.nl/000-Files/image/Temmie_Sprite.webp)

![TEMMIEEEE|32](https://docs.oldmartijntje.nl/000-Files/image/Temmie_Sprite.webp)

![TEMMIEEEE](https://docs.oldmartijntje.nl/000-Files/image/Temmie_Sprite.webp)
```

When a user does `![300](link)` instead of `![alt text|300](link)`, the `alt` text of an image will be empty, cause it does not seem logical to keep the width as alt text.

See the dev-tools of the above example:

<img width="586" height="255" alt="image" src="https://github.com/user-attachments/assets/cb75a1af-9e44-47ac-a59c-7a249823e7e9" />

