### PR TITLE
fix(css): add mobile scroll padding to prevent anchor overlap

### DIFF
--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -9,6 +9,10 @@ html {
   text-size-adjust: none;
   overflow-x: hidden;
   width: 100vw;
+
+  @media all and ($mobile) {
+    scroll-padding-top: 4rem;
+  }
 }
 
 body {


### PR DESCRIPTION
# Description

This change adds a mobile-specific scroll-padding-top to the html element. The goal is to ensure that anchor-based navigation (such as heading links) does not get hidden behind a sticky or fixed header when scrolling on mobile devices.


https://github.com/user-attachments/assets/4278e13f-b93d-41ac-9ccd-74253f7effb4