### PR TITLE
docs: add "Deep Learning: Zero to Hero" site to showcase

### DIFF
--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -8,6 +8,7 @@ Want to see what Quartz can do? Here are some cool community gardens:
 - [Jacky Zhao's Garden](https://jzhao.xyz/)
 - [Aaron Pham's Garden](https://aarnphm.xyz/)
 - [The Pond](https://turntrout.com/welcome)
+- [Deep Learning: Zero to Hero](https://deeplearningnotes.com)
 - [Eilleen's Everything Notebook](https://quartz.eilleeenz.com/)
 - [Morrowind Modding Wiki](https://morrowind-modding.github.io/)
 - [Stanford CME 302 Numerical Linear Algebra](https://ericdarve.github.io/NLA/)


### PR DESCRIPTION
Added my Quartz-based site "Deep Learning: Zero to Hero" to the community showcase.

The site focuses on structured deep learning notes and educational content, with 200+ notes on AI theory.