### PR TITLE
fix(explorer): allow touchpad/wheel scrolling over article links

### DIFF
--- a/quartz/components/styles/explorer.scss
+++ b/quartz/components/styles/explorer.scss
@@ -153,7 +153,7 @@ button.desktop-explorer {
   }
 
   .folder-outer > ul {
-    overflow: hidden;
+    overflow: clip;
     margin-left: 6px;
     padding-left: 0.8rem;
     border-left: 1px solid var(--lightgray);


### PR DESCRIPTION
## Summary

- Fixes explorer sidebar not responding to touchpad/wheel scroll when the cursor hovers over article links inside folders. Scrolling works fine on folder titles but breaks on the items within.

## Root cause

`overflow: hidden` on `.folder-outer > ul` creates a [scroll container](https://developer.mozilla.org/en-US/docs/Glossary/Scroll_container) that traps wheel/touchpad events. When the cursor is over an article link inside a folder, the browser routes scroll to this inner `<ul>` first. Since it can't actually scroll (content is clipped for the collapse animation), the events are consumed and never reach the parent `ul.overflow` — the actual scrollable container.

Folder titles scroll correctly because `.folder-container` is a direct child of `ul.overflow`, not inside the trapping `<ul>`.

## Fix

Replace `overflow: hidden` with `overflow: clip` on `.folder-outer > ul`. [`overflow: clip`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#clip) provides the same visual clipping needed for the `grid-template-rows: 0fr/1fr` collapse animation **without** creating a scroll container, so wheel events propagate normally to the parent.

## Browser support

`overflow: clip` is supported in all modern browsers (Chrome 90+, Firefox 81+, Safari 16+). See [caniuse](https://caniuse.com/mdn-css_properties_overflow_clip).