### PR TITLE
fix: correct URL for CSL locales

### DIFF
--- a/quartz/plugins/transformers/citations.ts
+++ b/quartz/plugins/transformers/citations.ts
@@ -31,7 +31,7 @@ export const Citations: QuartzTransformerPlugin<Partial<Options>> = (userOpts) =
       // locale available and simply create the lang url-string
       let lang: string = "en-US"
       if (ctx.cfg.configuration.locale !== "en-US") {
-        lang = `https://raw.githubusercontent.com/citation-stylelanguage/locales/refs/heads/master/locales-${ctx.cfg.configuration.locale}.xml`
+        lang = `https://raw.githubusercontent.com/citation-style-language/locales/refs/heads/master/locales-${ctx.cfg.configuration.locale}.xml`
       }
       // Add rehype-citation to the list of plugins
       plugins.push([


### PR DESCRIPTION
Thanks for this great piece of software! Today I was experimenting with the Citations plugin, and I noticed that the URL for CSL locales was missing a dash. This PR just corrects the URL.

Luiz Cláudio