### PR TITLE
docs(community): add Field Notes theme

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -36,7 +36,7 @@ Custom themes, CSS snippets, and starter templates for Quartz sites.
 <!-- Add templates/themes here -->
 <!-- Format: - **[Name](link)** — Brief description -->
 
-_No community templates listed yet._
+- **[Field Notes](https://github.com/oswarren/quartz-field-notes)** — A warm, single-column reading theme with book margins, a designed dark mode, and a one-command installer that can restore your original files.
 
 ## Guides & Tutorials
 


### PR DESCRIPTION
Adds Field Notes to the Templates & Themes section, per the page's invitation.

Field Notes is a free, warm single-column reading theme for Quartz 5: book margins, a designed (not inverted) dark mode, every stock component styled. The installer touches exactly two files (`quartz/styles/custom.scss` and `quartz.config.yaml`), snapshots them first, and `--restore` puts them back byte for byte.

Repo: https://github.com/oswarren/quartz-field-notes

Disclosure: I am the author. The theme itself is complete and free; its README mentions a paid pack with two more themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)