### PR TITLE
feat: make PageTitle configurable

### DIFF
--- a/quartz/components/PageTitle.tsx
+++ b/quartz/components/PageTitle.tsx
@@ -3,22 +3,28 @@ import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } fro
 import { classNames } from "../util/lang"
 import { i18n } from "../i18n"
 
-const PageTitle: QuartzComponent = ({ fileData, cfg, displayClass }: QuartzComponentProps) => {
-  const title = cfg?.pageTitle ?? i18n(cfg.locale).propertyDefaults.title
-  const baseDir = pathToRoot(fileData.slug!)
-  return (
-    <h2 class={classNames(displayClass, "page-title")}>
-      <a href={baseDir}>{title}</a>
-    </h2>
-  )
+type Options = {
+  title?: string
 }
 
-PageTitle.css = `
-.page-title {
-  font-size: 1.75rem;
-  margin: 0;
-  font-family: var(--titleFont);
-}
-`
+export default ((opts?: Options) => {
+  const PageTitle: QuartzComponent = ({ fileData, cfg, displayClass }: QuartzComponentProps) => {
+    const title = opts?.title ?? cfg?.pageTitle ?? i18n(cfg.locale).propertyDefaults.title
+    const baseDir = pathToRoot(fileData.slug!)
+    return (
+      <h2 class={classNames(displayClass, "page-title")}>
+        <a href={baseDir}>{title}</a>
+      </h2>
+    )
+  }
 
-export default (() => PageTitle) satisfies QuartzComponentConstructor
+  PageTitle.css = `
+  .page-title {
+    font-size: 1.75rem;
+    margin: 0;
+    font-family: var(--titleFont);
+  }
+  `
+
+  return PageTitle
+}) satisfies QuartzComponentConstructor<Options>


### PR DESCRIPTION
Usage example:

Replace
```
  Component.PageTitle(),
```
with
```
  Component.DesktopOnly(Component.PageTitle({title: 'Very long form title inappropriate on mobile'})),
  Component.MobileOnly(Component.PageTitle({title: 'Short title'})),
```