### PR TITLE
fix: watch quartz.config.yaml during serve

### DIFF
--- a/quartz/cli/handlers.js
+++ b/quartz/cli/handlers.js
@@ -593,6 +593,8 @@ export async function handleBuild(argv) {
       "**/*.tsx",
       "**/*.scss",
       "package.json",
+      "quartz.config.yaml",
+      "quartz.config.default.yaml",
     ])
     chokidar
       .watch(paths, { ignoreInitial: true })


### PR DESCRIPTION
The serve-mode watcher globs never matched quartz.config.yaml or quartz.config.default.yaml, so config edits (theme colors, plugin flags, footer links) silently required a server restart. This was a regression from v4, where quartz.config.ts matched the **/*.ts glob.

