### PR TITLE
fix: respect baseUrl pathname for 404 base href

### DIFF
--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -1,10 +1,11 @@
 import { i18n } from "../i18n"
-import { FullSlug, getFileExtension, joinSegments, pathToRoot } from "../util/path"
+import { getFileExtension, joinSegments, pathToRoot } from "../util/path"
 import { CSSResourceToStyleElement, JSResourceToScriptElement } from "../util/resources"
 import { googleFontHref, googleFontSubsetHref } from "../util/theme"
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
 import { unescapeHTML } from "../util/escape"
 import { CustomOgImagesEmitterName } from "../../.quartz/plugins"
+import { baseHrefForPage } from "../util/basePath"
 export default (() => {
   const Head: QuartzComponent = ({
     cfg,
@@ -23,9 +24,9 @@ export default (() => {
     const { css, js, additionalHead } = externalResources
 
     const url = new URL(`https://${cfg.baseUrl ?? "example.com"}`)
-    const path = url.pathname as FullSlug
-    const baseDir = fileData.slug === "404" ? path : pathToRoot(fileData.slug!)
+    const baseDir = pathToRoot(fileData.slug!)
     const iconPath = joinSegments(baseDir, "static/icon.png")
+    const baseHref = baseHrefForPage(cfg, fileData.slug!, ctx.argv.serve)
 
     // Url of current page
     const socialUrl =
@@ -45,6 +46,7 @@ export default (() => {
       <head>
         <title>{title}</title>
         <meta charSet="utf-8" />
+        {baseHref && <base href={baseHref} />}
         {coreStylesheet && <link rel="preload" href={coreStylesheet} as="style" />}
         {coreScript && coreScript.contentType === "external" && (
           <link rel="preload" href={coreScript.src} as="script" />

--- a/quartz/plugins/pageTypes/dispatcher.ts
+++ b/quartz/plugins/pageTypes/dispatcher.ts
@@ -77,17 +77,9 @@ async function emitPage(
   treeTransforms?: TreeTransform[],
 ) {
   const cfg = ctx.cfg.configuration
-  // For the 404 page, use an absolute base path so assets resolve correctly
-  // when the hosting provider serves 404.html from any URL depth.
-  // During local dev (--serve), the dev server strips baseDir itself and
-  // serves files from root, so the 404 page must use "/" to avoid requesting
-  // assets under a path prefix that the dev server doesn't serve.
-  const baseDir =
-    slug === "404"
-      ? ((ctx.argv.serve
-          ? "/"
-          : new URL(`https://${cfg.baseUrl ?? "example.com"}`).pathname) as FullSlug)
-      : pathToRoot(slug)
+  // Use relative paths for all pages. Head.tsx emits a base element for the
+  // 404 page so these paths resolve from the configured site root.
+  const baseDir = slug === "404" && ctx.argv.serve ? ("/" as FullSlug) : pathToRoot(slug)
   const externalResources = pageResources(baseDir, resources, ctx)
   const componentData: QuartzComponentProps = {
     ctx,

--- a/quartz/util/basePath.test.ts
+++ b/quartz/util/basePath.test.ts
@@ -1,0 +1,30 @@
+import test, { describe } from "node:test"
+import assert from "node:assert"
+import { baseHrefForPage } from "./basePath"
+import type { GlobalConfiguration } from "../cfg"
+
+describe("baseHrefForPage", () => {
+  test("uses the configured baseUrl pathname for static 404 pages", () => {
+    const cfg = { baseUrl: "example.com/quartz" } as GlobalConfiguration
+
+    assert.equal(baseHrefForPage(cfg, "404", false), "/quartz/")
+  })
+
+  test("uses root for static 404 pages without a baseUrl subpath", () => {
+    const cfg = { baseUrl: "example.com" } as GlobalConfiguration
+
+    assert.equal(baseHrefForPage(cfg, "404", false), "/")
+  })
+
+  test("uses root for served 404 pages", () => {
+    const cfg = { baseUrl: "example.com/quartz" } as GlobalConfiguration
+
+    assert.equal(baseHrefForPage(cfg, "404", true), "/")
+  })
+
+  test("omits the base element for non-404 pages", () => {
+    const cfg = { baseUrl: "example.com/quartz" } as GlobalConfiguration
+
+    assert.equal(baseHrefForPage(cfg, "features/search", false), undefined)
+  })
+})

--- a/quartz/util/basePath.ts
+++ b/quartz/util/basePath.ts
@@ -1,0 +1,21 @@
+import type { GlobalConfiguration } from "../cfg"
+
+function trailingSlash(path: string): string {
+  return path.endsWith("/") ? path : `${path}/`
+}
+
+export function baseHrefForPage(
+  cfg: GlobalConfiguration,
+  slug: string,
+  serve: boolean,
+): string | undefined {
+  if (slug !== "404") {
+    return undefined
+  }
+
+  if (serve || !cfg.baseUrl) {
+    return "/"
+  }
+
+  return trailingSlash(new URL(`https://${cfg.baseUrl}`).pathname)
+}


### PR DESCRIPTION
## Summary

This fixes 404 page asset resolution for sites deployed under a subpath.

Previously, the 404 page used the configured `baseUrl` pathname directly as the resource base path. The recent relative-path approach made the 404 output more consistent with other pages, but using `<base href="/">` would resolve assets from the domain root, which breaks deployments such as `example.com/quartz`.

This change keeps 404 resources relative and emits a 404-only `<base>` element derived from the configured site root:

- `baseUrl: example.com/quartz` -> `<base href="/quartz/">`
- `baseUrl: example.com` -> `<base href="/">`
- local `--serve` -> `<base href="/">`

Non-404 pages do not get a base element.

## Testing

- `npm run check`
- `npm test -- --test-reporter=spec`