### PR TITLE
build: improve polling for mounted content

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -157,6 +157,27 @@ If you want to start over, run `npx quartz restore` to recover your content from
 - Check that port 3001 (WebSocket) is not blocked — this is the default `--wsPort` used for hot reload notifications
 - If developing remotely, use `--remoteDevHost` to set the correct WebSocket URL
 
+### Changes on mounted or network content are not detected
+
+Some network filesystems and Docker bind mounts do not forward directory change events. Enable
+Chokidar polling so Quartz watches existing content files directly and periodically scans for added
+or deleted files:
+
+```shell
+CHOKIDAR_USEPOLLING=true CHOKIDAR_INTERVAL=1000 npx quartz build --serve
+```
+
+In PowerShell:
+
+```powershell
+$env:CHOKIDAR_USEPOLLING = "true"
+$env:CHOKIDAR_INTERVAL = "1000"
+npx quartz build --serve
+```
+
+Polling uses more CPU and filesystem I/O than native events. Increase `CHOKIDAR_INTERVAL` when
+watching a large content directory or when immediate updates are not required.
+
 ### Port already in use
 
 Change the port:

--- a/quartz/build.ts
+++ b/quartz/build.ts
@@ -22,6 +22,7 @@ import { getStaticResourcesFromPlugins } from "./plugins"
 import { randomIdNonSecure } from "./util/random"
 import { ChangeEvent } from "./plugins/types"
 import { minimatch } from "minimatch"
+import { diffContentFiles, pollingEnabled } from "./util/contentWatcher"
 
 function reportSlugCollisions(content: ProcessedContent[]): void {
   const collisions = detectSlugCollisions(content)
@@ -157,10 +158,16 @@ async function startWatching(
     lastBuildMs: 0,
   }
 
-  const watcher = chokidar.watch(".", {
+  const contentRoot = path.resolve(argv.directory)
+  const usePerFilePolling = pollingEnabled(process.env.CHOKIDAR_USEPOLLING)
+  const knownFiles = new Set(allFiles.map((fp) => toPosixPath(fp.toString()) as FilePath))
+  const watcherTargets = usePerFilePolling
+    ? Array.from(knownFiles, (fp) => path.resolve(contentRoot, fp))
+    : ["."]
+  const watcher = chokidar.watch(watcherTargets, {
     awaitWriteFinish: { stabilityThreshold: 250 },
     persistent: true,
-    cwd: argv.directory,
+    ...(usePerFilePolling ? {} : { cwd: argv.directory }),
     ignoreInitial: true,
   })
 
@@ -175,27 +182,79 @@ async function startWatching(
       })
     }, 100)
   }
+
+  const recordChange = (fp: string, type: ChangeEvent["type"]) => {
+    const relativePath = toPosixPath(
+      path.isAbsolute(fp) ? path.relative(contentRoot, fp) : fp,
+    ) as FilePath
+    if (relativePath.startsWith("../") || buildData.ignored(relativePath)) return
+
+    if (type === "add") knownFiles.add(relativePath)
+    if (type === "delete") knownFiles.delete(relativePath)
+    changes.push({ path: relativePath, type })
+    scheduleRebuild()
+  }
+
   watcher
     .on("add", (fp) => {
-      fp = toPosixPath(fp)
-      if (buildData.ignored(fp)) return
-      changes.push({ path: fp as FilePath, type: "add" })
-      scheduleRebuild()
+      recordChange(fp, "add")
     })
     .on("change", (fp) => {
-      fp = toPosixPath(fp)
-      if (buildData.ignored(fp)) return
-      changes.push({ path: fp as FilePath, type: "change" })
-      scheduleRebuild()
+      recordChange(fp, "change")
     })
     .on("unlink", (fp) => {
-      fp = toPosixPath(fp)
-      if (buildData.ignored(fp)) return
-      changes.push({ path: fp as FilePath, type: "delete" })
-      scheduleRebuild()
+      recordChange(fp, "delete")
     })
 
+  let discoveryTimer: ReturnType<typeof setInterval> | undefined
+  if (usePerFilePolling) {
+    if (watcherTargets.length > 0) {
+      await new Promise<void>((resolve, reject) => {
+        watcher.once("ready", resolve)
+        watcher.once("error", reject)
+      })
+    }
+
+    const configuredInterval = Number.parseInt(process.env.CHOKIDAR_INTERVAL ?? "", 10)
+    const discoveryInterval = Math.max(
+      Number.isFinite(configuredInterval) && configuredInterval > 0 ? configuredInterval : 100,
+      1000,
+    )
+    let scanInProgress = false
+    const reconcileFileList = async () => {
+      if (scanInProgress) return
+      scanInProgress = true
+      try {
+        const scannedFiles = await glob("**/*.*", argv.directory, cfg.configuration.ignorePatterns)
+        const currentFiles = new Set(scannedFiles)
+        const { added, deleted } = diffContentFiles(knownFiles, currentFiles)
+
+        for (const fp of added) {
+          watcher.add(path.resolve(contentRoot, fp))
+          recordChange(fp, "add")
+        }
+
+        for (const fp of deleted) {
+          await watcher.unwatch(path.resolve(contentRoot, fp))
+          recordChange(fp, "delete")
+        }
+      } finally {
+        scanInProgress = false
+      }
+    }
+
+    discoveryTimer = setInterval(() => {
+      reconcileFileList().catch((err) => {
+        console.error(styleText("red", "Content scan failed:"), err.message ?? err)
+      })
+    }, discoveryInterval)
+    console.log(
+      `Watching ${knownFiles.size} content files in \`${contentRoot}\` using polling (ready)`,
+    )
+  }
+
   return async () => {
+    if (discoveryTimer) clearInterval(discoveryTimer)
     await watcher.close()
   }
 }

--- a/quartz/util/contentWatcher.test.ts
+++ b/quartz/util/contentWatcher.test.ts
@@ -1,0 +1,27 @@
+import test, { describe } from "node:test"
+import assert from "node:assert"
+import { diffContentFiles, pollingEnabled } from "./contentWatcher"
+import type { FilePath } from "./path"
+
+const files = (...paths: string[]) => new Set(paths as FilePath[])
+
+describe("pollingEnabled", () => {
+  test("recognizes enabled values", () => {
+    for (const value of ["true", "TRUE", "1", "yes"]) {
+      assert.strictEqual(pollingEnabled(value), true)
+    }
+  })
+
+  test("recognizes disabled values", () => {
+    for (const value of [undefined, "", "false", "FALSE", "0"]) {
+      assert.strictEqual(pollingEnabled(value), false)
+    }
+  })
+})
+
+test("diffContentFiles finds additions and deletions", () => {
+  const result = diffContentFiles(files("kept.md", "deleted.md"), files("kept.md", "added.md"))
+
+  assert.deepStrictEqual(result.added, files("added.md"))
+  assert.deepStrictEqual(result.deleted, files("deleted.md"))
+})

--- a/quartz/util/contentWatcher.ts
+++ b/quartz/util/contentWatcher.ts
@@ -1,0 +1,16 @@
+import type { FilePath } from "./path"
+
+export function pollingEnabled(value: string | undefined): boolean {
+  if (value === undefined) return false
+  const normalized = value.trim().toLowerCase()
+  if (normalized === "false" || normalized === "0") return false
+  if (normalized === "true" || normalized === "1") return true
+  return normalized.length > 0
+}
+
+export function diffContentFiles(known: Set<FilePath>, current: Set<FilePath>) {
+  return {
+    added: current.difference(known),
+    deleted: known.difference(current),
+  }
+}


### PR DESCRIPTION
## Summary

- watch existing content files directly when `CHOKIDAR_USEPOLLING` is enabled
- periodically scan for files added or removed on mounted content
- preserve the existing directory watcher for normal local filesystems
- document the polling configuration
- add tests for polling configuration and file reconciliation

## Reproduction

Some network filesystems and Docker bind mounts do not reliably forward directory change events.

In an fnOS Docker deployment with WebDAV-synchronized content, polling the content directory did not detect changes, while polling individual files did.

This change only enables per-file watching and file discovery when polling is explicitly requested. The default native watcher remains unchanged.

## Testing

- `npm run check`
- `npm test` (166 tests passed)
- manually verified modification, addition, and deletion events in polling mode

This PR was written entirely using an LLM.