### PR TITLE
fix(schema): allow null for analytics field

### DIFF
--- a/quartz/plugins/quartz-plugins.schema.json
+++ b/quartz/plugins/quartz-plugins.schema.json
@@ -165,8 +165,11 @@
           }
         },
         "analytics": {
-          "type": "object",
-          "description": "Analytics configuration"
+          "oneOf": [
+            { "type": "null" },
+            { "type": "object", "description": "Analytics configuration" }
+          ],
+          "description": "Analytics configuration (null to disable)"
         },
         "ignorePatterns": {
           "type": "array",


### PR DESCRIPTION
Very small change: when opening the config yaml with an editor that validates the schema, it kept showing that analytics did not support "null", when it does. This aligns the schema so it doesn't complain anymore.