### PR TITLE
fix(ogImage): strip leading dot from og:image:type MIME value

### DIFF
--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -69,7 +69,7 @@ export default (() => {
             <meta name="twitter:image" content={ogImageDefaultPath} />
             <meta
               property="og:image:type"
-              content={`image/${getFileExtension(ogImageDefaultPath) ?? "png"}`}
+              content={`image/${getFileExtension(ogImageDefaultPath)?.replace(/^\./, "") ?? "png"}`}
             />
           </>
         )}

--- a/quartz/plugins/emitters/ogImage.tsx
+++ b/quartz/plugins/emitters/ogImage.tsx
@@ -158,7 +158,12 @@ export const CustomOgImages: QuartzEmitterPlugin<Partial<SocialImageOptions>> = 
               : undefined
             const defaultOgImagePath = `https://${baseUrl}/static/og-image.png`
             const ogImagePath = userDefinedOgImagePath ?? generatedOgImagePath ?? defaultOgImagePath
-            const ogImageMimeType = `image/${getFileExtension(ogImagePath) ?? "png"}`
+            // getFileExtension returns the match including the leading dot
+            // (e.g., ".png"), so strip it before interpolation — otherwise
+            // og:image:type emits "image/.png" and some social-preview
+            // parsers reject it as an invalid MIME type.
+            const ogImageExt = getFileExtension(ogImagePath)?.replace(/^\./, "") ?? "png"
+            const ogImageMimeType = `image/${ogImageExt}`
             return (
               <>
                 {!userDefinedOgImagePath && (


### PR DESCRIPTION
## Bug

`og:image:type` meta tag emits `image/.png` instead of `image/png` (or `image/.webp` instead of `image/webp` for the default WebP output). `getFileExtension()` returns the match including the leading dot:

```ts
export function getFileExtension(s: string): string | undefined {
  return s.match(/\.[A-Za-z0-9]+$/)?.[0]
}
```

So the interpolation in `ogImage.tsx` at line 161:

```ts
const ogImageMimeType = `image/${getFileExtension(ogImagePath) ?? "png"}`
```

produces `image/.png` for any real OG image path.

## Why it matters

Some social-preview parsers reject MIME types with a leading dot and silently skip the image. The result is broken or missing previews on those platforms even though the image itself is served correctly.

## Fix

Strip the leading `.` before interpolating. Two-line change; no other behavior affected. The fallback (`?? "png"`) is preserved.

## Verification

Built a Quartz site from this branch and inspected the rendered HTML. Before:

```html
<meta property="og:image:type" content="image/.webp"/>
```

After:

```html
<meta property="og:image:type" content="image/webp"/>
```