### PR TITLE
fix(assets): silence ENOENT races in watch mode

### DIFF
--- a/quartz/plugins/emitters/assets.ts
+++ b/quartz/plugins/emitters/assets.ts
@@ -57,11 +57,19 @@ export const Assets: QuartzEmitterPlugin = () => {
         if (ext === ".md" || excludeExtensions.has(ext)) continue
 
         if (changeEvent.type === "add" || changeEvent.type === "change") {
-          yield copyFile(ctx.argv, changeEvent.path)
+          try {
+            yield copyFile(ctx.argv, changeEvent.path)
+          } catch (err) {
+            if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err
+          }
         } else if (changeEvent.type === "delete") {
           const name = slugifyFilePath(changeEvent.path)
           const dest = joinSegments(ctx.argv.output, name) as FilePath
-          await fs.promises.unlink(dest)
+          try {
+            await fs.promises.unlink(dest)
+          } catch (err) {
+            if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err
+          }
         }
       }
     },


### PR DESCRIPTION
I noticed since v4 that when removing/renaming many files almost together, while having the quartz server on watch, it crashed because it didn't find the original it expected.

I applied this change on v4 some months ago, now ported to v5 and it keeps working perfectly.

Hope this helps!