### PR TITLE
fix: await micromorph() to prevent race condition with nav event handlers

### DIFF
--- a/quartz/components/scripts/spa.inline.ts
+++ b/quartz/components/scripts/spa.inline.ts
@@ -102,7 +102,7 @@ async function _navigate(url: URL, isBack: boolean = false) {
   html.body.appendChild(announcer)
 
   // morph body
-  micromorph(document.body, html.body)
+  await micromorph(document.body, html.body)
 
   // scroll into place and add history
   if (!isBack) {


### PR DESCRIPTION
## Summary

- Adds `await` before the `micromorph()` call in `_navigate()` to ensure DOM morphing completes before the `"nav"` event fires

## Details

`micromorph()` returns `Promise<void>` because its internal `patch()` function is `async` and uses `await Promise.all()` for recursive child patching. Without `await`, the DOM morph may still be in progress when `notifyNav()` dispatches the `"nav"` event and downstream handlers (e.g., `setupExplorer`) attempt to rebuild dynamic content.

The `_navigate` function is already `async`, so adding `await` is a safe, minimal change.

Fixes #2322