### PR TITLE
feat: add option to sort by frontmatter.order

### DIFF
--- a/docs/features/explorer.md
+++ b/docs/features/explorer.md
@@ -64,6 +64,7 @@ class FileTrieNode {
 export type ContentDetails = {
   slug: FullSlug
   title: string
+  order?: number
   links: SimpleSlug[]
   tags: string[]
   content: string
@@ -73,24 +74,28 @@ export type ContentDetails = {
 Every function you can pass is optional. By default, only a `sort` function will be used:
 
 ```ts title="Default sort function"
-// Sort order: folders first, then files. Sort folders and files alphabetically
 Component.Explorer({
   sortFn: (a, b) => {
-    if ((!a.isFolder && !b.isFolder) || (a.isFolder && b.isFolder)) {
-      return a.displayName.localeCompare(b.displayName, undefined, {
-        numeric: true,
-        sensitivity: "base",
-      })
+    if (a.isFolder !== b.isFolder) {
+      return a.isFolder ? -1 : 1
     }
 
-    if (!a.isFolder && b.isFolder) {
-      return 1
-    } else {
-      return -1
+    const aOrder = typeof a.data?.order === "number" ? a.data.order : Number.POSITIVE_INFINITY
+    const bOrder = typeof b.data?.order === "number" ? b.data.order : Number.POSITIVE_INFINITY
+
+    if (aOrder !== bOrder) {
+      return aOrder - bOrder
     }
+
+    return a.displayName.localeCompare(b.displayName, undefined, {
+      numeric: true,
+      sensitivity: "base",
+    })
   },
 })
 ```
+
+If a file or folder `index.md` defines frontmatter `order`, the default sorter will use that numeric value before falling back to alphabetical sorting by `displayName`.
 
 ---
 

--- a/quartz/components/Explorer.tsx
+++ b/quartz/components/Explorer.tsx
@@ -30,21 +30,23 @@ const defaultOptions: Options = {
     return node
   },
   sortFn: (a, b) => {
-    // Sort order: folders first, then files. Sort folders and files alphabeticall
-    if ((!a.isFolder && !b.isFolder) || (a.isFolder && b.isFolder)) {
-      // numeric: true: Whether numeric collation should be used, such that "1" < "2" < "10"
-      // sensitivity: "base": Only strings that differ in base letters compare as unequal. Examples: a ≠ b, a = á, a = A
-      return a.displayName.localeCompare(b.displayName, undefined, {
-        numeric: true,
-        sensitivity: "base",
-      })
+    if (a.isFolder !== b.isFolder) {
+      return a.isFolder ? -1 : 1
     }
 
-    if (!a.isFolder && b.isFolder) {
-      return 1
-    } else {
-      return -1
+    const aOrder = typeof a.data?.order === "number" ? a.data.order : Number.POSITIVE_INFINITY
+    const bOrder = typeof b.data?.order === "number" ? b.data.order : Number.POSITIVE_INFINITY
+
+    if (aOrder !== bOrder) {
+      return aOrder - bOrder
     }
+
+    // numeric: true: Whether numeric collation should be used, such that "1" < "2" < "10"
+    // sensitivity: "base": Only strings that differ in base letters compare as unequal. Examples: a ≠ b, a = á, a = A
+    return a.displayName.localeCompare(b.displayName, undefined, {
+      numeric: true,
+      sensitivity: "base",
+    })
   },
   filterFn: (node) => node.slugSegment !== "tags",
   order: ["filter", "map", "sort"],

--- a/quartz/plugins/emitters/contentIndex.tsx
+++ b/quartz/plugins/emitters/contentIndex.tsx
@@ -13,6 +13,7 @@ export type ContentDetails = {
   slug: FullSlug
   filePath: FilePath
   title: string
+  order?: number
   links: SimpleSlug[]
   tags: string[]
   content: string
@@ -107,6 +108,7 @@ export const ContentIndex: QuartzEmitterPlugin<Partial<Options>> = (opts) => {
             slug,
             filePath: file.data.relativePath!,
             title: file.data.frontmatter?.title!,
+            order: file.data.frontmatter?.order as number | undefined,
             links: file.data.links ?? [],
             tags: file.data.frontmatter?.tags ?? [],
             content: file.data.text ?? "",


### PR DESCRIPTION
Fixes #2363 

Simply put, if the frontmatter in `index.md` includes `order`, then sort folders by that key. If `order` is not found, fall back to the default alphabetical sort.

I used Codex to figure this out and tested it on my local Quartz build.