### PR TITLE
docs: clarify ConditionalRender overrides

### DIFF
--- a/docs/layout-components.md
+++ b/docs/layout-components.md
@@ -174,14 +174,28 @@ Available built-in conditions:
 
 ### TS Override
 
-For custom conditions that aren't covered by the built-in presets, use `Component.ConditionalRender()` in `quartz.ts`:
+For custom conditions that aren't covered by the built-in presets, import the internal component utilities and the component you want to wrap in `quartz.ts`. Place `Component.ConditionalRender()` in the layout slot where the wrapped component should appear. For example, this renders Search in the left sidebar only for pages under `notes/`:
 
 ```ts title="quartz.ts (override)"
-Component.ConditionalRender({
-  component: Plugin.Search(),
-  condition: (props) => props.displayClass !== "fullpage",
+import { loadQuartzConfig, loadQuartzLayout } from "./quartz/plugins/loader/config-loader"
+import * as Component from "./quartz/components"
+import { Search } from "./.quartz/plugins/search"
+
+const config = await loadQuartzConfig()
+export default config
+export const layout = await loadQuartzLayout({
+  defaults: {
+    left: [
+      Component.ConditionalRender({
+        component: Search(),
+        condition: (props) => props.fileData.slug?.startsWith("notes/") ?? false,
+      }),
+    ],
+  },
 })
 ```
+
+The wrapped plugin must be installed and enabled in `quartz.config.yaml`. A TypeScript layout override replaces the selected slot, so include any other components you want to keep in that slot alongside the conditional component.
 
 ```typescript
 type ConditionalRenderConfig = {


### PR DESCRIPTION
## Summary

- show where `Component.ConditionalRender()` belongs in a complete `quartz.ts` layout override
- document the required internal-component and installed-plugin imports
- use a type-checked custom slug predicate and explain that a slot override replaces that slot's defaults

Closes #2480

## Validation

- the documented override type-checks with the repository's installed Search plugin
- TypeScript check passed under Node 24.14.0
- repository Prettier check passed
- all 109 repository tests passed
- documentation build completed and emitted 313 files
- `git diff --check` passed

This PR was written entirely using an LLM.
