### PR TITLE
build: clear processed incremental changes

### DIFF
--- a/quartz/build.ts
+++ b/quartz/build.ts
@@ -22,6 +22,7 @@ import { getStaticResourcesFromPlugins } from "./plugins"
 import { randomIdNonSecure } from "./util/random"
 import { ChangeEvent } from "./plugins/types"
 import { minimatch } from "minimatch"
+import { ChangeRecord, clearChangeRecord } from "./util/incremental"
 
 function reportSlugCollisions(content: ProcessedContent[]): void {
   const collisions = detectSlugCollisions(content)
@@ -45,7 +46,7 @@ type BuildData = {
   ignored: GlobbyFilterFunction
   mut: Mutex
   contentMap: ContentMap
-  changesSinceLastBuild: Record<FilePath, ChangeEvent["type"]>
+  changesSinceLastBuild: ChangeRecord
   lastBuildMs: number
 }
 
@@ -353,6 +354,7 @@ async function rebuild(changes: ChangeEvent[], clientRefresh: () => void, buildD
       `Emitted ${emittedFiles} files to \`${argv.output}\` in ${perf.timeSince("rebuild")}`,
     )
     console.log(styleText("green", `Done rebuilding in ${perf.timeSince()}`))
+    clearChangeRecord(changesSinceLastBuild)
     changes.splice(0, numChangesInBuild)
     clientRefresh()
   } finally {

--- a/quartz/util/incremental.test.ts
+++ b/quartz/util/incremental.test.ts
@@ -1,0 +1,17 @@
+import test from "node:test"
+import assert from "node:assert"
+import { clearChangeRecord, ChangeRecord } from "./incremental"
+import type { FilePath } from "./path"
+
+test("clearChangeRecord clears the existing record", () => {
+  const changes = {
+    ["first.md" as FilePath]: "change",
+    ["asset.png" as FilePath]: "delete",
+  } satisfies ChangeRecord
+  const originalRecord = changes
+
+  clearChangeRecord(changes)
+
+  assert.strictEqual(changes, originalRecord)
+  assert.deepStrictEqual(changes, {})
+})

--- a/quartz/util/incremental.ts
+++ b/quartz/util/incremental.ts
@@ -1,0 +1,10 @@
+import type { ChangeEvent } from "../plugins/types"
+import type { FilePath } from "./path"
+
+export type ChangeRecord = Record<FilePath, ChangeEvent["type"]>
+
+export function clearChangeRecord(changes: ChangeRecord) {
+  for (const fp of Object.keys(changes)) {
+    delete changes[fp as FilePath]
+  }
+}


### PR DESCRIPTION
## Summary

- clear `changesSinceLastBuild` after a successful incremental rebuild
- clear the record in place to preserve references held by queued rebuilds
- add a regression test for the in-place state cleanup

## Reproduction

After each successful incremental rebuild, previously processed changes remain in `changesSinceLastBuild`. Later rebuilds parse and emit those old changes again.

This causes the number of parsed files to accumulate across otherwise unrelated edits and can replay old delete events.

## Testing

- `npm run check`
- `npm test` (164 tests passed)

This PR was written entirely using an LLM.