### PR TITLE
fix: add ofm support for unterminated comments

### DIFF
--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -130,6 +130,7 @@ export const tableWikilinkRegex = new RegExp(/(!?\[\[[^\]]*?\]\]|\[\^[^\]]*?\])/
 
 const highlightRegex = new RegExp(/==([^=]+)==/g)
 const commentRegex = new RegExp(/%%[\s\S]*?%%/g)
+const commentEndRegex = new RegExp(/%%[\s\S]*?$/)
 // from https://github.com/escwxyz/remark-obsidian-callout/blob/main/src/index.ts
 const calloutRegex = new RegExp(/^\[\!([\w-]+)\|?(.+?)?\]([+-]?)/)
 const calloutLineRegex = new RegExp(/^> *\[\!\w+\|?.*?\][+-]?.*$/gm)
@@ -162,6 +163,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options>>
       // do comments at text level
       if (opts.comments) {
         src = src.replace(commentRegex, "")
+        src = src.replace(commentEndRegex, "")
       }
 
       // pre-transform blockquotes


### PR DESCRIPTION
Since Obsidian honors unterminated comments, these must also be filtered out, which the current Regex does not do. I am very unfamiliar with Regex, so there may be a simpler way to do this, which I welcome, but this is the quick and easy fix that I implemented.