### PR TITLE
docs: add "Deep Learning: Zero to Hero" site to showcase

### DIFF
--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -8,6 +8,7 @@ Want to see what Quartz can do? Here are some cool community gardens:
 - [Jacky Zhao's Garden](https://jzhao.xyz/)
 - [Aaron Pham's Garden](https://aarnphm.xyz/)
 - [The Pond](https://turntrout.com/welcome)
+- [Deep Learning: Zero to Hero](https://deeplearningnotes.com)
 - [Eilleen's Everything Notebook](https://quartz.eilleeenz.com/)
 - [Morrowind Modding Wiki](https://morrowind-modding.github.io/)
 - [Stanford CME 302 Numerical Linear Algebra](https://ericdarve.github.io/NLA/)


### PR DESCRIPTION
Added my site, **Deep Learning: Zero to Hero**, to the community showcase.

The site is a long-form deep learning reference organized around structured notes, mathematical derivations, visual explanations, and theory-to-code sections. It contains 200+ interconnected notes covering neural networks, backpropagation, optimization, CNNs, RNNs, attention, Transformers, diffusion models, information theory, and curated paper-reading paths.

Its goal is to make deep learning concepts intelligible without flattening their mathematical structure: rigor when it clarifies, intuition when it reveals, and implementation details when theory meets practice.