### PR TITLE
fix: prevent underscore emphasis in wikilink image filenames

### DIFF
--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -202,6 +202,17 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options>>
             return `${embedDisplay}[${displayAlias.replace(/^\|/, "")}](${rawFp})`
           }
 
+          // Convert image embeds to standard markdown to prevent underscores
+          // in filenames from being parsed as emphasis by the markdown parser.
+          // Uses angle-bracket destination syntax to preserve special characters.
+          if (embedDisplay === "!" && fp) {
+            const ext = path.extname(fp).toLowerCase()
+            if ([".png", ".jpg", ".jpeg", ".gif", ".bmp", ".svg", ".webp"].includes(ext)) {
+              const alt = displayAlias ? displayAlias.replace(/^\|/, "").trim() : ""
+              return `![${alt}](<${fp}>)`
+            }
+          }
+
           return `${embedDisplay}[[${fp}${displayAnchor}${displayAlias}]]`
         })
       }


### PR DESCRIPTION
## Summary

Fixes #2305

Image wikilinks like `![[my_photo_2024-01-01_overview_(1).jpg]]` fail to render as `<img>` tags because the Markdown parser interprets `_text_` patterns in the filename as emphasis, fragmenting the wikilink text across multiple mdast nodes before `mdastFindReplace` can match and convert it.

This PR modifies the existing `textTransform` wikilink handler in `ofm.ts` to convert image embeds to standard Markdown image syntax with angle-bracket destinations (`![alt](<filename>)`), which preserves underscores verbatim through the Markdown parser.

## Root cause

The processing pipeline in `ofm.ts`:

1. **`textTransform`** — recognizes `![[file.jpg]]` via `wikilinkRegex`, but re-emits it as raw `![[file.jpg]]` text
2. **remark parser** — parses the text into mdast; `_text_` patterns inside `[[...]]` become `emphasis` nodes, splitting the wikilink text
3. **`markdownPlugins` / `mdastFindReplace`** — can no longer match the wikilink regex because the text is fragmented by emphasis nodes

## Fix

In the `textTransform` phase where image wikilinks are already identified by `wikilinkRegex`, convert them to standard Markdown image syntax:

```
![[file_name_(1).jpg]]       →  ![](<file_name_(1).jpg>)
![[file_name_(1).jpg|alt]]   →  ![alt](<file_name_(1).jpg>)
```

The angle-bracket destination syntax is part of the CommonMark spec and prevents the Markdown parser from interpreting underscores as emphasis. `CrawlLinks` resolves the image path from the resulting `image` node as usual.

Non-image embeds (video, audio, PDF, transclusion) remain as wikilinks for the existing `markdownPlugins` handling.

## Test plan

- [ ] Image wikilinks with underscores render correctly (e.g. `![[my_photo_2024.png]]`)
- [ ] Image wikilinks without underscores still render correctly
- [ ] Image wikilinks with aliases render correctly (e.g. `![[photo.png|alt text]]`)
- [ ] Non-image embeds (video, PDF, transclusion) are unaffected
- [ ] Images inside callouts render correctly
