### PR TITLE
fix: force lowercase URLs to resolve case sensitivity errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tsconfig.tsbuildinfo
 private/
 .replit
 replit.nix
+.vscode/

--- a/quartz/util/path.ts
+++ b/quartz/util/path.ts
@@ -59,6 +59,7 @@ function sluggify(s: string): string {
     .split("/")
     .map((segment) =>
       segment
+        .toLowerCase()
         .replace(/\s/g, "-")
         .replace(/&/g, "-and-")
         .replace(/%/g, "-percent")


### PR DESCRIPTION
## Description of Changes
This PR resolves the issue where Quartz links break and return 404 errors when the casing in the markdown link does not perfectly match the destination file's casing. 

Since,
- Obsidian treats wiki-links as case-insensitive but Quartz resolves paths strictly.
- Obsidian prevents the creation of files with the same name but different casing within the same directory, meaning it is safe to normalize all paths without risk of collision.

I updated the `sluggify` logic to force all generated URLs and paths to lowercase. This ensures that the compiled `href` attributes will correctly match the generated HTML file paths regardless of how they are capitalized in the source markdown.

Fixes #2316