### PR TITLE
fix(layout): allow plugins to target the `header` layout position

### DIFF
--- a/quartz/plugins/loader/config-loader.ts
+++ b/quartz/plugins/loader/config-loader.ts
@@ -740,6 +740,7 @@ function buildLayoutForEntries(
       groupOptions?: PluginLayoutDeclaration["groupOptions"]
     }[]
   > = {
+    header: [],
     left: [],
     right: [],
     beforeBody: [],

--- a/quartz/plugins/loader/types.ts
+++ b/quartz/plugins/loader/types.ts
@@ -8,7 +8,7 @@ import { BuildCtx } from "../../util/ctx"
 
 export type PluginCategory = "transformer" | "filter" | "emitter" | "pageType" | "component"
 
-export type LayoutPosition = "left" | "right" | "beforeBody" | "afterBody"
+export type LayoutPosition = "header" | "left" | "right" | "beforeBody" | "afterBody"
 
 export type LayoutDisplay = "all" | "mobile-only" | "desktop-only"
 

--- a/quartz/plugins/quartz-plugins.schema.json
+++ b/quartz/plugins/quartz-plugins.schema.json
@@ -238,7 +238,7 @@
             "properties": {
               "position": {
                 "type": "string",
-                "enum": ["left", "right", "beforeBody", "afterBody", "body"],
+                "enum": ["header", "left", "right", "beforeBody", "afterBody", "body"],
                 "description": "Layout position"
               },
               "priority": {


### PR DESCRIPTION
The docs mention ([here](https://quartz.jzhao.xyz/layout#:~:text=scripts%2C%20and%20styles.-,header,-is%20a%20set)) that header is a valid layout field, but it was missing from `buildLayoutForEntries`. This resulted in any plugins declaring layout.position: header to be silently dropped.

This also adds header to the LayoutPosition type and the schema's position enum so the config type checks and validates.

---

Closes #2446

Example replicating the Quartz 3 header in the new Quartz 5 YAML way:

```yaml
plugins:
  - source: github:quartz-community/page-title
    enabled: true
    layout:
      position: header
      priority: 10
      group: header-bar
      groupOptions:
        grow: true
  - source: github:quartz-community/search
    enabled: true
    layout:
      position: header
      priority: 20
      group: header-bar
  - source: github:quartz-community/darkmode
    enabled: true
    layout:
      position: header
      priority: 30
      group: header-bar

layout:
  groups:
    header-bar:
      direction: row
      gap: 0.5rem
```

<img width="571" height="298" alt="quartz3-header" src="https://github.com/user-attachments/assets/bcd4e472-928b-435f-a784-8c55a9a15f01" />
