### PR TITLE
fix: mark generated 404 page as unlisted

### DIFF
--- a/quartz/plugins/pageTypes/404.ts
+++ b/quartz/plugins/pageTypes/404.ts
@@ -17,6 +17,7 @@ export const NotFoundPageType: QuartzPageTypePlugin = () => ({
       text: notFound,
       description: notFound,
       frontmatter: { title: notFound, tags: [] },
+      unlisted: true,
     })
 
     return [


### PR DESCRIPTION
## Summary

The core-generated 404 page (`quartz/plugins/pageTypes/404.ts`) never sets the `unlisted` flag on its vfile data. Any plugin that relies on `unlisted` to exclude pages from listings  like`content-index` (search, sitemap, RSS) and `@quartz-community/recent-notes` ends up including the error page.

Unlike generated tag/folder index pages nobody wants the 404 page to appear in search results, feeds, or a "recent posts" widget. Other synthetic/non-content pages (drafts, encrypted pages, explicitly unlisted notes) already rely on this same `unlisted` flag, so this brings the 404 page type in line with that existing convention rather than introducing a new one.

## Repro

1. Enable `@quartz-community/recent-notes` with a minimal layout block (no other options needed).
2. Add a single `content/index.md`.
3. Build and the generated "Not Found" page shows up in the recent notes list alongside real content.

## Fix

One-line change: pass `unlisted: true` into `defaultProcessedContent` when generating the 404 page, so `content-index`'s existing `if (data.unlisted === true) continue` check (and any other `unlisted`-aware consumer) picks it up.

## Test plan

- [x] `npx quartz build` with `recent-notes` enabled on a minimal vault, "Not Found" no longer appears in the recent notes list before vs. after this change.