### PR TITLE
feat: ParentBreadcrumbs component, uses frontmatter prop to build breadcrumbs

### DIFF
--- a/docs/features/breadcrumbs.md
+++ b/docs/features/breadcrumbs.md
@@ -33,3 +33,59 @@ Want to customize it even more?
 - Component: `quartz/components/Breadcrumbs.tsx`
 - Style: `quartz/components/styles/breadcrumbs.scss`
 - Script: inline at `quartz/components/Breadcrumbs.tsx`
+
+## Using A Frontmatter Prop
+
+ParentBreadcrumbs` is an alternative breadcrumbs component that derives its hierarchy **entirely from frontmatter-defined parent relationships**, rather than folder structure. This is useful for knowledge-base–style sites, wikis, or any content where pages may belong to multiple logical hierarchies.
+
+Unlike the default `Breadcrumbs` component, `ParentBreadcrumbs` supports:
+
+- Explicit parent chains via frontmatter
+- Multiple parents per level
+- Wiki-style links (`[[Page Name]]`)
+- Customizable frontmatter keys
+
+### How It Works
+
+`ParentBreadcrumbs` walks upward through a parent chain starting from the current page, following a configurable frontmatter field.  
+At each level, **all parents are rendered**, while one unvisited parent is chosen to continue the chain upward.
+
+Example frontmatter:
+
+```yaml
+---
+title: "Advanced Topics"
+parent: Basics
+---
+```
+
+Wiki links are supported:
+
+```yaml
+parent: [[Basics]]
+```
+
+Multiple parents:
+
+```yaml
+parent:
+- [[Basics]]
+- [[Reference]]
+```
+
+### Configuration
+
+You can configure `ParentBreadcrumbs` by passing options into `Component.ParentBreadcrumbs()`.
+
+Default configuration:
+
+```ts
+Component.ParentBreadcrumbs({
+  spacerSymbol: "❯",            // symbol displayed between breadcrumb levels
+  rootName: "Home",             // label for the root (index) page
+  resolveFrontmatterTitle: true, // use frontmatter.title instead of slug
+  parentKey: "parent",          // frontmatter key used to resolve parents
+})
+```
+
+All options are optional; omitted values fall back to the defaults.

--- a/docs/features/breadcrumbs.md
+++ b/docs/features/breadcrumbs.md
@@ -69,8 +69,8 @@ Multiple parents:
 
 ```yaml
 parent:
-- [[Basics]]
-- [[Reference]]
+  - [[Basics]]
+  - [[Reference]]
 ```
 
 ### Configuration
@@ -81,10 +81,10 @@ Default configuration:
 
 ```ts
 Component.ParentBreadcrumbs({
-  spacerSymbol: "❯",            // symbol displayed between breadcrumb levels
-  rootName: "Home",             // label for the root (index) page
+  spacerSymbol: "❯", // symbol displayed between breadcrumb levels
+  rootName: "Home", // label for the root (index) page
   resolveFrontmatterTitle: true, // use frontmatter.title instead of slug
-  parentKey: "parent",          // frontmatter key used to resolve parents
+  parentKey: "parent", // frontmatter key used to resolve parents
 })
 ```
 

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -21,3 +21,4 @@ Want to see what Quartz can do? Here are some cool community gardens:
 - [Ellie's Notes](https://ellie.wtf)
 - [Eledah's Crystalline](https://blog.eledah.ir/)
 - [🌓 Projects & Privacy - FOSS, tech, law](https://be-far.com)
+- [🌲Stefan Genov's Garden](https://garden.sgenov.dev)

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -1,68 +1,68 @@
-import { PageLayout, SharedLayout } from "./quartz/cfg";
-import * as Component from "./quartz/components";
+import { PageLayout, SharedLayout } from "./quartz/cfg"
+import * as Component from "./quartz/components"
 
 // components shared across all pages
 export const sharedPageComponents: SharedLayout = {
-	head: Component.Head(),
-	header: [],
-	afterBody: [],
-	footer: Component.Footer({
-		links: {
-			GitHub: "https://github.com/jackyzha0/quartz",
-			"Discord Community": "https://discord.gg/cRFFHYye7t",
-		},
-	}),
-};
+  head: Component.Head(),
+  header: [],
+  afterBody: [],
+  footer: Component.Footer({
+    links: {
+      GitHub: "https://github.com/jackyzha0/quartz",
+      "Discord Community": "https://discord.gg/cRFFHYye7t",
+    },
+  }),
+}
 
 // components for pages that display a single page (e.g. a single note)
 export const defaultContentPageLayout: PageLayout = {
-	beforeBody: [
-		Component.ConditionalRender({
-			component: Component.ParentBreadcrumbs(),
-			condition: (page) => page.fileData.slug !== "index",
-		}),
-		Component.ArticleTitle(),
-		Component.ContentMeta(),
-		Component.TagList(),
-	],
-	left: [
-		Component.PageTitle(),
-		Component.MobileOnly(Component.Spacer()),
-		Component.Flex({
-			components: [
-				{
-					Component: Component.Search(),
-					grow: true,
-				},
-				{ Component: Component.Darkmode() },
-				{ Component: Component.ReaderMode() },
-			],
-		}),
-		Component.Explorer(),
-	],
-	right: [
-		Component.Graph(),
-		Component.DesktopOnly(Component.TableOfContents()),
-		Component.Backlinks(),
-	],
-};
+  beforeBody: [
+    Component.ConditionalRender({
+      component: Component.ParentBreadcrumbs(),
+      condition: (page) => page.fileData.slug !== "index",
+    }),
+    Component.ArticleTitle(),
+    Component.ContentMeta(),
+    Component.TagList(),
+  ],
+  left: [
+    Component.PageTitle(),
+    Component.MobileOnly(Component.Spacer()),
+    Component.Flex({
+      components: [
+        {
+          Component: Component.Search(),
+          grow: true,
+        },
+        { Component: Component.Darkmode() },
+        { Component: Component.ReaderMode() },
+      ],
+    }),
+    Component.Explorer(),
+  ],
+  right: [
+    Component.Graph(),
+    Component.DesktopOnly(Component.TableOfContents()),
+    Component.Backlinks(),
+  ],
+}
 
 // components for pages that display lists of pages  (e.g. tags or folders)
 export const defaultListPageLayout: PageLayout = {
-	beforeBody: [Component.Breadcrumbs(), Component.ArticleTitle(), Component.ContentMeta()],
-	left: [
-		Component.PageTitle(),
-		Component.MobileOnly(Component.Spacer()),
-		Component.Flex({
-			components: [
-				{
-					Component: Component.Search(),
-					grow: true,
-				},
-				{ Component: Component.Darkmode() },
-			],
-		}),
-		Component.Explorer(),
-	],
-	right: [],
-};
+  beforeBody: [Component.Breadcrumbs(), Component.ArticleTitle(), Component.ContentMeta()],
+  left: [
+    Component.PageTitle(),
+    Component.MobileOnly(Component.Spacer()),
+    Component.Flex({
+      components: [
+        {
+          Component: Component.Search(),
+          grow: true,
+        },
+        { Component: Component.Darkmode() },
+      ],
+    }),
+    Component.Explorer(),
+  ],
+  right: [],
+}

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -18,7 +18,7 @@ export const sharedPageComponents: SharedLayout = {
 export const defaultContentPageLayout: PageLayout = {
   beforeBody: [
     Component.ConditionalRender({
-      component: Component.ParentBreadcrumbs(),
+      component: Component.Breadcrumbs(),
       condition: (page) => page.fileData.slug !== "index",
     }),
     Component.ArticleTitle(),

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -1,68 +1,68 @@
-import { PageLayout, SharedLayout } from "./quartz/cfg"
-import * as Component from "./quartz/components"
+import { PageLayout, SharedLayout } from "./quartz/cfg";
+import * as Component from "./quartz/components";
 
 // components shared across all pages
 export const sharedPageComponents: SharedLayout = {
-  head: Component.Head(),
-  header: [],
-  afterBody: [],
-  footer: Component.Footer({
-    links: {
-      GitHub: "https://github.com/jackyzha0/quartz",
-      "Discord Community": "https://discord.gg/cRFFHYye7t",
-    },
-  }),
-}
+	head: Component.Head(),
+	header: [],
+	afterBody: [],
+	footer: Component.Footer({
+		links: {
+			GitHub: "https://github.com/jackyzha0/quartz",
+			"Discord Community": "https://discord.gg/cRFFHYye7t",
+		},
+	}),
+};
 
 // components for pages that display a single page (e.g. a single note)
 export const defaultContentPageLayout: PageLayout = {
-  beforeBody: [
-    Component.ConditionalRender({
-      component: Component.Breadcrumbs(),
-      condition: (page) => page.fileData.slug !== "index",
-    }),
-    Component.ArticleTitle(),
-    Component.ContentMeta(),
-    Component.TagList(),
-  ],
-  left: [
-    Component.PageTitle(),
-    Component.MobileOnly(Component.Spacer()),
-    Component.Flex({
-      components: [
-        {
-          Component: Component.Search(),
-          grow: true,
-        },
-        { Component: Component.Darkmode() },
-        { Component: Component.ReaderMode() },
-      ],
-    }),
-    Component.Explorer(),
-  ],
-  right: [
-    Component.Graph(),
-    Component.DesktopOnly(Component.TableOfContents()),
-    Component.Backlinks(),
-  ],
-}
+	beforeBody: [
+		Component.ConditionalRender({
+			component: Component.ParentBreadcrumbs(),
+			condition: (page) => page.fileData.slug !== "index",
+		}),
+		Component.ArticleTitle(),
+		Component.ContentMeta(),
+		Component.TagList(),
+	],
+	left: [
+		Component.PageTitle(),
+		Component.MobileOnly(Component.Spacer()),
+		Component.Flex({
+			components: [
+				{
+					Component: Component.Search(),
+					grow: true,
+				},
+				{ Component: Component.Darkmode() },
+				{ Component: Component.ReaderMode() },
+			],
+		}),
+		Component.Explorer(),
+	],
+	right: [
+		Component.Graph(),
+		Component.DesktopOnly(Component.TableOfContents()),
+		Component.Backlinks(),
+	],
+};
 
 // components for pages that display lists of pages  (e.g. tags or folders)
 export const defaultListPageLayout: PageLayout = {
-  beforeBody: [Component.Breadcrumbs(), Component.ArticleTitle(), Component.ContentMeta()],
-  left: [
-    Component.PageTitle(),
-    Component.MobileOnly(Component.Spacer()),
-    Component.Flex({
-      components: [
-        {
-          Component: Component.Search(),
-          grow: true,
-        },
-        { Component: Component.Darkmode() },
-      ],
-    }),
-    Component.Explorer(),
-  ],
-  right: [],
-}
+	beforeBody: [Component.Breadcrumbs(), Component.ArticleTitle(), Component.ContentMeta()],
+	left: [
+		Component.PageTitle(),
+		Component.MobileOnly(Component.Spacer()),
+		Component.Flex({
+			components: [
+				{
+					Component: Component.Search(),
+					grow: true,
+				},
+				{ Component: Component.Darkmode() },
+			],
+		}),
+		Component.Explorer(),
+	],
+	right: [],
+};

--- a/quartz/components/ParentBreadcrumbs.tsx
+++ b/quartz/components/ParentBreadcrumbs.tsx
@@ -8,16 +8,19 @@ interface ParentBreadcrumbsOptions {
 	spacerSymbol?: string;
 	rootName?: string;
 	resolveFrontmatterTitle?: boolean;
+	frontmatterProp?: string,
 }
 
 const defaultOptions: ParentBreadcrumbsOptions = {
 	spacerSymbol: "❯",
 	rootName: "Home",
 	resolveFrontmatterTitle: true,
+	frontmatterProp: "parent",
 };
 
 export default ((opts?: ParentBreadcrumbsOptions) => {
 	const options = { ...defaultOptions, ...opts };
+	const parentKey = options.frontmatterProp;
 
 	const ParentBreadcrumbs: QuartzComponent = ({
 		fileData,
@@ -34,41 +37,61 @@ export default ((opts?: ParentBreadcrumbsOptions) => {
 
 		const findFile = (name: string) => {
 			const targetSlug = simplifySlug(name as FullSlug);
-
 			return allFiles.find((f: QuartzPluginData) => {
 				const fSlug = simplifySlug(f.slug!);
 				return fSlug === targetSlug || fSlug.endsWith(targetSlug) || f.frontmatter?.title === name;
 			});
 		};
 
-		const crumbs: Array<{ displayName: string; path: string; }> = [];
+		type BreadcrumbNode = { displayName: string; path: string; };
+		const crumbs: Array<BreadcrumbNode[]> = [];
+
 		let current = fileData;
 		const visited = new Set<string>();
 		if (current.slug) visited.add(current.slug);
 
-		while (current && current.frontmatter?.parent) {
-			const parentLink = parseWikiLink(current.frontmatter.parent as string);
-			const parentFile = findFile(parentLink);
+		while (current && current.frontmatter?.[parentKey!]) {
+			const rawParent = current.frontmatter[parentKey!];
+			const parentList = Array.isArray(rawParent) ? rawParent : [rawParent];
 
-			if (parentFile && parentFile.slug && !visited.has(parentFile.slug)) {
-				visited.add(parentFile.slug);
-				crumbs.push({
-					displayName: options.resolveFrontmatterTitle
-						? parentFile.frontmatter?.title ?? parentFile.slug
-						: parentFile.slug,
-					path: resolveRelative(fileData.slug!, parentFile.slug!)
-				});
-				current = parentFile;
+			const currentLevelNodes: BreadcrumbNode[] = [];
+			let nextParent: QuartzPluginData | undefined = undefined;
+
+			for (const p of parentList) {
+				const linkStr = parseWikiLink(p as string);
+				const parentFile = findFile(linkStr);
+
+				if (parentFile && parentFile.slug) {
+					currentLevelNodes.push({
+						displayName: options.resolveFrontmatterTitle
+							? parentFile.frontmatter?.title ?? parentFile.slug
+							: parentFile.slug,
+						path: resolveRelative(fileData.slug!, parentFile.slug!)
+					});
+
+					if (!nextParent && !visited.has(parentFile.slug)) {
+						nextParent = parentFile;
+					}
+				}
+			}
+
+			if (currentLevelNodes.length > 0) {
+				crumbs.push(currentLevelNodes);
+			}
+
+			if (nextParent) {
+				visited.add(nextParent.slug!);
+				current = nextParent;
 			} else {
 				break;
 			}
 		}
 
 		if (current.slug !== "index") {
-			crumbs.push({
+			crumbs.push([{
 				displayName: options.rootName!,
 				path: resolveRelative(fileData.slug!, "index" as SimpleSlug)
-			});
+			}]);
 		}
 
 		crumbs.reverse();
@@ -79,10 +102,15 @@ export default ((opts?: ParentBreadcrumbsOptions) => {
 
 		return (
 			<nav class={classNames(displayClass, "breadcrumb-container")} aria-label="breadcrumbs">
-				{crumbs.map((crumb, index) => (
+				{crumbs.map((crumbLevel, levelIndex) => (
 					<div class="breadcrumb-element">
-						<a href={crumb.path}>{crumb.displayName}</a>
-						{index !== crumbs.length && <p>{options.spacerSymbol}</p>}
+						{crumbLevel.map((node, nodeIndex) => (
+							<>
+								<a href={node.path}>{node.displayName}</a>
+								{nodeIndex < crumbLevel.length - 1 && <span style={{ opacity: 0.5 }}> / </span>}
+							</>
+						))}
+						{levelIndex !== crumbs.length && <p>{options.spacerSymbol}</p>}
 					</div>
 				))}
 				<div class="breadcrumb-element">
@@ -94,4 +122,4 @@ export default ((opts?: ParentBreadcrumbsOptions) => {
 
 	ParentBreadcrumbs.css = style;
 	return ParentBreadcrumbs;
-}) satisfies QuartzComponentConstructor
+}) satisfies QuartzComponentConstructor;

--- a/quartz/components/ParentBreadcrumbs.tsx
+++ b/quartz/components/ParentBreadcrumbs.tsx
@@ -38,7 +38,11 @@ export default ((opts?: ParentBreadcrumbsOptions) => {
       const targetSlug = simplifySlug(name as FullSlug)
       return allFiles.find((f: QuartzPluginData) => {
         const fSlug = simplifySlug(f.slug!)
-        return fSlug === targetSlug || fSlug.endsWith(targetSlug) || f.frontmatter?.title === name
+        return (
+          fSlug === targetSlug ||
+          fSlug.normalize() == targetSlug.normalize() ||
+          f.frontmatter?.title === name
+        )
       })
     }
 

--- a/quartz/components/ParentBreadcrumbs.tsx
+++ b/quartz/components/ParentBreadcrumbs.tsx
@@ -1,0 +1,97 @@
+import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types";
+import { QuartzPluginData } from "../plugins/vfile";
+import { classNames } from "../util/lang";
+import { resolveRelative, simplifySlug, FullSlug, SimpleSlug } from "../util/path";
+import style from "./styles/breadcrumbs.scss";
+
+interface ParentBreadcrumbsOptions {
+	spacerSymbol?: string;
+	rootName?: string;
+	resolveFrontmatterTitle?: boolean;
+}
+
+const defaultOptions: ParentBreadcrumbsOptions = {
+	spacerSymbol: "❯",
+	rootName: "Home",
+	resolveFrontmatterTitle: true,
+};
+
+export default ((opts?: ParentBreadcrumbsOptions) => {
+	const options = { ...defaultOptions, ...opts };
+
+	const ParentBreadcrumbs: QuartzComponent = ({
+		fileData,
+		allFiles,
+		displayClass,
+	}: QuartzComponentProps) => {
+
+		const parseWikiLink = (content: string): string => {
+			if (!content) return "";
+			let clean = content.trim().replace(/^["']|["']$/g, "");
+			clean = clean.replace(/^\[\[|\]\]$/g, "");
+			return clean.split("|")[0];
+		};
+
+		const findFile = (name: string) => {
+			const targetSlug = simplifySlug(name as FullSlug);
+
+			return allFiles.find((f: QuartzPluginData) => {
+				const fSlug = simplifySlug(f.slug!);
+				return fSlug === targetSlug || fSlug.endsWith(targetSlug) || f.frontmatter?.title === name;
+			});
+		};
+
+		const crumbs: Array<{ displayName: string; path: string; }> = [];
+		let current = fileData;
+		const visited = new Set<string>();
+		if (current.slug) visited.add(current.slug);
+
+		while (current && current.frontmatter?.parent) {
+			const parentLink = parseWikiLink(current.frontmatter.parent as string);
+			const parentFile = findFile(parentLink);
+
+			if (parentFile && parentFile.slug && !visited.has(parentFile.slug)) {
+				visited.add(parentFile.slug);
+				crumbs.push({
+					displayName: options.resolveFrontmatterTitle
+						? parentFile.frontmatter?.title ?? parentFile.slug
+						: parentFile.slug,
+					path: resolveRelative(fileData.slug!, parentFile.slug!)
+				});
+				current = parentFile;
+			} else {
+				break;
+			}
+		}
+
+		if (current.slug !== "index") {
+			crumbs.push({
+				displayName: options.rootName!,
+				path: resolveRelative(fileData.slug!, "index" as SimpleSlug)
+			});
+		}
+
+		crumbs.reverse();
+
+		if (crumbs.length === 0 && fileData.slug === "index") {
+			return <></>;
+		}
+
+		return (
+			<nav class={classNames(displayClass, "breadcrumb-container")} aria-label="breadcrumbs">
+				{crumbs.map((crumb, index) => (
+					<div class="breadcrumb-element">
+						<a href={crumb.path}>{crumb.displayName}</a>
+						{index !== crumbs.length && <p>{options.spacerSymbol}</p>}
+					</div>
+				))}
+				<div class="breadcrumb-element">
+					<p>{fileData.frontmatter?.title}</p>
+				</div>
+			</nav>
+		);
+	};
+
+	ParentBreadcrumbs.css = style;
+	return ParentBreadcrumbs;
+}) satisfies QuartzComponentConstructor

--- a/quartz/components/ParentBreadcrumbs.tsx
+++ b/quartz/components/ParentBreadcrumbs.tsx
@@ -1,125 +1,126 @@
-import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types";
-import { QuartzPluginData } from "../plugins/vfile";
-import { classNames } from "../util/lang";
-import { resolveRelative, simplifySlug, FullSlug, SimpleSlug } from "../util/path";
-import style from "./styles/breadcrumbs.scss";
+import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
+import { QuartzPluginData } from "../plugins/vfile"
+import { classNames } from "../util/lang"
+import { resolveRelative, simplifySlug, FullSlug, SimpleSlug } from "../util/path"
+import style from "./styles/breadcrumbs.scss"
 
 interface ParentBreadcrumbsOptions {
-	spacerSymbol?: string;
-	rootName?: string;
-	resolveFrontmatterTitle?: boolean;
-	frontmatterProp?: string,
+  spacerSymbol?: string
+  rootName?: string
+  resolveFrontmatterTitle?: boolean
+  frontmatterProp?: string
 }
 
 const defaultOptions: ParentBreadcrumbsOptions = {
-	spacerSymbol: "❯",
-	rootName: "Home",
-	resolveFrontmatterTitle: true,
-	frontmatterProp: "parent",
-};
+  spacerSymbol: "❯",
+  rootName: "Home",
+  resolveFrontmatterTitle: true,
+  frontmatterProp: "parent",
+}
 
 export default ((opts?: ParentBreadcrumbsOptions) => {
-	const options = { ...defaultOptions, ...opts };
-	const parentKey = options.frontmatterProp;
+  const options = { ...defaultOptions, ...opts }
+  const parentKey = options.frontmatterProp
 
-	const ParentBreadcrumbs: QuartzComponent = ({
-		fileData,
-		allFiles,
-		displayClass,
-	}: QuartzComponentProps) => {
+  const ParentBreadcrumbs: QuartzComponent = ({
+    fileData,
+    allFiles,
+    displayClass,
+  }: QuartzComponentProps) => {
+    const parseWikiLink = (content: string): string => {
+      if (!content) return ""
+      let clean = content.trim().replace(/^["']|["']$/g, "")
+      clean = clean.replace(/^\[\[|\]\]$/g, "")
+      return clean.split("|")[0]
+    }
 
-		const parseWikiLink = (content: string): string => {
-			if (!content) return "";
-			let clean = content.trim().replace(/^["']|["']$/g, "");
-			clean = clean.replace(/^\[\[|\]\]$/g, "");
-			return clean.split("|")[0];
-		};
+    const findFile = (name: string) => {
+      const targetSlug = simplifySlug(name as FullSlug)
+      return allFiles.find((f: QuartzPluginData) => {
+        const fSlug = simplifySlug(f.slug!)
+        return fSlug === targetSlug || fSlug.endsWith(targetSlug) || f.frontmatter?.title === name
+      })
+    }
 
-		const findFile = (name: string) => {
-			const targetSlug = simplifySlug(name as FullSlug);
-			return allFiles.find((f: QuartzPluginData) => {
-				const fSlug = simplifySlug(f.slug!);
-				return fSlug === targetSlug || fSlug.endsWith(targetSlug) || f.frontmatter?.title === name;
-			});
-		};
+    type BreadcrumbNode = { displayName: string; path: string }
+    const crumbs: Array<BreadcrumbNode[]> = []
 
-		type BreadcrumbNode = { displayName: string; path: string; };
-		const crumbs: Array<BreadcrumbNode[]> = [];
+    let current = fileData
+    const visited = new Set<string>()
+    if (current.slug) visited.add(current.slug)
 
-		let current = fileData;
-		const visited = new Set<string>();
-		if (current.slug) visited.add(current.slug);
+    while (current && current.frontmatter?.[parentKey!]) {
+      const rawParent = current.frontmatter[parentKey!]
+      const parentList = Array.isArray(rawParent) ? rawParent : [rawParent]
 
-		while (current && current.frontmatter?.[parentKey!]) {
-			const rawParent = current.frontmatter[parentKey!];
-			const parentList = Array.isArray(rawParent) ? rawParent : [rawParent];
+      const currentLevelNodes: BreadcrumbNode[] = []
+      let nextParent: QuartzPluginData | undefined = undefined
 
-			const currentLevelNodes: BreadcrumbNode[] = [];
-			let nextParent: QuartzPluginData | undefined = undefined;
+      for (const p of parentList) {
+        const linkStr = parseWikiLink(p as string)
+        const parentFile = findFile(linkStr)
 
-			for (const p of parentList) {
-				const linkStr = parseWikiLink(p as string);
-				const parentFile = findFile(linkStr);
+        if (parentFile && parentFile.slug) {
+          currentLevelNodes.push({
+            displayName: options.resolveFrontmatterTitle
+              ? (parentFile.frontmatter?.title ?? parentFile.slug)
+              : parentFile.slug,
+            path: resolveRelative(fileData.slug!, parentFile.slug!),
+          })
 
-				if (parentFile && parentFile.slug) {
-					currentLevelNodes.push({
-						displayName: options.resolveFrontmatterTitle
-							? parentFile.frontmatter?.title ?? parentFile.slug
-							: parentFile.slug,
-						path: resolveRelative(fileData.slug!, parentFile.slug!)
-					});
+          if (!nextParent && !visited.has(parentFile.slug)) {
+            nextParent = parentFile
+          }
+        }
+      }
 
-					if (!nextParent && !visited.has(parentFile.slug)) {
-						nextParent = parentFile;
-					}
-				}
-			}
+      if (currentLevelNodes.length > 0) {
+        crumbs.push(currentLevelNodes)
+      }
 
-			if (currentLevelNodes.length > 0) {
-				crumbs.push(currentLevelNodes);
-			}
+      if (nextParent) {
+        visited.add(nextParent.slug!)
+        current = nextParent
+      } else {
+        break
+      }
+    }
 
-			if (nextParent) {
-				visited.add(nextParent.slug!);
-				current = nextParent;
-			} else {
-				break;
-			}
-		}
+    if (current.slug !== "index") {
+      crumbs.push([
+        {
+          displayName: options.rootName!,
+          path: resolveRelative(fileData.slug!, "index" as SimpleSlug),
+        },
+      ])
+    }
 
-		if (current.slug !== "index") {
-			crumbs.push([{
-				displayName: options.rootName!,
-				path: resolveRelative(fileData.slug!, "index" as SimpleSlug)
-			}]);
-		}
+    crumbs.reverse()
 
-		crumbs.reverse();
+    if (crumbs.length === 0 && fileData.slug === "index") {
+      return <></>
+    }
 
-		if (crumbs.length === 0 && fileData.slug === "index") {
-			return <></>;
-		}
+    return (
+      <nav class={classNames(displayClass, "breadcrumb-container")} aria-label="breadcrumbs">
+        {crumbs.map((crumbLevel, levelIndex) => (
+          <div class="breadcrumb-element">
+            {crumbLevel.map((node, nodeIndex) => (
+              <>
+                <a href={node.path}>{node.displayName}</a>
+                {nodeIndex < crumbLevel.length - 1 && <span style={{ opacity: 0.5 }}> / </span>}
+              </>
+            ))}
+            {levelIndex !== crumbs.length && <p>{options.spacerSymbol}</p>}
+          </div>
+        ))}
+        <div class="breadcrumb-element">
+          <p>{fileData.frontmatter?.title}</p>
+        </div>
+      </nav>
+    )
+  }
 
-		return (
-			<nav class={classNames(displayClass, "breadcrumb-container")} aria-label="breadcrumbs">
-				{crumbs.map((crumbLevel, levelIndex) => (
-					<div class="breadcrumb-element">
-						{crumbLevel.map((node, nodeIndex) => (
-							<>
-								<a href={node.path}>{node.displayName}</a>
-								{nodeIndex < crumbLevel.length - 1 && <span style={{ opacity: 0.5 }}> / </span>}
-							</>
-						))}
-						{levelIndex !== crumbs.length && <p>{options.spacerSymbol}</p>}
-					</div>
-				))}
-				<div class="breadcrumb-element">
-					<p>{fileData.frontmatter?.title}</p>
-				</div>
-			</nav>
-		);
-	};
-
-	ParentBreadcrumbs.css = style;
-	return ParentBreadcrumbs;
-}) satisfies QuartzComponentConstructor;
+  ParentBreadcrumbs.css = style
+  return ParentBreadcrumbs
+}) satisfies QuartzComponentConstructor

--- a/quartz/components/index.ts
+++ b/quartz/components/index.ts
@@ -1,53 +1,55 @@
-import Content from "./pages/Content"
-import TagContent from "./pages/TagContent"
-import FolderContent from "./pages/FolderContent"
-import NotFound from "./pages/404"
-import ArticleTitle from "./ArticleTitle"
-import Darkmode from "./Darkmode"
-import ReaderMode from "./ReaderMode"
-import Head from "./Head"
-import PageTitle from "./PageTitle"
-import ContentMeta from "./ContentMeta"
-import Spacer from "./Spacer"
-import TableOfContents from "./TableOfContents"
-import Explorer from "./Explorer"
-import TagList from "./TagList"
-import Graph from "./Graph"
-import Backlinks from "./Backlinks"
-import Search from "./Search"
-import Footer from "./Footer"
-import DesktopOnly from "./DesktopOnly"
-import MobileOnly from "./MobileOnly"
-import RecentNotes from "./RecentNotes"
-import Breadcrumbs from "./Breadcrumbs"
-import Comments from "./Comments"
-import Flex from "./Flex"
-import ConditionalRender from "./ConditionalRender"
+import Content from "./pages/Content";
+import TagContent from "./pages/TagContent";
+import FolderContent from "./pages/FolderContent";
+import NotFound from "./pages/404";
+import ArticleTitle from "./ArticleTitle";
+import Darkmode from "./Darkmode";
+import ReaderMode from "./ReaderMode";
+import Head from "./Head";
+import PageTitle from "./PageTitle";
+import ContentMeta from "./ContentMeta";
+import Spacer from "./Spacer";
+import TableOfContents from "./TableOfContents";
+import Explorer from "./Explorer";
+import TagList from "./TagList";
+import Graph from "./Graph";
+import Backlinks from "./Backlinks";
+import Search from "./Search";
+import Footer from "./Footer";
+import DesktopOnly from "./DesktopOnly";
+import MobileOnly from "./MobileOnly";
+import RecentNotes from "./RecentNotes";
+import Breadcrumbs from "./Breadcrumbs";
+import Comments from "./Comments";
+import Flex from "./Flex";
+import ConditionalRender from "./ConditionalRender";
+import ParentBreadcrumbs from "./ParentBreadcrumbs";
 
 export {
-  ArticleTitle,
-  Content,
-  TagContent,
-  FolderContent,
-  Darkmode,
-  ReaderMode,
-  Head,
-  PageTitle,
-  ContentMeta,
-  Spacer,
-  TableOfContents,
-  Explorer,
-  TagList,
-  Graph,
-  Backlinks,
-  Search,
-  Footer,
-  DesktopOnly,
-  MobileOnly,
-  RecentNotes,
-  NotFound,
-  Breadcrumbs,
-  Comments,
-  Flex,
-  ConditionalRender,
-}
+	ParentBreadcrumbs,
+	ArticleTitle,
+	Content,
+	TagContent,
+	FolderContent,
+	Darkmode,
+	ReaderMode,
+	Head,
+	PageTitle,
+	ContentMeta,
+	Spacer,
+	TableOfContents,
+	Explorer,
+	TagList,
+	Graph,
+	Backlinks,
+	Search,
+	Footer,
+	DesktopOnly,
+	MobileOnly,
+	RecentNotes,
+	NotFound,
+	Breadcrumbs,
+	Comments,
+	Flex,
+	ConditionalRender,
+};

--- a/quartz/components/index.ts
+++ b/quartz/components/index.ts
@@ -1,55 +1,55 @@
-import Content from "./pages/Content";
-import TagContent from "./pages/TagContent";
-import FolderContent from "./pages/FolderContent";
-import NotFound from "./pages/404";
-import ArticleTitle from "./ArticleTitle";
-import Darkmode from "./Darkmode";
-import ReaderMode from "./ReaderMode";
-import Head from "./Head";
-import PageTitle from "./PageTitle";
-import ContentMeta from "./ContentMeta";
-import Spacer from "./Spacer";
-import TableOfContents from "./TableOfContents";
-import Explorer from "./Explorer";
-import TagList from "./TagList";
-import Graph from "./Graph";
-import Backlinks from "./Backlinks";
-import Search from "./Search";
-import Footer from "./Footer";
-import DesktopOnly from "./DesktopOnly";
-import MobileOnly from "./MobileOnly";
-import RecentNotes from "./RecentNotes";
-import Breadcrumbs from "./Breadcrumbs";
-import Comments from "./Comments";
-import Flex from "./Flex";
-import ConditionalRender from "./ConditionalRender";
-import ParentBreadcrumbs from "./ParentBreadcrumbs";
+import Content from "./pages/Content"
+import TagContent from "./pages/TagContent"
+import FolderContent from "./pages/FolderContent"
+import NotFound from "./pages/404"
+import ArticleTitle from "./ArticleTitle"
+import Darkmode from "./Darkmode"
+import ReaderMode from "./ReaderMode"
+import Head from "./Head"
+import PageTitle from "./PageTitle"
+import ContentMeta from "./ContentMeta"
+import Spacer from "./Spacer"
+import TableOfContents from "./TableOfContents"
+import Explorer from "./Explorer"
+import TagList from "./TagList"
+import Graph from "./Graph"
+import Backlinks from "./Backlinks"
+import Search from "./Search"
+import Footer from "./Footer"
+import DesktopOnly from "./DesktopOnly"
+import MobileOnly from "./MobileOnly"
+import RecentNotes from "./RecentNotes"
+import Breadcrumbs from "./Breadcrumbs"
+import Comments from "./Comments"
+import Flex from "./Flex"
+import ConditionalRender from "./ConditionalRender"
+import ParentBreadcrumbs from "./ParentBreadcrumbs"
 
 export {
-	ParentBreadcrumbs,
-	ArticleTitle,
-	Content,
-	TagContent,
-	FolderContent,
-	Darkmode,
-	ReaderMode,
-	Head,
-	PageTitle,
-	ContentMeta,
-	Spacer,
-	TableOfContents,
-	Explorer,
-	TagList,
-	Graph,
-	Backlinks,
-	Search,
-	Footer,
-	DesktopOnly,
-	MobileOnly,
-	RecentNotes,
-	NotFound,
-	Breadcrumbs,
-	Comments,
-	Flex,
-	ConditionalRender,
-};
+  ParentBreadcrumbs,
+  ArticleTitle,
+  Content,
+  TagContent,
+  FolderContent,
+  Darkmode,
+  ReaderMode,
+  Head,
+  PageTitle,
+  ContentMeta,
+  Spacer,
+  TableOfContents,
+  Explorer,
+  TagList,
+  Graph,
+  Backlinks,
+  Search,
+  Footer,
+  DesktopOnly,
+  MobileOnly,
+  RecentNotes,
+  NotFound,
+  Breadcrumbs,
+  Comments,
+  Flex,
+  ConditionalRender,
+}


### PR DESCRIPTION
ParentBreadcrumbs` is an alternative breadcrumbs component that derives its hierarchy **entirely from frontmatter-defined parent relationships**, rather than folder structure. This is useful for knowledge-base–style sites, wikis, or any content where pages may belong to multiple logical hierarchies.

Unlike the default `Breadcrumbs` component, `ParentBreadcrumbs` supports:

- Explicit parent chains via frontmatter
- Multiple parents per level
- Wiki-style links (`[[Page Name]]`)
- Customizable frontmatter keys

### How It Works

`ParentBreadcrumbs` walks upward through a parent chain starting from the current page, following a configurable frontmatter field.  
At each level, **all parents are rendered**, while one unvisited parent is chosen to continue the chain upward.

Example frontmatter:

```yaml
---
title: "Advanced Topics"
parent: Basics
---
```

Wiki links are supported:

```yaml
parent: [[Basics]]
```

Multiple parents:

```yaml
parent:
- [[Basics]]
- [[Reference]]
```

### Configuration

You can configure `ParentBreadcrumbs` by passing options into `Component.ParentBreadcrumbs()`.

Default configuration:

```ts
Component.ParentBreadcrumbs({
  spacerSymbol: "❯",            // symbol displayed between breadcrumb levels
  rootName: "Home",             // label for the root (index) page
  resolveFrontmatterTitle: true, // use frontmatter.title instead of slug
  parentKey: "parent",          // frontmatter key used to resolve parents
})
```

All options are optional; omitted values fall back to the defaults.


Here is an interactive example how it looks like and how it behaves: https://garden.sgenov.dev/KIT/PKM
And a screenshot:
<img width="1101" height="563" alt="image" src="https://github.com/user-attachments/assets/69f29a54-4be6-4e6d-8bd9-0110e45a00e7" />



Full disclosure on LLMS: I used it to generate the documentation from the code due to laziness 😄 