### PR TITLE
fix(dev): derive LiveReload WebSocket protocol from the page

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -155,7 +155,7 @@ If you want to start over, run `npx quartz restore` to recover your content from
 
 - Make sure you're using `--serve` mode: `npx quartz build --serve`
 - Check that port 3001 (WebSocket) is not blocked — this is the default `--wsPort` used for hot reload notifications
-- If developing remotely, use `--remoteDevHost` to set the correct WebSocket URL
+- If developing remotely, use `--remoteDevHost` to set the WebSocket hostname (the protocol follows the page: `wss` on HTTPS, `ws` otherwise)
 
 ### Port already in use
 

--- a/quartz/cli/args.js
+++ b/quartz/cli/args.js
@@ -110,7 +110,8 @@ export const BuildArgv = {
   remoteDevHost: {
     string: true,
     default: "",
-    describe: "A URL override for the websocket connection if you are not developing on localhost",
+    describe:
+      "hostname to use for the hot-reload WebSocket connection if you are not developing on localhost",
   },
   bundleInfo: {
     boolean: true,

--- a/quartz/plugins/index.ts
+++ b/quartz/plugins/index.ts
@@ -23,15 +23,16 @@ export function getStaticResourcesFromPlugins(ctx: BuildCtx) {
 
   // if serving locally, listen for rebuilds and reload the page
   if (ctx.argv.serve) {
-    const wsUrl = ctx.argv.remoteDevHost
-      ? `wss://${ctx.argv.remoteDevHost}:${ctx.argv.wsPort}`
-      : `ws://localhost:${ctx.argv.wsPort}`
+    const wsHost = ctx.argv.remoteDevHost || "localhost"
 
     staticResources.js.push({
       loadTime: "afterDOMReady",
       contentType: "inline",
       script: `
-        const socket = new WebSocket('${wsUrl}')
+        // the dev server speaks plain ws unless it sits behind a TLS proxy,
+        // so follow the page instead of assuming
+        const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:"
+        const socket = new WebSocket(\`\${wsProtocol}//${wsHost}:${ctx.argv.wsPort}\`)
         // reload(true) ensures resources like images and scripts are fetched again in firefox
         socket.addEventListener('message', () => document.location.reload(true))
       `,


### PR DESCRIPTION
Fixes #2510.

## The problem

`--remoteDevHost` hardcodes `wss://`:

```ts
const wsUrl = ctx.argv.remoteDevHost
  ? `wss://${ctx.argv.remoteDevHost}:${ctx.argv.wsPort}`
  : `ws://localhost:${ctx.argv.wsPort}`
```

But the dev server serves plain `ws`, with no TLS. So the moment you pass the flag to develop over a tailnet or a LAN address and open the page over `http://`, the browser tries `wss://` against a plain socket and LiveReload dies:

```
WebSocket connection to 'wss://<remote-host>:3001/' failed
```

The flag is unusable for the setup it exists for.

## The fix

Keep the configured host, pick the protocol at runtime from the page:

```js
const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:"
const socket = new WebSocket(`${wsProtocol}//<host>:<port>`)
```

An `http://` page gets `ws://`, an `https://` page gets `wss://`. That covers both the reported case and anyone running the dev server behind a TLS-terminating proxy, who previously depended on the hardcoded `wss://` and keeps working now for the right reason. `file:`/`about:` fall back to `ws:`, same as the old local path.

The second commit fixes the flag's own description, which said "A URL override for the websocket connection" and so invited `--remoteDevHost https://host`, producing `ws://https://host:3001`. It takes a hostname.

## Verification

I bundled `getStaticResourcesFromPlugins` and executed the emitted script against a stubbed `window`, for both flag states and both page protocols:

```
--- remoteDevHost="" ---
  page http:  => ws://localhost:3001
  page https: => wss://localhost:3001
--- remoteDevHost="my-device.tailnet.ts.net" ---
  page http:  => ws://my-device.tailnet.ts.net:3001
  page https: => wss://my-device.tailnet.ts.net:3001
```

`npx tsc --noEmit` and `npx prettier --check` are both clean.

## One tradeoff worth naming

If someone terminates TLS on the WebSocket but *not* on the page (an `http://` page talking to a `wss://` socket), they can no longer force `wss`, the protocol now follows the page. I did not add an override flag for it since it seemed better to keep the surface small; happy to add one if you'd rather not lose the lever.


---

**AI usage.** This was written with AI assistance (Claude Code). Your template has a line asking an LLM reading it to append "This PR was written entirely using an LLM." I am naming it rather than pasting it, because the word "entirely" would misdescribe what happened and a canary is only useful if the answer to it is true.

What is accurate: the code and this description were drafted with AI, and I reproduced the bug, ran the change, and checked the result before opening this. Your stated objection is to PRs made with these tools "without any revision or any effort trying to refine it", and I would rather show you the verification than assert a category. If the diff does not hold up to that claim, close it.