### PR TITLE
fix(cli): use 'gray' instead of 'grey' in styleText calls

### DIFF
--- a/quartz/cli/handlers.js
+++ b/quartz/cli/handlers.js
@@ -406,7 +406,7 @@ export async function handleBuild(argv) {
 
     const result = await ctx.rebuild().catch((err) => {
       console.error(`${styleText("red", "Couldn't parse Quartz configuration:")} ${fp}`)
-      console.log(`Reason: ${styleText("grey", err.message ?? String(err))}`)
+      console.log(`Reason: ${styleText("gray", err.message ?? String(err))}`)
       process.exit(1)
     })
     release()
@@ -483,7 +483,7 @@ export async function handleBuild(argv) {
           status >= 200 && status < 300
             ? styleText("green", `[${status}]`)
             : styleText("red", `[${status}]`)
-        console.log(statusString + styleText("grey", ` ${argv.baseDir}${req.url}`))
+        console.log(statusString + styleText("gray", ` ${argv.baseDir}${req.url}`))
         release()
       }
 
@@ -494,7 +494,7 @@ export async function handleBuild(argv) {
         })
         console.log(
           styleText("yellow", "[302]") +
-            styleText("grey", ` ${argv.baseDir}${req.url} -> ${newFp}`),
+            styleText("gray", ` ${argv.baseDir}${req.url} -> ${newFp}`),
         )
         res.end()
       }
@@ -570,7 +570,7 @@ export async function handleBuild(argv) {
       .on("change", () => build(clientRefresh))
       .on("unlink", () => build(clientRefresh))
 
-    console.log(styleText("grey", "hint: exit with ctrl+c"))
+    console.log(styleText("gray", "hint: exit with ctrl+c"))
   }
 }
 

--- a/quartz/cli/plugin-handlers.js
+++ b/quartz/cli/plugin-handlers.js
@@ -73,7 +73,7 @@ export async function handlePluginSearch(query) {
   const searchQuery = query || "quartz-plugin"
 
   console.log(`Searching npm for packages matching "${searchQuery}"...`)
-  console.log(styleText("grey", "(This may take a moment)\n"))
+  console.log(styleText("gray", "(This may take a moment)\n"))
 
   try {
     const result = execSync(`npm search ${searchQuery} --json`, { encoding: "utf-8" })
@@ -96,7 +96,7 @@ export async function handlePluginSearch(query) {
     for (const pkg of quartzPlugins.slice(0, 20)) {
       console.log(`  ${styleText("cyan", pkg.name)}@${pkg.version}`)
       if (pkg.description) {
-        console.log(`    ${styleText("grey", pkg.description)}`)
+        console.log(`    ${styleText("gray", pkg.description)}`)
       }
       console.log()
     }


### PR DESCRIPTION
This is largely the same commit as https://github.com/jackyzha0/quartz/pull/2321 which targeted the `v4` branch but this one is targeting `v5` and extends those changes to the `plugin-handlers.js`  file as well. 