### PR TITLE
perf: memoize the mkdir in emitter write()

### DIFF
--- a/quartz/plugins/emitters/helpers.ts
+++ b/quartz/plugins/emitters/helpers.ts
@@ -11,10 +11,19 @@ type WriteOptions = {
   content: string | Buffer | Readable
 }
 
+// the output dir is cleaned once per process, so a dir we've made stays made. holding the
+// promise rather than a flag keeps a concurrent write from racing a half-finished mkdir.
+const ensuredDirs = new Map<string, Promise<string | undefined>>()
+
 export const write = async ({ ctx, slug, ext, content }: WriteOptions): Promise<FilePath> => {
   const pathToPage = joinSegments(ctx.argv.output, slug + ext) as FilePath
   const dir = path.dirname(pathToPage)
-  await fs.promises.mkdir(dir, { recursive: true })
+  let ensured = ensuredDirs.get(dir)
+  if (!ensured) {
+    ensured = fs.promises.mkdir(dir, { recursive: true })
+    ensuredDirs.set(dir, ensured)
+  }
+  await ensured
   await fs.promises.writeFile(pathToPage, content)
   return pathToPage
 }


### PR DESCRIPTION
## Problem

`write()` in `quartz/plugins/emitters/helpers.ts` does a recursive `mkdir` for every file it writes:

```ts
const dir = path.dirname(pathToPage)
await fs.promises.mkdir(dir, { recursive: true })
await fs.promises.writeFile(pathToPage, content)
```

Every emitter funnels through this. A site that emits a page, an og image and an asset per note does thousands of redundant `mkdir` syscalls per build, nearly all of them on directories that already exist.

## Change

Cache the directories we've already made. The output directory is cleaned exactly once per process — `buildQuartz` does `rm(output, ...)` at line 79 and nothing else removes directories during a build — so once a directory has been made it stays made for the life of the process. Watch mode re-imports the whole build module on a source change, which resets the map along with everything else.

The map holds the in-flight promise rather than a boolean, so two concurrent writes into the same new directory can't race a half-finished `mkdir`.

## Verification

- `tsc --noEmit` clean
- `npx quartz build -d docs` succeeds, 313 files emitted
- output compared with and without the change: identical for all 309 deterministic files. Four files differ — `index.xml`, `sitemap.xml`, `plugins/encryptedpages-demo.html`, `static/encryptedContentIndex.json` — but a control run of two builds of *unmodified* code differs in exactly the same four, so that's build timestamps and the per-build encryption salt, not this change.

This is small on its own; it matters more once emitters write concurrently (see quartz-community/og-image#2).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>