### PR TITLE
fix: Fix mutation in contentIndex

### DIFF
--- a/quartz/plugins/emitters/contentIndex.tsx
+++ b/quartz/plugins/emitters/contentIndex.tsx
@@ -143,9 +143,11 @@ export const ContentIndex: QuartzEmitterPlugin<Partial<Options>> = (opts) => {
           // remove description and from content index as nothing downstream
           // actually uses it. we only keep it in the index as we need it
           // for the RSS feed
-          delete content.description
-          delete content.date
-          return [slug, content]
+          // Assigning temp allows ensuring mutation doesn't occur
+          const temp = { ...content }
+          delete temp.description
+          delete temp.date
+          return [slug, temp]
         }),
       )
 


### PR DESCRIPTION
contentIndex was deleting description and date from linkIndex entries before writing contentIndex.json. This mutated the shared Map used by explorer, search, and graph components, breaking date sorting and other features that rely on these fields.

Create a separate simplified object for JSON output instead of mutating the original entries.

Fixes #2267