### PR TITLE
fix(cli): use 'gray' instead of 'grey' in styleText calls

### DIFF
--- a/quartz/cli/handlers.js
+++ b/quartz/cli/handlers.js
@@ -318,7 +318,7 @@ export async function handleBuild(argv) {
 
     const result = await ctx.rebuild().catch((err) => {
       console.error(`${styleText("red", "Couldn't parse Quartz configuration:")} ${fp}`)
-      console.log(`Reason: ${styleText("grey", err)}`)
+      console.log(`Reason: ${styleText("gray", err)}`)
       process.exit(1)
     })
     release()
@@ -395,7 +395,7 @@ export async function handleBuild(argv) {
           status >= 200 && status < 300
             ? styleText("green", `[${status}]`)
             : styleText("red", `[${status}]`)
-        console.log(statusString + styleText("grey", ` ${argv.baseDir}${req.url}`))
+        console.log(statusString + styleText("gray", ` ${argv.baseDir}${req.url}`))
         release()
       }
 
@@ -406,7 +406,7 @@ export async function handleBuild(argv) {
         })
         console.log(
           styleText("yellow", "[302]") +
-            styleText("grey", ` ${argv.baseDir}${req.url} -> ${newFp}`),
+            styleText("gray", ` ${argv.baseDir}${req.url} -> ${newFp}`),
         )
         res.end()
       }
@@ -482,7 +482,7 @@ export async function handleBuild(argv) {
       .on("change", () => build(clientRefresh))
       .on("unlink", () => build(clientRefresh))
 
-    console.log(styleText("grey", "hint: exit with ctrl+c"))
+    console.log(styleText("gray", "hint: exit with ctrl+c"))
   }
 }
 


### PR DESCRIPTION
## Summary

- `util.styleText('grey', ...)` throws `ERR_INVALID_ARG_VALUE` because `'grey'` is not a valid format name
- While `util.inspect.colors` defines `'grey'` as an alias for `'gray'`, the alias is non-enumerable — and `styleText` validates against `Object.keys(inspect.colors)`, which only includes enumerable properties
- This bug was introduced in #1879 when `chalk` was replaced with `styleText` — `chalk` accepts `'grey'`, but `styleText` does not
- Replaces all 4 occurrences of `'grey'` with `'gray'`

## Test plan

- [x] `npx quartz build --serve` no longer crashes with `ERR_INVALID_ARG_VALUE`