### PR TITLE
fix(build): clear output dir contents rather than rmdir

### DIFF
--- a/quartz/build.ts
+++ b/quartz/build.ts
@@ -2,7 +2,7 @@ import sourceMapSupport from "source-map-support"
 sourceMapSupport.install(options)
 import path from "path"
 import { PerfTimer } from "./util/perf"
-import { rm } from "fs/promises"
+import { rm, readdir } from "fs/promises"
 import { GlobbyFilterFunction, isGitIgnored } from "globby"
 import { styleText } from "util"
 import { parseMarkdown } from "./processors/parse"
@@ -76,7 +76,14 @@ async function buildQuartz(argv: Argv, mut: Mutex, clientRefresh: () => void) {
 
   const release = await mut.acquire()
   perf.addEvent("clean")
-  await rm(output, { recursive: true, force: true })
+  try {
+    const entries = await readdir(output)
+    await Promise.all(
+      entries.map((e) => rm(path.join(output, e), { recursive: true, force: true })),
+    )
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err
+  }
   console.log(`Cleaned output directory \`${output}\` in ${perf.timeSince("clean")}`)
 
   perf.addEvent("glob")


### PR DESCRIPTION
I had this issue (#2138) since a while, given I'm running quartz via docker: this fixes the EBUSY on bind mounts.
This way it leaves the empty folder there, if you'd prefer for this to be kept behaving the same, so removing the output folder when possible, I can try to add it.