### PR TITLE
fix: remove stale pages after incremental deletes

### DIFF
--- a/quartz/plugins/pageTypes/dispatcher.test.ts
+++ b/quartz/plugins/pageTypes/dispatcher.test.ts
@@ -1,8 +1,17 @@
 import test, { describe } from "node:test"
 import assert from "node:assert"
-import { collectComponents, resolveLayout } from "./dispatcher"
+import fs from "fs"
+import os from "os"
+import path from "path"
+import {
+  collectComponents,
+  pageOutputPath,
+  removeStalePageOutput,
+  resolveLayout,
+} from "./dispatcher"
 import { QuartzPageTypePluginInstance } from "../types"
 import { QuartzComponent } from "../../components/types"
+import { FilePath, FullSlug } from "../../util/path"
 
 const StubA: QuartzComponent = (() => null) as unknown as QuartzComponent
 const StubB: QuartzComponent = (() => null) as unknown as QuartzComponent
@@ -140,5 +149,54 @@ describe("collectComponents", () => {
 
     const result = collectComponents(pageTypes, sharedDefaults, byPageType)
     assert.ok(result.every((component) => component))
+  })
+})
+
+describe("incremental page deletion", () => {
+  test("maps Markdown sources to their emitted HTML paths", () => {
+    const cases: Array<[FilePath, string]> = [
+      ["note.md" as FilePath, "public/note.html"],
+      ["index.md" as FilePath, "public/index.html"],
+      ["folder/index.md" as FilePath, "public/folder/index.html"],
+      ["folder/folder.md" as FilePath, "public/folder/index.html"],
+    ]
+
+    for (const [sourcePath, expected] of cases) {
+      assert.strictEqual(pageOutputPath("public", sourcePath), expected)
+    }
+  })
+
+  test("removes stale output and tolerates an already-missing file", async (t) => {
+    const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "quartz-page-delete-"))
+    t.after(() => fs.promises.rm(outputDir, { recursive: true, force: true }))
+
+    const sourcePath = "folder/folder.md" as FilePath
+    const outputPath = pageOutputPath(outputDir, sourcePath)
+    await fs.promises.mkdir(path.dirname(outputPath), { recursive: true })
+    await fs.promises.writeFile(outputPath, "stale")
+
+    const removed = await removeStalePageOutput(outputDir, sourcePath, new Set<FullSlug>())
+    assert.strictEqual(removed, outputPath)
+    await assert.rejects(fs.promises.access(outputPath), { code: "ENOENT" })
+
+    await removeStalePageOutput(outputDir, sourcePath, new Set<FullSlug>())
+  })
+
+  test("preserves output when another source still owns the slug", async (t) => {
+    const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "quartz-page-delete-"))
+    t.after(() => fs.promises.rm(outputDir, { recursive: true, force: true }))
+
+    const sourcePath = "folder/folder.md" as FilePath
+    const outputPath = pageOutputPath(outputDir, sourcePath)
+    await fs.promises.mkdir(path.dirname(outputPath), { recursive: true })
+    await fs.promises.writeFile(outputPath, "current")
+
+    const removed = await removeStalePageOutput(
+      outputDir,
+      sourcePath,
+      new Set(["folder/index" as FullSlug]),
+    )
+    assert.strictEqual(removed, undefined)
+    assert.strictEqual(await fs.promises.readFile(outputPath, "utf8"), "current")
   })
 })

--- a/quartz/plugins/pageTypes/dispatcher.ts
+++ b/quartz/plugins/pageTypes/dispatcher.ts
@@ -291,18 +291,14 @@ export const PageTypeDispatcher: QuartzEmitterPlugin<Partial<DispatcherOptions>>
       ) as Set<FullSlug>
       const changedSlugs = new Set<string>()
       for (const changeEvent of changeEvents) {
-        if (path.extname(changeEvent.path).toLowerCase() === ".md") {
-          await removeStalePageOutput(
-            ctx.argv.output,
-            changeEvent.path,
-            currentSlugs,
-            changeEvent.file?.data.slug,
-          )
-        }
+        if (path.extname(changeEvent.path).toLowerCase() !== ".md") continue
 
-        if (changeEvent.type === "add" || changeEvent.type === "change") {
-          const slug = changeEvent.file?.data.slug
-          if (slug) changedSlugs.add(slug)
+        const slug = changeEvent.file?.data.slug ?? slugifyFilePath(changeEvent.path)
+        if (currentSlugs.has(slug)) {
+          // A remaining source may have taken ownership after a slug collision.
+          changedSlugs.add(slug)
+        } else {
+          await removeStalePageOutput(ctx.argv.output, changeEvent.path, currentSlugs, slug)
         }
       }
 

--- a/quartz/plugins/pageTypes/dispatcher.ts
+++ b/quartz/plugins/pageTypes/dispatcher.ts
@@ -2,7 +2,7 @@ import { QuartzEmitterPlugin, QuartzPageTypePluginInstance, TreeTransform } from
 import { QuartzComponent, QuartzComponentProps } from "../../components/types"
 import { pageResources, renderPage } from "../../components/renderPage"
 import { FullPageLayout } from "../../cfg"
-import { FilePath, FullSlug, pathToRoot } from "../../util/path"
+import { FilePath, FullSlug, joinSegments, pathToRoot, slugifyFilePath } from "../../util/path"
 import { ProcessedContent, defaultProcessedContent } from "../vfile"
 import { write } from "../emitters/helpers"
 import { BuildCtx, trieFromAllFiles } from "../../util/ctx"
@@ -10,6 +10,8 @@ import { StaticResources } from "../../util/resources"
 import { render } from "preact-render-to-string"
 import { fromHtml } from "hast-util-from-html"
 import { Root as HtmlRoot } from "hast"
+import fs from "fs"
+import path from "path"
 
 function getPageTypes(ctx: BuildCtx): QuartzPageTypePluginInstance[] {
   return (ctx.cfg.plugins.pageTypes ?? []) as unknown as QuartzPageTypePluginInstance[]
@@ -107,6 +109,31 @@ async function emitPage(
     slug,
     ext: ".html",
   })
+}
+
+/** @internal Exported for testing only. */
+export function pageOutputPath(
+  outputDir: string,
+  sourcePath: FilePath,
+  fileSlug?: FullSlug,
+): FilePath {
+  const slug = fileSlug ?? slugifyFilePath(sourcePath)
+  return joinSegments(outputDir, `${slug}.html`) as FilePath
+}
+
+/** @internal Exported for testing only. */
+export async function removeStalePageOutput(
+  outputDir: string,
+  sourcePath: FilePath,
+  currentSlugs: ReadonlySet<FullSlug>,
+  fileSlug?: FullSlug,
+): Promise<FilePath | undefined> {
+  const slug = fileSlug ?? slugifyFilePath(sourcePath)
+  if (currentSlugs.has(slug)) return
+
+  const outputPath = pageOutputPath(outputDir, sourcePath, slug)
+  await fs.promises.rm(outputPath, { force: true })
+  return outputPath
 }
 
 /**
@@ -259,11 +286,23 @@ export const PageTypeDispatcher: QuartzEmitterPlugin<Partial<DispatcherOptions>>
       // Rebuild trie on partial emit to reflect file changes
       ctx.trie = trieFromAllFiles(allFiles)
 
+      const currentSlugs = new Set(
+        allFiles.flatMap((file) => (file.slug ? [file.slug] : [])),
+      ) as Set<FullSlug>
       const changedSlugs = new Set<string>()
       for (const changeEvent of changeEvents) {
-        if (!changeEvent.file) continue
+        if (path.extname(changeEvent.path).toLowerCase() === ".md") {
+          await removeStalePageOutput(
+            ctx.argv.output,
+            changeEvent.path,
+            currentSlugs,
+            changeEvent.file?.data.slug,
+          )
+        }
+
         if (changeEvent.type === "add" || changeEvent.type === "change") {
-          changedSlugs.add(changeEvent.file.data.slug!)
+          const slug = changeEvent.file?.data.slug
+          if (slug) changedSlugs.add(slug)
         }
       }
 


### PR DESCRIPTION
## Summary

- remove generated HTML when a Markdown source is deleted or filtered out during watch mode
- re-emit pages when another source takes ownership of the same slug
- make stale page cleanup idempotent
- add regression tests for regular pages, root indexes, and folder notes

## Reproduction

Deleting a Markdown file during watch mode updates Explorer and the content index, but leaves its previously generated HTML in the output directory. The stale page remains directly accessible until a full rebuild clears the output.

## Testing

- `npm run check`
- `npm test`
- manually verified that deleting a page removes its HTML and makes the old URL return 404

This PR was written entirely using an LLM.