### PR TITLE
fix: decouple Head.tsx from og-image plugin import

### DIFF
--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -4,7 +4,7 @@ import { CSSResourceToStyleElement, JSResourceToScriptElement } from "../util/re
 import { googleFontHref, googleFontSubsetHref } from "../util/theme"
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
 import { unescapeHTML } from "../util/escape"
-import { CustomOgImagesEmitterName } from "../../.quartz/plugins"
+
 export default (() => {
   const Head: QuartzComponent = ({
     cfg,
@@ -31,9 +31,7 @@ export default (() => {
     const socialUrl =
       fileData.slug === "404" ? url.toString() : joinSegments(url.toString(), fileData.slug!)
 
-    const usesCustomOgImage = ctx.cfg.plugins.emitters.some(
-      (e) => e.name === CustomOgImagesEmitterName,
-    )
+    const usesCustomOgImage = ctx.cfg.plugins.emitters.some((e) => e.name === "CustomOgImages")
     const ogImageDefaultPath = `https://${cfg.baseUrl}/static/og-image.png`
 
     const coreStylesheet = css[0]?.content

--- a/quartz/util/fileTrie.ts
+++ b/quartz/util/fileTrie.ts
@@ -1,4 +1,4 @@
-import { ContentDetails } from "../../.quartz/plugins"
+import type { ContentDetails } from "../../.quartz/plugins"
 import { FullSlug, joinSegments } from "./path"
 
 interface FileTrieData {


### PR DESCRIPTION
## Problem

`Head.tsx` unconditionally imports `CustomOgImagesEmitterName` from `.quartz/plugins`. When the `og-image` plugin is not listed in `quartz.config.yaml`, the plugin index doesn't export that symbol, and the build fails:

```
No matching export in ".quartz/plugins/index.ts" for import "CustomOgImagesEmitterName"
```

This violates the plugin system's opt-in contract — all community plugins should be optional.

## Fix

- **`Head.tsx`**: Remove the import. Inline the emitter name string constant (`"CustomOgImages"`) at the usage site (line 35). The value is a stable plugin identity that won't change.
- **`fileTrie.ts`**: Convert `import { ContentDetails }` to `import type { ContentDetails }`. This import is only used in a type position and was already elided by the bundler, but the explicit `import type` makes the intent clear.

## Verification

- `npm test` — 109 tests pass
- Full Quartz build succeeds **without** og-image in the plugin config
- Full Quartz build succeeds **with** og-image in the plugin config (no regression)