### PR TITLE
fix: skip disabled components instead of crashing build

### DIFF
--- a/quartz/plugins/pageTypes/dispatcher.ts
+++ b/quartz/plugins/pageTypes/dispatcher.ts
@@ -55,7 +55,7 @@ function collectComponents(
       layout.footer,
     ]
     for (const c of all) {
-      seen.add(c)
+      if (c) seen.add(c)
     }
   }
   return [...seen]


### PR DESCRIPTION
## Issue
When optional plugins (e.g. the footer) is disabled they become undefined. Adding undefined to the seen Set caused a crash in componentResources.ts when destructuring component properties.

**Sample error:**
```
 Failed to emit from plugin `ComponentResources`: Cannot destructure property 'css' of 'component' as it is undefined.
     at getComponentResources (../plugins/emitters/componentResources.ts:57:13)
     at Object.emit (../plugins/emitters/componentResources.ts:283:34)
     at emit.next (<anonymous>)
     at runEmitter (../processors/emit.ts:23:24)
     at async Promise.all (index 0)
     at emitContent (../processors/emit.ts:72:18)
     at buildQuartz (../build.ts:97:3)
     at default (../build.ts:342:12)
     at build (file:///Users/michael/quartz/quartz/cli/handlers.js:434:20)
     at handleBuild (file:///Users/michael/quartz/quartz/cli/handlers.js:447:5)
```

## Resolution

Check if undefined before adding to the set.