### PR TITLE
fix: explorer content leaking into viewport on mobile

### DIFF
--- a/quartz/components/styles/explorer.scss
+++ b/quartz/components/styles/explorer.scss
@@ -229,6 +229,13 @@ li:has(> .folder-outer:not(.open)) > .folder-container > svg {
         transform: translateX(-100vw);
         visibility: hidden;
       }
+
+      // Override .folder-outer.open's visibility: visible which otherwise
+      // leaks through the parent's visibility: hidden (CSS spec allows
+      // children to override inherited visibility).
+      .folder-outer.open {
+        visibility: hidden;
+      }
     }
 
     &:not(.collapsed) {


### PR DESCRIPTION
## Summary

On mobile, a few pixels of explorer navigation links bleed into the visible viewport when the explorer is collapsed, appearing as floating text on the left edge of the screen.

**Root cause:** The collapsed explorer uses `visibility: hidden` + `transform: translateX(-100vw)` to hide its content panel. However:

1. `.folder-outer.open` inside it sets `visibility: visible`, which per CSS spec overrides the parent's `visibility: hidden`
2. `.explorer-content` is absolutely positioned relative to `.sidebar.left` (which has padding from the viewport edge), so `translateX(-100vw)` doesn't fully move the content off-screen

This causes visible explorer links to leak through the ~16px gap.

**Fix:** Override `.folder-outer.open` visibility to `hidden` when the explorer is in its collapsed state on mobile.

## Screenshots

**Before** (floating text circled on left edge):

<img width="419" height="708" alt="quartz-explorer-mobile-visibility-leak-before" src="https://github.com/user-attachments/assets/99473702-1020-4552-9f4e-15c6003f1222" />

## Test plan

- [ ] Verify no floating text appears on the left edge of pages in mobile view
- [ ] Verify the explorer hamburger menu still opens and shows navigation correctly
- [ ] Verify folder expand/collapse animations still work within the open explorer