### PR TITLE
feat: add Gizmo Analytics as a provider

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,7 @@ This part of the configuration concerns anything that can affect the whole site.
   - `{ provider: 'matomo', siteId: '<your-matomo-id-code', host: 'matomo.example.com' }`: use [Matomo](https://matomo.org/), without protocol.
   - `{ provider: 'vercel' }`: use [Vercel Web Analytics](https://vercel.com/docs/concepts/analytics).
   - `{ provider: 'rybbit', siteId: 'my-rybbit-id' }` (managed) or `{ provider: 'rybbit', siteId: 'my-rybbit-id', host: 'my-rybbit-domain.com' }` (self-hosted) use [Rybbit](https://rybbit.com);
+  - `{ provider: 'gizmo', dataKey: '<your-gizmo-public-key>' }` (managed) or `{ provider: 'gizmo', dataKey: '<your-gizmo-public-key>', host: 'https://<your-gizmo-host>' }` (self-hosted): use [Gizmo Analytics](https://gizmoanalytics.io/). Grab the public key (safe to inline in client-side source) from your dashboard at `/dashboard/keys`. Cookieless, AI-readable via MCP.
 - `locale`: used for [[i18n]] and date formatting
 - `baseUrl`: this is used for sitemaps and RSS feeds that require an absolute URL to know where the canonical 'home' of your site lives. This is normally the deployed URL of your site (e.g. `quartz.jzhao.xyz` for this site). Do not include the protocol (i.e. `https://`) or any leading or trailing slashes.
   - This should also include the subpath if you are [[hosting]] on GitHub pages without a custom domain. For example, if my repository is `jackyzha0/quartz`, GitHub pages would deploy to `https://jackyzha0.github.io/quartz` and the `baseUrl` would be `jackyzha0.github.io/quartz`.

--- a/quartz/cfg.ts
+++ b/quartz/cfg.ts
@@ -55,6 +55,14 @@ export type Analytics =
       siteId: string
       host?: string
     }
+  | {
+      provider: "gizmo"
+      // Public key for ingest. Created at /dashboard/keys; safe to inline
+      // in browser-shipped source (write-only, can't read analytics).
+      dataKey: string
+      // Optional self-hosted origin. Defaults to https://gizmoanalytics.io.
+      host?: string
+    }
 
 export interface GlobalConfiguration {
   pageTitle: string

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -251,6 +251,25 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
 
       document.head.appendChild(rybbitScript);
     `)
+  } else if (cfg.analytics?.provider === "gizmo") {
+    const gizmoHost = cfg.analytics.host ?? "https://gizmoanalytics.io"
+    componentResources.afterDOMLoaded.push(`
+      const gizmoScript = document.createElement('script');
+      gizmoScript.src = '${gizmoHost}/script.js';
+      gizmoScript.setAttribute('data-key', '${cfg.analytics.dataKey}');
+      gizmoScript.defer = true;
+      gizmoScript.onload = () => {
+        // Quartz dispatches a 'nav' event for SPA navigation rather
+        // than History.pushState, so Gizmo's built-in History hooks
+        // don't fire on internal nav. Wire the nav event to the
+        // public window.gizmo() API to record those pageviews.
+        document.addEventListener('nav', () => {
+          if (window.gizmo) window.gizmo('pageview');
+        });
+      };
+
+      document.head.appendChild(gizmoScript);
+    `)
   }
 
   if (cfg.enableSPA) {


### PR DESCRIPTION
Adds Gizmo Analytics (https://gizmoanalytics.io) as a new analytics provider, following the same shape as the existing managed/self-hosted options (Plausible, etc). 