### PR TITLE
fix: Render Undefined Footer Component When Not Enable

### DIFF
--- a/quartz/components/frames/DefaultFrame.tsx
+++ b/quartz/components/frames/DefaultFrame.tsx
@@ -54,7 +54,7 @@ export const DefaultFrame: PageFrame = {
             <BodyComponent {...componentData} />
           ))}
         </div>
-        <Footer {...componentData} />
+        {Footer && <Footer {...componentData} />}
       </>
     )
   },

--- a/quartz/components/frames/FullWidthFrame.tsx
+++ b/quartz/components/frames/FullWidthFrame.tsx
@@ -44,7 +44,7 @@ export const FullWidthFrame: PageFrame = {
             ))}
           </div>
         </div>
-        <Footer {...componentData} />
+        {Footer && <Footer {...componentData} />}
       </>
     )
   },

--- a/quartz/components/frames/MinimalFrame.tsx
+++ b/quartz/components/frames/MinimalFrame.tsx
@@ -16,7 +16,7 @@ export const MinimalFrame: PageFrame = {
         <div class="center minimal">
           <Content {...componentData} />
         </div>
-        <Footer {...componentData} />
+        {Footer && <Footer {...componentData} />}
       </>
     )
   },


### PR DESCRIPTION
To reproduce the issue you guys can check the DOM when not enable the Footer component.
<img width="1422" height="768" alt="CleanShot 2026-07-10 at 19 39 47@2x" src="https://github.com/user-attachments/assets/ac7f273a-886c-49b1-9a61-11b4533f9f8a" />
"This PR was written entirely using an LLM."
