### PR TITLE
feat: JPEG XL Support

### DIFF
--- a/quartz/plugins/transformers/ofm.ts
+++ b/quartz/plugins/transformers/ofm.ts
@@ -230,7 +230,7 @@ export const ObsidianFlavoredMarkdown: QuartzTransformerPlugin<Partial<Options>>
                 if (value.startsWith("!")) {
                   const ext: string = path.extname(fp).toLowerCase()
                   const url = slugifyFilePath(fp as FilePath)
-                  if ([".png", ".jpg", ".jpeg", ".gif", ".bmp", ".svg", ".webp"].includes(ext)) {
+                  if ([".jxl", ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".svg", ".webp"].includes(ext)) {
                     const match = wikilinkImageEmbedRegex.exec(alias ?? "")
                     const alt = match?.groups?.alt ?? ""
                     const width = match?.groups?.width ?? "auto"


### PR DESCRIPTION
Implemented support for JPEG XL as most major browsers are close to shipping it, some already do, e.g. Zen.
It's arguably the most capable and efficient image format out there for both lossy and lossless workflows.
Luckily, it's a one word change since it just works if your browser supports it.

Before:
<img width="904" height="679" alt="image" src="https://github.com/user-attachments/assets/de89f442-83c3-4e77-a0b2-61d636be66d3" />

After:
<img width="896" height="1119" alt="image" src="https://github.com/user-attachments/assets/5daba1cb-32a7-4471-b26b-c63a606f8b60" />

Closes #2385 
Thanks @saberzero1 for the solution!
