### PR TITLE
Fix build before generated plugin index exists

### DIFF
--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -4,7 +4,9 @@ import { CSSResourceToStyleElement, JSResourceToScriptElement } from "../util/re
 import { googleFontHref, googleFontSubsetHref } from "../util/theme"
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
 import { unescapeHTML } from "../util/escape"
-import { CustomOgImagesEmitterName } from "../../.quartz/plugins"
+
+const CustomOgImagesEmitterName = "CustomOgImages"
+
 export default (() => {
   const Head: QuartzComponent = ({
     cfg,

--- a/quartz/util/fileTrie.ts
+++ b/quartz/util/fileTrie.ts
@@ -1,10 +1,13 @@
-import { ContentDetails } from "../../.quartz/plugins"
 import { FullSlug, joinSegments } from "./path"
 
 interface FileTrieData {
   slug: string
   title: string
   filePath: string
+}
+
+export interface ContentDetails extends FileTrieData {
+  [key: string]: unknown
 }
 
 export class FileTrieNode<T extends FileTrieData = ContentDetails> {


### PR DESCRIPTION
## Summary

- Remove core imports from the generated `.quartz/plugins` index so Quartz can build before external plugins are installed.
- Keep the custom OG image emitter detection by comparing against its stable emitter name.
- Add a local structural `ContentDetails` type for `FileTrieNode` instead of using a generated plugin type as the default generic.

Fixes #2429.

## Testing

- Red check before fix: `npx quartz build` failed with `Could not resolve "../../.quartz/plugins"` from `quartz/components/Head.tsx`
- `npx quartz build`
- `npm run check`
- `npm test`
- `git diff --check`
