### PR TITLE
docs: add Image Zoom to community plugins

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -18,7 +18,7 @@ npx quartz plugin add <github-url>
 <!-- Add community plugins here as they become available -->
 <!-- Format: - **[Plugin Name](link)** — Brief description -->
 
-_No community plugins listed yet. Be the first to share yours!_
+- **[Image Zoom](https://github.com/vazome/quartz-image-zoom)** — Click any image to open it full-size, using a native `<dialog>` so Esc-to-close and focus trapping come from the platform.
 
 ## Tools & Integrations
 


### PR DESCRIPTION
The Community Plugins section is currently empty — this adds the first entry.

**Image Zoom** — click any image to open it full-size. It is a transformer that tags `<img>` elements and ships a small inline script that opens a native `<dialog>`, so Esc or click outside of the image to close the zoom. Handled by the browser. No options, no dependencies to install.

Repo: https://github.com/vazome/quartz-image-zoom
Install: `npx quartz plugin add github:vazome/quartz-image-zoom`