### PR TITLE
docs: fix Roam Research compatibility link

### DIFF
--- a/docs/plugins/RoamFlavoredMarkdown.md
+++ b/docs/plugins/RoamFlavoredMarkdown.md
@@ -4,7 +4,7 @@ tags:
   - plugin/transformer
 ---
 
-This plugin provides support for [Roam Research](https://roamresearch.com) compatibility. See [[Roam Research Compatibility]] for more information.
+This plugin provides support for [Roam Research](https://roamresearch.com) compatibility. See [[features/Roam Research compatibility|Roam Research Compatibility]] for more information.
 
 > [!note]
 > For information on how to add, remove or configure plugins, see the [[Configuration#Plugins|Configuration]] page.


### PR DESCRIPTION
This PR fixes a broken docs link in RoamFlavoredMarkdown.md

The wikilink `[[Roam Research Compatibility]]` on line 7 of `docs/plugins/RoamFlavoredMarkdown.md` was resolving to `../Roam-Research-Compatibility`, which doesn't match the actual generated page path (`features/Roam-Research-compatibility`), resulting in a broken link in the built documentation.

**Change:** Updated the link to `[[features/Roam Research compatibility|Roam Research Compatibility]]` so it correctly resolves to the Roam Research compatibility page under `features/`.

**Tested:** Confirmed against the generated HTML output at `plugins/RoamFlavoredMarkdown.html`.