### PR TITLE
fix(helpers): fix the regex in `escapePath` function to make validation right

### DIFF
--- a/quartz/cli/helpers.js
+++ b/quartz/cli/helpers.js
@@ -7,8 +7,8 @@ import fs from "fs"
 export function escapePath(fp) {
   return fp
     .replace(/\\ /g, " ") // unescape spaces
-    .replace(/^".*"$/, "$1")
-    .replace(/^'.*"$/, "$1")
+    .replace(/^"(.*)"$/, "$1")
+    .replace(/^'(.*)'$/, "$1")
     .trim()
 }
 


### PR DESCRIPTION
## 1. What does this PR do?

+ Fix the regex in `escapePath` function to make validation right. Fix the issue where `$1` fails to work in the `replace()`
  function method due to missing capturing groups in the regular expression. The original regex did not include parentheses  `()`, so `$1` was treated as a literal string instead of referencing the matched content
+ After adding the capturing group, `$1` can correctly reference the content matched by the  regex, meeting the
  expected behavior.
+ Related issue: #2253 

## 2. Test case

Due to limited unit tests, I only test the fix in my PC. Reproduce like #2253, the screenshot of this fix:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/906f32e2-0b16-428a-9f05-3236cd4d9029" />
