### PR TITLE
fix(docker): 2-stage build, apt cache mounts, .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.quartz/

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -8,7 +8,14 @@ on:
     branches: [v5]
     paths:
       - .github/workflows/docker-build-push.yaml
+      - .dockerignore
+      - Dockerfile
       - quartz/**
+      - package*.json
+      - quartz*
+      - globals.d.ts
+      - index.d.ts
+      - tsconfig.json
   workflow_dispatch:
 
 jobs:
@@ -85,4 +92,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags || steps.meta-pr.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels || steps.meta-pr.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM builder AS plugins
 COPY quartz/bootstrap-cli.mjs ./quartz/bootstrap-cli.mjs
 COPY quartz/cli/ ./quartz/cli/
 COPY quartz.lock.json* quartz.config*.yaml ./
-RUN npx quartz plugin install
+RUN mkdir -p .quartz/plugins && npx quartz plugin install
 
 FROM node:22-slim
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,23 @@
 FROM node:22-slim AS builder
 
-# install git to install plugins
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y git
 
 WORKDIR /usr/src/app
-COPY package.json .
-COPY package-lock.json* .
-COPY .npmrc* .
-COPY quartz/ ./quartz/
-COPY quartz.lock.json* .
-RUN npm install; npx quartz plugin install
+COPY package.json package-lock.json* .npmrc* ./
+RUN npm ci
+
+FROM builder AS plugins
+
+COPY quartz/bootstrap-cli.mjs ./quartz/bootstrap-cli.mjs
+COPY quartz/cli/ ./quartz/cli/
+COPY quartz.lock.json* quartz.config*.yaml ./
+RUN npx quartz plugin install
 
 FROM node:22-slim
 WORKDIR /usr/src/app
-COPY --from=builder /usr/src/app/ /usr/src/app/
+COPY --from=builder /usr/src/app/node_modules ./node_modules
+COPY --from=plugins /usr/src/app/.quartz/ ./.quartz/
 COPY . .
 CMD ["npx", "quartz", "build", "--serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 WORKDIR /usr/src/app
 COPY package.json package-lock.json* .npmrc* ./
+ENV NPM_CONFIG_USERCONFIG=/usr/src/app/.npmrc
 RUN npm ci
-
-FROM builder AS plugins
 
 COPY quartz/bootstrap-cli.mjs ./quartz/bootstrap-cli.mjs
 COPY quartz/cli/ ./quartz/cli/
@@ -18,6 +17,6 @@ RUN mkdir -p .quartz/plugins && npx quartz plugin install
 FROM node:22-slim
 WORKDIR /usr/src/app
 COPY --from=builder /usr/src/app/node_modules ./node_modules
-COPY --from=plugins /usr/src/app/.quartz/ ./.quartz/
+COPY --from=builder /usr/src/app/.quartz/ ./.quartz/
 COPY . .
 CMD ["npx", "quartz", "build", "--serve"]


### PR DESCRIPTION
I noticed rebuilds were slow since npm install and plugin install shared a layer, so changing one busted the other. Pulling the image was also slow as everything was bundled together.

I initially split into three stages (builder, plugins, runtime) to cache npm and plugin install independently, then revised to two stages after realising that plugins with `requiresInstall` add native deps to root `node_modules`, so copying node_modules from a stage that skipped plugin install would silently drop those.

The builder stage now runs both `npm ci` and plugin install, each as its own layer, so the npm cache still survives a plugin-only change. The runtime stage copies node_modules and .quartz from builder.

I also added `ENV NPM_CONFIG_USERCONFIG=/usr/src/app/.npmrc` since plugin install can spawn child npm processes inside `.quartz/plugins/<name>/`, which would miss the root .npmrc otherwise, plus apt cache mounts to keep the apt cache out of the layers, a .dockerignore to keep node_modules and .quartz out of the build context, and glob patterns on quartz.lock.json and quartz.config.yaml.