### PR TITLE
fix(router): router reload loop on recent notes - another try

### DIFF
--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -70,7 +70,9 @@ export function getSiteRoot(cfg: GlobalConfiguration): FullSlug {
     return "/" as FullSlug
   }
 
-  return pathname.endsWith("/") && pathname !== "/" ? pathname.slice(0, -1) as FullSlug : pathname as FullSlug
+  return pathname.endsWith("/") && pathname !== "/"
+    ? (pathname.slice(0, -1) as FullSlug)
+    : (pathname as FullSlug)
 }
 
 function renderTranscludes(

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -24,22 +24,22 @@ interface RenderComponents {
 
 const headerRegex = new RegExp(/h[1-6]/)
 export function pageResources(
-  baseDir: FullSlug | RelativeURL,
+  siteRoot: FullSlug | RelativeURL,
   staticResources: StaticResources,
 ): StaticResources {
-  const contentIndexPath = joinSegments(baseDir, "static/contentIndex.json")
+  const contentIndexPath = joinSegments(siteRoot, "static/contentIndex.json")
   const contentIndexScript = `const fetchData = fetch("${contentIndexPath}").then(data => data.json())`
 
   const resources: StaticResources = {
     css: [
       {
-        content: joinSegments(baseDir, "index.css"),
+        content: joinSegments(siteRoot, "index.css"),
       },
       ...staticResources.css,
     ],
     js: [
       {
-        src: joinSegments(baseDir, "prescript.js"),
+        src: joinSegments(siteRoot, "prescript.js"),
         loadTime: "beforeDOMReady",
         contentType: "external",
       },
@@ -55,13 +55,22 @@ export function pageResources(
   }
 
   resources.js.push({
-    src: joinSegments(baseDir, "postscript.js"),
+    src: joinSegments(siteRoot, "postscript.js"),
     loadTime: "afterDOMReady",
     moduleType: "module",
     contentType: "external",
   })
 
   return resources
+}
+
+export function getSiteRoot(cfg: GlobalConfiguration): FullSlug {
+  const pathname = new URL(`https://${cfg.baseUrl ?? "example.com"}`).pathname
+  if (pathname === "") {
+    return "/" as FullSlug
+  }
+
+  return pathname.endsWith("/") && pathname !== "/" ? pathname.slice(0, -1) as FullSlug : pathname as FullSlug
 }
 
 function renderTranscludes(

--- a/quartz/plugins/emitters/404.tsx
+++ b/quartz/plugins/emitters/404.tsx
@@ -1,7 +1,7 @@
 import { QuartzEmitterPlugin } from "../types"
 import { QuartzComponentProps } from "../../components/types"
 import BodyConstructor from "../../components/Body"
-import { pageResources, renderPage } from "../../components/renderPage"
+import { getSiteRoot, pageResources, renderPage } from "../../components/renderPage"
 import { FullPageLayout } from "../../cfg"
 import { FullSlug } from "../../util/path"
 import { sharedPageComponents } from "../../../quartz.layout"
@@ -31,8 +31,6 @@ export const NotFoundPage: QuartzEmitterPlugin = () => {
       const cfg = ctx.cfg.configuration
       const slug = "404" as FullSlug
 
-      const url = new URL(`https://${cfg.baseUrl ?? "example.com"}`)
-      const path = url.pathname as FullSlug
       const notFound = i18n(cfg.locale).pages.error.title
       const [tree, vfile] = defaultProcessedContent({
         slug,
@@ -40,7 +38,7 @@ export const NotFoundPage: QuartzEmitterPlugin = () => {
         description: notFound,
         frontmatter: { title: notFound, tags: [] },
       })
-      const externalResources = pageResources(path, resources)
+      const externalResources = pageResources(getSiteRoot(cfg), resources)
       const componentData: QuartzComponentProps = {
         ctx,
         fileData: vfile.data,

--- a/quartz/plugins/emitters/contentPage.tsx
+++ b/quartz/plugins/emitters/contentPage.tsx
@@ -3,9 +3,8 @@ import { QuartzEmitterPlugin } from "../types"
 import { QuartzComponentProps } from "../../components/types"
 import HeaderConstructor from "../../components/Header"
 import BodyConstructor from "../../components/Body"
-import { pageResources, renderPage } from "../../components/renderPage"
+import { getSiteRoot, pageResources, renderPage } from "../../components/renderPage"
 import { FullPageLayout } from "../../cfg"
-import { pathToRoot } from "../../util/path"
 import { defaultContentPageLayout, sharedPageComponents } from "../../../quartz.layout"
 import { Content } from "../../components"
 import { styleText } from "util"
@@ -25,7 +24,7 @@ async function processContent(
 ) {
   const slug = fileData.slug!
   const cfg = ctx.cfg.configuration
-  const externalResources = pageResources(pathToRoot(slug), resources)
+  const externalResources = pageResources(getSiteRoot(cfg), resources)
   const componentData: QuartzComponentProps = {
     ctx,
     fileData,

--- a/quartz/plugins/emitters/folderPage.tsx
+++ b/quartz/plugins/emitters/folderPage.tsx
@@ -2,7 +2,7 @@ import { QuartzEmitterPlugin } from "../types"
 import { QuartzComponentProps } from "../../components/types"
 import HeaderConstructor from "../../components/Header"
 import BodyConstructor from "../../components/Body"
-import { pageResources, renderPage } from "../../components/renderPage"
+import { getSiteRoot, pageResources, renderPage } from "../../components/renderPage"
 import { ProcessedContent, QuartzPluginData, defaultProcessedContent } from "../vfile"
 import { FullPageLayout } from "../../cfg"
 import path from "path"
@@ -11,7 +11,6 @@ import {
   SimpleSlug,
   stripSlashes,
   joinSegments,
-  pathToRoot,
   simplifySlug,
 } from "../../util/path"
 import { defaultListPageLayout, sharedPageComponents } from "../../../quartz.layout"
@@ -38,7 +37,7 @@ async function* processFolderInfo(
     const slug = joinSegments(folder, "index") as FullSlug
     const [tree, file] = folderContent
     const cfg = ctx.cfg.configuration
-    const externalResources = pageResources(pathToRoot(slug), resources)
+    const externalResources = pageResources(getSiteRoot(cfg), resources)
     const componentData: QuartzComponentProps = {
       ctx,
       fileData: file.data,

--- a/quartz/plugins/emitters/folderPage.tsx
+++ b/quartz/plugins/emitters/folderPage.tsx
@@ -6,13 +6,7 @@ import { getSiteRoot, pageResources, renderPage } from "../../components/renderP
 import { ProcessedContent, QuartzPluginData, defaultProcessedContent } from "../vfile"
 import { FullPageLayout } from "../../cfg"
 import path from "path"
-import {
-  FullSlug,
-  SimpleSlug,
-  stripSlashes,
-  joinSegments,
-  simplifySlug,
-} from "../../util/path"
+import { FullSlug, SimpleSlug, stripSlashes, joinSegments, simplifySlug } from "../../util/path"
 import { defaultListPageLayout, sharedPageComponents } from "../../../quartz.layout"
 import { FolderContent } from "../../components"
 import { write } from "./helpers"

--- a/quartz/plugins/emitters/tagPage.tsx
+++ b/quartz/plugins/emitters/tagPage.tsx
@@ -2,10 +2,10 @@ import { QuartzEmitterPlugin } from "../types"
 import { QuartzComponentProps } from "../../components/types"
 import HeaderConstructor from "../../components/Header"
 import BodyConstructor from "../../components/Body"
-import { pageResources, renderPage } from "../../components/renderPage"
+import { getSiteRoot, pageResources, renderPage } from "../../components/renderPage"
 import { ProcessedContent, QuartzPluginData, defaultProcessedContent } from "../vfile"
 import { FullPageLayout } from "../../cfg"
-import { FullSlug, getAllSegmentPrefixes, joinSegments, pathToRoot } from "../../util/path"
+import { FullSlug, getAllSegmentPrefixes, joinSegments } from "../../util/path"
 import { defaultListPageLayout, sharedPageComponents } from "../../../quartz.layout"
 import { TagContent } from "../../components"
 import { write } from "./helpers"
@@ -73,7 +73,7 @@ async function processTagPage(
   const slug = joinSegments("tags", tag) as FullSlug
   const [tree, file] = tagContent
   const cfg = ctx.cfg.configuration
-  const externalResources = pageResources(pathToRoot(slug), resources)
+  const externalResources = pageResources(getSiteRoot(cfg), resources)
   const componentData: QuartzComponentProps = {
     ctx,
     fileData: file.data,


### PR DESCRIPTION
fix #2375 

The pull resquest changes how the slug and baseDir(siteRoot) are calculated. It fixes an apparent issue with trailing slashes, that caused a render-issue in netlify-deployed apps, where the router gets stuck in an infinite reload-loop when clicking a "Recent Notes"-link in quartz V4. The type for the route is now enforced instead of expecting any string.

The new method of calculating the route is then also used in emitters.