### PR TITLE
fix: plugin install --from-config doesn't detect a changed pinned source

### DIFF
--- a/quartz/cli/plugin-git-handlers.js
+++ b/quartz/cli/plugin-git-handlers.js
@@ -175,6 +175,16 @@ function linkPeerPlugins(pluginDir) {
 }
 
 /**
+ * Whether a plugin's previously-installed lockfile record no longer matches
+ * its current config source (e.g. a pinned ref was bumped), meaning the
+ * on-disk plugin directory is stale and must be reinstalled rather than
+ * reused as-is.
+ */
+export function pluginSourceChanged(priorEntry, currentSource) {
+  return priorEntry !== undefined && priorEntry.source !== currentSource
+}
+
+/**
  * Search installed plugins for one whose package.json "name" matches the given
  * npm package name (e.g. "@quartz-community/bases-page").
  */
@@ -506,7 +516,13 @@ export async function handlePluginInstallUnified({
       .filter((entry) => {
         const name = extractPluginName(entry.source)
         const pluginDir = path.join(PLUGINS_DIR, name)
-        if (lockfile.plugins[name] && fs.existsSync(pluginDir)) return false
+        const priorEntry = lockfile.plugins[name]
+        if (
+          !pluginSourceChanged(priorEntry, entry.source) &&
+          priorEntry &&
+          fs.existsSync(pluginDir)
+        )
+          return false
         const src = getSourceUrl(entry.source)
         return (
           src.startsWith("github:") ||
@@ -575,6 +591,17 @@ export async function handlePluginInstallUnified({
       try {
         const { name, url, ref, local, subdir } = parseGitSource(entry.source)
         const pluginDir = path.join(PLUGINS_DIR, name)
+        const priorEntry = lockfile.plugins[name]
+
+        if (fs.existsSync(pluginDir) && pluginSourceChanged(priorEntry, entry.source)) {
+          console.log(
+            styleText(
+              "yellow",
+              `⚠ ${name} source changed (${formatSource(priorEntry.source)} → ${formatSource(entry.source)}), reinstalling`,
+            ),
+          )
+          fs.rmSync(pluginDir, { recursive: true, force: true })
+        }
 
         if (fs.existsSync(pluginDir)) {
           if (local) {

--- a/quartz/cli/plugin-git-handlers.test.js
+++ b/quartz/cli/plugin-git-handlers.test.js
@@ -1,0 +1,30 @@
+import test, { describe } from "node:test"
+import assert from "node:assert"
+import { pluginSourceChanged } from "./plugin-git-handlers.js"
+
+describe("pluginSourceChanged", () => {
+  test("is false when there is no prior lockfile record", () => {
+    // First-ever install: nothing to compare against, so this alone must not
+    // force a reinstall of an unrelated pre-existing directory.
+    assert.strictEqual(pluginSourceChanged(undefined, "github:owner/repo#main"), false)
+  })
+
+  test("is false when the source is unchanged", () => {
+    const priorEntry = { source: "github:owner/repo#main", resolved: "...", commit: "abc123" }
+    assert.strictEqual(pluginSourceChanged(priorEntry, "github:owner/repo#main"), false)
+  })
+
+  test("is true when the pinned ref changed", () => {
+    // This is the case `plugin install --from-config` used to miss entirely:
+    // the directory and lockfile entry both already exist, so the plugin was
+    // treated as "already installed" and never re-cloned even though its
+    // configured ref moved to a different branch.
+    const priorEntry = { source: "github:owner/repo#old-branch", resolved: "...", commit: "abc123" }
+    assert.strictEqual(pluginSourceChanged(priorEntry, "github:owner/repo#new-branch"), true)
+  })
+
+  test("is true when the repo itself changed", () => {
+    const priorEntry = { source: "github:owner/old-repo", resolved: "...", commit: "abc123" }
+    assert.strictEqual(pluginSourceChanged(priorEntry, "github:owner/new-repo"), true)
+  })
+})


### PR DESCRIPTION
# Fixes

## `plugin install --from-config` silently keeps a stale plugin when its pinned source changes

### Goal
Bumping a plugin's pinned source in `quartz.config.yaml` (e.g. switching a fork branch, or repointing at a different fork/ref) should always be picked up the next time `npx quartz plugin install --from-config` runs, whether that's a fresh checkout or a reused `.quartz/plugins/` directory (a persistent CI cache, or a local dev machine that already had the old version installed).

### Problem
`handlePluginInstallUnified()`'s "is this plugin already installed" check only verified that `quartz.lock.json` had an entry for the plugin's name *and* that its directory existed on disk — it never compared that entry's recorded `source` against the plugin's current source in `quartz.config.yaml`. So whenever the old directory and lockfile record were still present, the plugin was treated as up to date and never re-cloned, regardless of what the config now said.

This is easy to miss with the tool's own default workflow (delete `.quartz/` or start from a fresh checkout, so there's no stale state to miss in the first place), but it bites as soon as `.quartz/plugins/` is reused across runs — most notably a CI cache keyed on something coarser than every individual plugin's source, or repeated local runs of `plugin install --from-config` after editing the config.

It's also worse than a silent no-op: the existing-directory fast path re-stamps the lockfile's `source` field to the *new* value while leaving `commit` pointing at whatever was actually still checked out — producing a lockfile entry that claims to be on the new ref while actually still serving the old one.

### Implementation
- `quartz/cli/plugin-git-handlers.js`: extracted the comparison into a small pure `pluginSourceChanged(priorEntry, currentSource)` helper, used in both:
  - the "is this plugin missing" filter that decides what needs installing, and
  - the existing-directory fast path, which now removes the stale directory and falls through to a normal (re)install instead of just re-stamping the lockfile.
  
  An unrelated pre-existing directory with *no* prior lockfile record at all (e.g. first-ever install onto an already-populated `.quartz/plugins/`) is left alone, matching the previous behavior for that case.
- `quartz/cli/plugin-git-handlers.test.js` (new): covers `pluginSourceChanged` — no prior record, unchanged source, changed ref, changed repo.

Verified: `npm test` (167 tests passing) and `npm run check` (`tsc --noEmit` + `prettier --check`) both clean.