### PR TITLE
build(#2418): adding git in docker file to resolve plugin clone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:22-slim AS builder
+RUN apt-get -y update && apt-get -y install git
 WORKDIR /usr/src/app
 COPY package.json .
 COPY package-lock.json* .


### PR DESCRIPTION
Following #2418 

Issue: When running `docker build .` the cloning of plugins is failing. 

Why: git is not installed in the base image

Resolution: Install git in the DockerFile