### PR TITLE
fix: make asset deletion idempotent

### DIFF
--- a/quartz/plugins/emitters/assets.test.ts
+++ b/quartz/plugins/emitters/assets.test.ts
@@ -1,0 +1,54 @@
+import test, { afterEach, describe } from "node:test"
+import assert from "node:assert"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { Assets } from "./assets"
+import type { StaticResources } from "../../util/resources"
+import type { BuildCtx } from "../../util/ctx"
+import type { ChangeEvent } from "../types"
+import type { FilePath } from "../../util/path"
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.promises.rm(dir, { recursive: true })))
+})
+
+const consumeDelete = async (output: string, changeEvent: ChangeEvent) => {
+  const partialEmit = Assets().partialEmit
+  assert(partialEmit)
+
+  const ctx = {
+    argv: { output },
+    cfg: { plugins: { pageTypes: [] } },
+  } as unknown as BuildCtx
+  const emitted = partialEmit(ctx, [], {} as StaticResources, [changeEvent])
+  assert(emitted)
+
+  if (Symbol.asyncIterator in emitted) {
+    for await (const _file of emitted) {
+      // Consume the async generator so the delete side effect runs.
+    }
+  } else {
+    await emitted
+  }
+}
+
+describe("Assets.partialEmit", () => {
+  test("deleting an asset is idempotent", async () => {
+    const output = await fs.promises.mkdtemp(path.join(os.tmpdir(), "quartz-assets-"))
+    tempDirs.push(output)
+
+    const asset = path.join(output, "image.png")
+    await fs.promises.writeFile(asset, "test")
+    const changeEvent: ChangeEvent = {
+      type: "delete",
+      path: "image.png" as FilePath,
+    }
+
+    await consumeDelete(output, changeEvent)
+    assert.strictEqual(fs.existsSync(asset), false)
+    await assert.doesNotReject(consumeDelete(output, changeEvent))
+  })
+})

--- a/quartz/plugins/emitters/assets.ts
+++ b/quartz/plugins/emitters/assets.ts
@@ -61,7 +61,7 @@ export const Assets: QuartzEmitterPlugin = () => {
         } else if (changeEvent.type === "delete") {
           const name = slugifyFilePath(changeEvent.path)
           const dest = joinSegments(ctx.argv.output, name) as FilePath
-          await fs.promises.unlink(dest)
+          await fs.promises.rm(dest, { force: true })
         }
       }
     },


### PR DESCRIPTION
## Summary

- replace `unlink` with `rm(..., { force: true })` for deleted assets
- prevent incremental rebuilds from failing when the generated asset is already absent
- add a regression test that deletes the same asset twice

## Reproduction

When a delete event is replayed after its generated asset has already been removed, the asset emitter throws `ENOENT` and aborts the incremental rebuild.

## Testing

- `npm run check`
- `npm test` (164 tests passed)

This PR was written entirely using an LLM.